### PR TITLE
Implement vec3.dist, a method for calculating the distance between two vectors

### DIFF
--- a/gl-matrix.js
+++ b/gl-matrix.js
@@ -347,6 +347,25 @@ vec3.lerp = function (vec, vec2, lerp, dest) {
 };
 
 /*
+ * vec3.dist
+ * Calculates the euclidian distance between two vec3
+ *
+ * Params:
+ * vec - vec3, first vector
+ * vec2 - vec3, second vector
+ *
+ * Returns:
+ * distance between vec and vec2
+ */
+vec3.dist = function (vec, vec2) {
+    var x = vec2[0] - vec[0],
+        y = vec2[1] - vec[1],
+        z = vec2[2] - vec[2];
+        
+    return Math.sqrt(x*x + y*y + z*z);
+};
+
+/*
  * vec3.str
  * Returns a string representation of a vector
  *


### PR DESCRIPTION
Hey @toji,

First of all, thanks for writing gl-matrix! I really like the way it handles things. It's my favourite JS 3D math library so far.

I needed to calculate the distance between two points represented as `vec3`, and found no easy way to do so. I could of course use `.subtract` and then `.length`, but that would be slower than calculating the distance directly. Since this library is focused on speed, I figured a method for calculating distances would come in handy.

This commit adds a pretty trivial `vec3.dist` method that does exactly this. I tryied to respect the conventions used by the library, but you might want to change the name into something else.

Thanks.
