### PR TITLE
additional functions for quat4

### DIFF
--- a/spec/javascripts/helpers/spec_helper.js
+++ b/spec/javascripts/helpers/spec_helper.js
@@ -1,5 +1,5 @@
 beforeEach(function() {
-  var EPSILON = 0.000001;
+  var EPSILON = 0.00001;
   
   this.addMatchers({
     /*
@@ -10,13 +10,13 @@ beforeEach(function() {
     */
     toBeEqualish: function(expected) {
       if (typeof(this.actual) == 'number')
-        return Math.abs(this.actual) - Math.abs(expected) < EPSILON;
-        
+        return Math.abs(this.actual - expected) < EPSILON;
+
       if (this.actual.length != expected.length) return false;
       for (var i = 0; i < this.actual.length; i++)
-        if (Math.abs(this.actual[i]) - Math.abs(expected[i]) < EPSILON)
-          return true;
-      return false;
+        if (Math.abs(this.actual[i] - expected[i]) >= EPSILON)
+          return false;
+      return true;
     }
   });
 });

--- a/spec/javascripts/quat4_spec.js
+++ b/spec/javascripts/quat4_spec.js
@@ -1,0 +1,189 @@
+describe("quat4", function() {
+  var dest;
+  beforeEach(function() { dest = quat4.create(); });
+  
+  describe("fromRotationMatrix", function() {
+    var mat;
+    beforeEach(function() { mat = mat3.create([1, 0, 0, 0, 0, -1, 0, 1, 0]); });
+    
+    describe("with a dest quat4", function() {
+      it("should return dest", function() {
+        expect(quat4.fromRotationMatrix(mat, dest)).toBe(dest);
+      });
+      
+      it("should set dest to the correct value", function() {
+        quat4.fromRotationMatrix(mat, dest);
+        expect(dest).toBeEqualish([0.707106, 0, 0, 0.707106]);
+      });
+      
+      it("should not modify mat", function() {
+        expect(mat).toBeEqualish([1, 0, 0, 0, 0, -1, 0, 1, 0]);
+      });
+    });
+    
+    describe("without a dest quat4", function() {
+      it("should return a new quat4", function() {
+        expect(quat4.fromRotationMatrix(mat)).toBeEqualish([0.707106, 0, 0, 0.707106]);
+      });
+
+      it("should not modify mat", function() {
+        expect(mat).toBeEqualish([1, 0, 0, 0, 0, -1, 0, 1, 0]);
+      });
+    });
+    
+    it("should be aliased as mat3.toQuat4", function() {
+      expect(mat3.toQuat4(mat)).toBeEqualish([0.707106, 0, 0, 0.707106]);
+    });
+  });
+  
+  describe("fromAxes", function() {
+    var view, right, up, dest;
+    beforeEach(function() {
+      right = vec3.create([1,  0, 0]);
+      up    = vec3.create([0,  0, 1]);
+      view  = vec3.create([0, -1, 0]);
+      dest  = quat4.create();
+    });
+    
+    describe("with a dest quat4", function() {
+      it("should not modify view", function() {
+        quat4.fromAxes(view, right, up, dest);
+        expect(view).toBeEqualish([0, -1, 0]);
+      });
+
+      it("should not modify up", function() {
+        quat4.fromAxes(view, right, up, dest);
+        expect(up).toBeEqualish([0, 0, 1]);
+      });
+
+      it("should not modify right", function() {
+        quat4.fromAxes(view, right, up, dest);
+        expect(right).toBeEqualish([1, 0, 0]);
+      });
+      
+      it("should return dest", function() {
+        expect(quat4.fromAxes(view, right, up, dest)).toBe(dest);
+      });
+      
+      it("should set correct quat4 values", function() {
+        quat4.fromAxes(view, right, up, dest);
+        expect(dest).toBeEqualish([0.707106, 0, 0, 0.707106]);
+      });
+    });
+    
+    describe("without a dest quat4", function() {
+      it("should not modify view", function() {
+        quat4.fromAxes(view, right, up, dest);
+        expect(view).toBeEqualish([0, -1, 0]);
+      });
+
+      it("should not modify up", function() {
+        quat4.fromAxes(view, right, up, dest);
+        expect(up).toBeEqualish([0, 0, 1]);
+      });
+
+      it("should not modify right", function() {
+        quat4.fromAxes(view, right, up, dest);
+        expect(right).toBeEqualish([1, 0, 0]);
+      });
+      
+      it("should return correct quat4 values", function() {
+        expect(quat4.fromAxes(view, right, up)).toBeEqualish([0.707106, 0, 0, 0.707106]);
+      });
+    });
+  });
+  
+  describe("identity", function() {
+    describe("with a dest quat4", function() {
+      it("should return dest", function() {
+        expect(quat4.identity(dest)).toBe(dest);
+      });
+      
+      it("should set dest to identity", function() {
+        quat4.identity(dest);
+        expect(dest).toBeEqualish([0, 0, 0, 1]);
+      });
+    });
+    
+    describe("with no dest", function() {
+      it("should return a new identity quat4", function() {
+        expect(quat4.identity()).toBeEqualish([0, 0, 0, 1]);
+      });
+    });
+  });
+  
+  describe("fromAngleAxis", function() {
+    var axis, angle;
+    
+    beforeEach(function() {
+      angle = 0.466;
+      axis = vec3.create([0.627, 0, 0.778]);
+    });
+    
+    describe("with a dest quat4", function() {
+      it("should set the value of dest", function() {
+        quat4.fromAngleAxis(angle, axis, dest);
+        expect(dest).toBeEqualish([0.144772, 0, 0.179638, 0.972978]);
+      });
+      
+      it("should return dest", function() {
+        expect(quat4.fromAngleAxis(angle, axis, dest)).toBe(dest);
+      });
+      
+      it("should not modify axis", function() {
+        quat4.fromAngleAxis(angle, axis, dest);
+        expect(axis).toBeEqualish([0.627, 0, 0.778]);
+      });
+    });
+    
+    describe("without a dest quat4", function() {
+      it("should return the correct quat4", function() {
+        expect(quat4.fromAngleAxis(angle, axis)).toBeEqualish([0.144772, 0, 0.179638, 0.972978]);
+      });
+      
+      it("should not modify axis", function() {
+        quat4.fromAngleAxis(angle, axis, dest);
+        expect(axis).toBeEqualish([0.627, 0, 0.778]);
+      });
+    });
+  });
+  
+  describe("toAngleAxis", function() {
+    var quat;
+    
+    beforeEach(function() {
+      quat = quat4.create([0.144772, 0, 0.179638, 0.972978]);
+    });
+    
+    describe("with a dest vec4", function() {
+      var dest;
+      
+      beforeEach(function() { dest = [0,0,0,0]; });
+      
+      it("should set the value of dest", function() {
+        quat4.toAngleAxis(quat, dest);
+        expect(dest).toBeEqualish([0.627490, 0, 0.778611, 0.466000]);
+      });
+      
+      it("should return dest", function() {
+        expect(quat4.toAngleAxis(quat, dest)).toBe(dest);
+      });
+      
+      it("should not modify quat", function() {
+        quat4.toAngleAxis(quat, dest);
+        expect(quat).toBeEqualish([0.144772, 0, 0.179638, 0.972978]);
+      });
+    });
+    
+    describe("without a dest vec4", function() {
+      it("should return the correct values", function() {
+        expect(quat4.toAngleAxis(quat)).toBeEqualish([0.627490, 0, 0.778611, 0.466000]);
+      });
+      
+      it("should modify quat", function() {
+        quat4.toAngleAxis(quat);
+        expect(quat).toBeEqualish([0.627490, 0, 0.778611, 0.466000]);
+      });
+    });
+  });
+});

--- a/spec/javascripts/vec3_spec.js
+++ b/spec/javascripts/vec3_spec.js
@@ -51,7 +51,7 @@ describe("vec3", function() {
       beforeEach(function() { vec3.add(vec, [3,4,5], dest = vec3.create()); });
       
       it("should not modify original vector", function() {
-        expect(vec).toBeEqualish([3,4,5]);
+        expect(vec).toBeEqualish([1,2,3]);
       });
       
       it("should modify dest vector", function() {
@@ -76,7 +76,7 @@ describe("vec3", function() {
     describe("if dest vector given", function() {
       beforeEach(function() { vec3.subtract(vec, [3,4,5], dest = vec3.create()); });
       
-      it("should not modify original vector", function() { expect(vec).toBeEqualish([3,4,5]); });
+      it("should not modify original vector", function() { expect(vec).toBeEqualish([1,2,3]); });
       it("should modify dest vector", function() { expect(dest).toBeEqualish([-2,-2,-2]); });
     });
   });
@@ -256,7 +256,7 @@ describe("vec3", function() {
   describe("unproject", function() {
       var modelView, projection, viewport;
       
-      var expectedVec = [0, 0, 1];
+      var expectedVec = [0, 0, -1024];
       
       beforeEach(function() {
         vec = vec3.create([320, 240, 1]);


### PR DESCRIPTION
Hi,

This pull request adds the following:
- `quat4.fromRotationMatrix` - creates or sets a quat4 from a 3x3 rotation matrix; aliased as `mat3.toQuat4`
- `quat4.fromAxes` - creates or sets a quat4 from `vec3`s which together produce a 3D space
- `quat4.identity` - creates or sets an identity quat4
- `quat4.fromAngleAxis` - creates or sets a quat4 from an angle in radians and a `vec3` axis
- `quat4.toAngleAxis` - sets the first 3 components of a `vec4` to the quat's XYZ axis, and its 4th component to the quat's angle

Also added `Math.invsqrt`, which is used by `quat4.toAngleAxis`. This tries to use an optimized version (see http://jsperf.com/inverse-square-root/5) and falls back to `1 / Math.sqrt(num)` if necessary.

Tests are in `spec/quat4_spec.js` and are passing.
