### PR TITLE
adding 2d projection to mat3

### DIFF
--- a/src/gl-matrix/mat3.js
+++ b/src/gl-matrix/mat3.js
@@ -538,6 +538,27 @@ mat3.normalFromMat4 = function (out, a) {
 };
 
 /**
+ * Generates a 2D projection matrix with the given bounds
+ *
+ * @param {mat3} out mat3 frustum matrix will be written into
+ * @param {number} width Width of your gl context
+ * @param {number} height Height of gl context
+ * @returns {mat3} out
+ */
+mat3.projection = function (out, width, height) {
+    out[0] = 2 / width;
+    out[1] = 0;
+    out[2] = 0;
+    out[3] = 0;
+    out[4] = -2 / height;
+    out[5] = 0;
+    out[6] = -1;
+    out[7] = 1;
+    out[8] = 1;
+    return out;
+};
+
+/**
  * Returns a string representation of a mat3
  *
  * @param {mat3} mat matrix to represent as a string


### PR DESCRIPTION
While developing a small framework to work with Quads on 2D environment, and for speed purposes, I found it useful to add a project2d style method. It receives the canvas width and height, and inverts on the Y axis so the 0 coordinate is on top.