### PR TITLE
fix 4th component in vec4.transformQuat output

### DIFF
--- a/src/gl-matrix/vec4.js
+++ b/src/gl-matrix/vec4.js
@@ -479,6 +479,7 @@ vec4.transformQuat = function(out, a, q) {
     out[0] = ix * qw + iw * -qx + iy * -qz - iz * -qy;
     out[1] = iy * qw + iw * -qy + iz * -qx - ix * -qz;
     out[2] = iz * qw + iw * -qz + ix * -qy - iy * -qx;
+    out[3] = a[3];
     return out;
 };
 


### PR DESCRIPTION
vec4.transformQuat() does not set the 4th component of the output vector. It should be set to the 4th component of the input vector.

This request is replacing one I submitted a few months ago (https://github.com/toji/gl-matrix/pull/123) which I believe was not acceptable because of some junk in the history from a previous request of mine, so I started from a fresh clone this time.  

The function can also be written like this to test that both calculations give the same result:

vec4.transformQuat = function(out, a, q) {
    return vec4.transformMat4(out, a, mat4.fromQuat(mat4.create(), q));
};
