### PR TITLE
Implement vec4.random as a vector uniformly distributed on a 4-sphere surface

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -25,4 +25,4 @@ If Ruby is not installed, you must test with `jasmine-node` directly:
 
     NODE_PATH=$NODE_PATH:.                       \
       node_modules/jasmine-node/bin/jasmine-node \
-      spec/helpers/node_helper.js
+      spec/helpers/node-helper.js

--- a/spec/gl-matrix/vec4-spec.js
+++ b/spec/gl-matrix/vec4-spec.js
@@ -380,7 +380,7 @@ describe("vec4", function() {
         describe("with a scale", function() {
             beforeEach(function() { result = vec4.random(out, 5.0); });
             
-            it("should result in a unit length vector", function() { expect(vec4.length(out)).toBeCloseTo(5.0); });
+            it("should result in a vector of length 5", function() { expect(vec4.length(out)).toBeCloseTo(5.0); });
             it("should return out", function() { expect(result).toBe(out); });
         });
     });

--- a/src/gl-matrix/vec4.js
+++ b/src/gl-matrix/vec4.js
@@ -428,13 +428,27 @@ vec4.lerp = function (out, a, b, t) {
 vec4.random = function (out, scale) {
     scale = scale || 1.0;
 
-    //TODO: This is a pretty awful way of doing this. Find something better.
-    out[0] = GLMAT_RANDOM();
-    out[1] = GLMAT_RANDOM();
-    out[2] = GLMAT_RANDOM();
-    out[3] = GLMAT_RANDOM();
-    vec4.normalize(out, out);
-    vec4.scale(out, out, scale);
+    // Marsaglia, George. Choosing a Point from the Surface of a
+    // Sphere. Ann. Math. Statist. 43 (1972), no. 2, 645--646.
+    // http://projecteuclid.org/euclid.aoms/1177692644;
+    var v1, v2, v3, v4;
+    var s1, s2;
+    do {
+        v1 = GLMAT_RANDOM() * 2 - 1;
+        v2 = GLMAT_RANDOM() * 2 - 1;
+        s1 = v1 * v1 + v2 * v2;
+    } while (s1 >= 1);
+    do {
+        v3 = GLMAT_RANDOM() * 2 - 1;
+        v4 = GLMAT_RANDOM() * 2 - 1;
+        s2 = v3 * v3 + v4 * v4;
+    } while (s2 >= 1);
+
+    var d = Math.sqrt((1 - s1) / s2);
+    out[0] = scale * v1;
+    out[1] = scale * v2;
+    out[2] = scale * v3 * d;
+    out[3] = scale * v4 * d;
     return out;
 };
 


### PR DESCRIPTION
`vec4.random` has had a TODO to improve it for some time; it generated uniformly distributed elements and then normalized and scaled the result. This is projecting a hypercube onto a hypersphere, and like projecting a cube onto a sphere, the distribution has dense "corners."

This changes it to follow [Marsaglia (1972)](http://projecteuclid.org/euclid.aoms/1177692644) and generate the points uniformly on the hypersphere's surface. It is slightly less efficient because of the rejected samples, but still contains only one sqrt call.
