### PR TITLE
added mat3.multiplyVec3(mat, vec[, dest])

### DIFF
--- a/gl-matrix.js
+++ b/gl-matrix.js
@@ -448,6 +448,25 @@ mat3.create = function (mat) {
 };
 
 /**
+ * Transforms the vec3 according to this rotation matrix.
+ *
+ * @param {mat3} matrix the 3x3 matrix to multiply against
+ * @param {vec3} vec    the vector to multiply
+ * @param {vec3} [dest] an optional receiving vector. If not given, vec is used.
+ *
+ * @returns {vec3} The multiplication result
+ **/
+mat3.multiplyVec3 = function(matrix, vec, dest) {
+  if (!dest) dest = vec;
+  
+  dest[0] = vec[0] * matrix[0] + vec[1] * matrix[3] + vec[2] * matrix[6];
+  dest[1] = vec[0] * matrix[1] + vec[1] * matrix[4] + vec[2] * matrix[7];
+  dest[2] = vec[0] * matrix[2] + vec[1] * matrix[5] + vec[2] * matrix[8];
+  
+  return dest;
+};
+
+/**
  * Copies the values of one mat3 to another
  *
  * @param {mat3} mat mat3 containing values to copy

--- a/spec/javascripts/mat3_spec.js
+++ b/spec/javascripts/mat3_spec.js
@@ -1,0 +1,49 @@
+describe("mat3", function() {
+  var mat, vec, dest;
+  
+  beforeEach(function() {
+    vec = vec3.create([1, 2, 3]);
+    dest = vec3.create();
+  });
+  
+  describe("multiplyVec3", function() {
+    describe("when set to identity", function() {
+      beforeEach(function() { mat = mat3.identity(mat3.create()); });
+
+      it("should produce the same vec3", function() {
+        expect(mat3.multiplyVec3(mat, vec)).toBeEqualish([1, 2, 3]);
+      });
+    });
+    
+    describe("with an arbitrary mat3", function() {
+      beforeEach(function() { mat = mat3.create([-1, 0, 1, 0, -1, 0, 1, 0, -1]); });
+      
+      describe("given a dest vec3", function() {
+        it("should not modify incoming vec3", function() {
+          mat3.multiplyVec3(mat, vec, vec3.create());
+          expect(vec).toBeEqualish([1, 2, 3]);
+        });
+
+        it("should store results in dest", function() {
+          mat3.multiplyVec3(mat, vec, dest);
+          expect(dest).toBeEqualish([2, -2, -2]);
+        });
+        
+        it("should return dest", function() {
+          expect(mat3.multiplyVec3(mat, vec, dest)).toBe(dest);
+        });
+      });
+      
+      describe("not given a dest vec3", function() {
+        it("should modify incoming vec3", function() {
+          mat3.multiplyVec3(mat, vec);
+          expect(vec).toBeEqualish([2, -2, -2]);
+        });
+        
+        it("should return incoming vec3", function() {
+          expect(mat3.multiplyVec3(mat, vec)).toBe(vec);
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
Added `mat3.multiplyVec3`, and corresponding tests in `spec/javascripts/mat3_spec.js`, which are passing.
