### PR TITLE
Update ruby dependencies for Ruby >= 2.2.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :gemcutter
+source 'https://rubygems.org'
 
 # core ruby
 gem 'rake'
@@ -10,10 +10,14 @@ gem 'jasmine'
 gem 'sprockets'
 
 # https://github.com/lautis/uglifier
-gem 'uglifier'
+# Newer versions than 1.2.7 result in many copies of the copyright notice in
+# the minified output.
+gem 'uglifier', '1.2.7'
 
 # for jasmine:ci task
 gem 'json'
 
 # https://github.com/wycats/thor - for release debug
 gem 'thor'
+
+gem 'rspec'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,58 +1,52 @@
 GEM
-  remote: http://rubygems.org/
+  remote: https://rubygems.org/
   specs:
-    childprocess (0.3.8)
-      ffi (~> 1.0, >= 1.0.11)
-    diff-lcs (1.1.3)
-    execjs (1.4.0)
-      multi_json (~> 1.0)
-    ffi (1.4.0)
-    ffi (1.4.0-x86-mingw32)
-    hike (1.2.1)
-    jasmine (1.2.1)
-      jasmine-core (>= 1.2.0)
-      rack (~> 1.0)
-      rspec (>= 1.3.1)
-      selenium-webdriver (>= 0.1.3)
-    jasmine-core (1.2.0)
-    json (1.7.4)
-    multi_json (1.6.1)
-    rack (1.5.1)
-    rake (0.9.2.2)
-    rspec (2.11.0)
-      rspec-core (~> 2.11.0)
-      rspec-expectations (~> 2.11.0)
-      rspec-mocks (~> 2.11.0)
-    rspec-core (2.11.1)
-    rspec-expectations (2.11.2)
-      diff-lcs (~> 1.1.3)
-    rspec-mocks (2.11.2)
-    rubyzip (0.9.9)
-    selenium-webdriver (2.30.0)
-      childprocess (>= 0.2.5)
-      multi_json (~> 1.0)
-      rubyzip
-      websocket (~> 1.0.4)
-    sprockets (2.8.2)
+    diff-lcs (1.2.5)
+    execjs (2.5.2)
+    hike (1.2.3)
+    jasmine (2.2.0)
+      jasmine-core (~> 2.2)
+      phantomjs
+      rack (>= 1.2.1)
+      rake
+    jasmine-core (2.2.0)
+    json (1.8.2)
+    multi_json (1.11.0)
+    phantomjs (1.9.8.0)
+    rack (1.6.0)
+    rake (10.4.2)
+    rspec (3.2.0)
+      rspec-core (~> 3.2.0)
+      rspec-expectations (~> 3.2.0)
+      rspec-mocks (~> 3.2.0)
+    rspec-core (3.2.3)
+      rspec-support (~> 3.2.0)
+    rspec-expectations (3.2.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.2.0)
+    rspec-mocks (3.2.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.2.0)
+    rspec-support (3.2.2)
+    sprockets (2.12.3)
       hike (~> 1.2)
       multi_json (~> 1.0)
       rack (~> 1.0)
       tilt (~> 1.1, != 1.3.0)
-    thor (0.14.6)
-    tilt (1.3.3)
+    thor (0.19.1)
+    tilt (1.4.1)
     uglifier (1.2.7)
       execjs (>= 0.3.0)
       multi_json (~> 1.3)
-    websocket (1.0.7)
 
 PLATFORMS
   ruby
-  x86-mingw32
 
 DEPENDENCIES
   jasmine
   json
   rake
+  rspec
   sprockets
   thor
-  uglifier
+  uglifier (= 1.2.7)


### PR DESCRIPTION
Previous version did not specify "rspec" in the Gemfile, which caused `rake` (as specified in TESTING.md) to not work after a `bundle install`.

Previous version pinned to json 1.7.6, which is incompatible with Ruby >= 2.2. New version is autogenerated as of 2015-04-09 and works with the supplied rake tasks. 

Previous version used `:gemcutter` for the gems source which uses http. This was switched to 'https://rubygems.org' as recommended by bundler docs.

Note that I don't really know Ruby, and the checked-in `Gemfile.lock` seems a bit crazy to me (especially without pinned versions in Gemfile), so I don't know the protocol on when it should be updated or not. But, this makes the tasks work again on an up-to-date OSX with Ruby 2.2.1 as of the time of writing.