### PR TITLE
Fix tests

### DIFF
--- a/gl-matrix.js
+++ b/gl-matrix.js
@@ -539,10 +539,10 @@
      **/
     mat3.multiplyVec3 = function(matrix, vec, dest) {
       if (!dest) dest = vec;
-      
-      dest[0] = vec[0] * matrix[0] + vec[1] * matrix[3] + vec[2] * matrix[6];
-      dest[1] = vec[0] * matrix[1] + vec[1] * matrix[4] + vec[2] * matrix[7];
-      dest[2] = vec[0] * matrix[2] + vec[1] * matrix[5] + vec[2] * matrix[8];
+      var x = vec[0], y = vec[1], z = vec[2];
+      dest[0] = x * matrix[0] + y * matrix[3] + z * matrix[6];
+      dest[1] = x * matrix[1] + y * matrix[4] + z * matrix[7];
+      dest[2] = x * matrix[2] + y * matrix[5] + z * matrix[8];
       
       return dest;
     };


### PR DESCRIPTION
Changed the `factory` function under node.js to be called with `global` as the root (instead of `undefined`), and altered the type detection functions to hook into the root. This allowed the tests to run properly.

In the process, I also noticed that one of the tests was failing. There was a bug in `mat3.multiplyVec3`, which this pull request fixes.
