### PR TITLE
Implement add/subtract for mat2, mat2d, mat3, and mat4

### DIFF
--- a/spec/gl-matrix/mat2-spec.js
+++ b/spec/gl-matrix/mat2-spec.js
@@ -207,4 +207,59 @@ describe("mat2", function() {
         });
    });
 
+    describe("add", function() {
+        describe("with a separate output matrix", function() {
+            beforeEach(function() { result = mat2.add(out, matA, matB); });
+
+            it("should place values into out", function() { expect(out).toBeEqualish([6, 8, 10, 12]); });
+            it("should return out", function() { expect(result).toBe(out); });
+            it("should not modify matA", function() { expect(matA).toBeEqualish([1, 2, 3, 4]); });
+            it("should not modify matB", function() { expect(matB).toBeEqualish([5, 6, 7, 8]); });
+        });
+
+        describe("when matA is the output matrix", function() {
+            beforeEach(function() { result = mat2.add(matA, matA, matB); });
+
+            it("should place values into matA", function() { expect(matA).toBeEqualish([6, 8, 10, 12]); });
+            it("should return matA", function() { expect(result).toBe(matA); });
+            it("should not modify matB", function() { expect(matB).toBeEqualish([5, 6, 7, 8]); });
+        });
+
+        describe("when matB is the output matrix", function() {
+            beforeEach(function() { result = mat2.add(matB, matA, matB); });
+
+            it("should place values into matB", function() { expect(matB).toBeEqualish([6, 8, 10, 12]); });
+            it("should return matB", function() { expect(result).toBe(matB); });
+            it("should not modify matA", function() { expect(matA).toBeEqualish([1, 2, 3, 4]); });
+        });
+    });
+
+    describe("subtract", function() {
+        it("should have an alias called 'sub'", function() { expect(mat2.sub).toEqual(mat2.subtract); });
+
+        describe("with a separate output matrix", function() {
+            beforeEach(function() { result = mat2.subtract(out, matA, matB); });
+
+            it("should place values into out", function() { expect(out).toBeEqualish([-4, -4, -4, -4]); });
+            it("should return out", function() { expect(result).toBe(out); });
+            it("should not modify matA", function() { expect(matA).toBeEqualish([1, 2, 3, 4]); });
+            it("should not modify matB", function() { expect(matB).toBeEqualish([5, 6, 7, 8]); });
+        });
+
+        describe("when matA is the output matrix", function() {
+            beforeEach(function() { result = mat2.subtract(matA, matA, matB); });
+
+            it("should place values into matA", function() { expect(matA).toBeEqualish([-4, -4, -4, -4]); });
+            it("should return matA", function() { expect(result).toBe(matA); });
+            it("should not modify matB", function() { expect(matB).toBeEqualish([5, 6, 7, 8]); });
+        });
+
+        describe("when matB is the output matrix", function() {
+            beforeEach(function() { result = mat2.subtract(matB, matA, matB); });
+
+            it("should place values into matB", function() { expect(matB).toBeEqualish([-4, -4, -4, -4]); });
+            it("should return matB", function() { expect(result).toBe(matB); });
+            it("should not modify matA", function() { expect(matA).toBeEqualish([1, 2, 3, 4]); });
+        });
+    });
 });

--- a/spec/gl-matrix/mat2d-spec.js
+++ b/spec/gl-matrix/mat2d-spec.js
@@ -191,4 +191,59 @@ describe("mat2d", function() {
         it("should return the Frobenius Norm of the matrix", function() { expect(result).toEqual( Math.sqrt(Math.pow(1, 2) + Math.pow(2, 2) + Math.pow(3, 2) + Math.pow(4, 2) + Math.pow(5, 2) + Math.pow(6, 2) + 1)); });
    });
 
+    describe("add", function() {
+        describe("with a separate output matrix", function() {
+            beforeEach(function() { result = mat2d.add(out, matA, matB); });
+
+            it("should place values into out", function() { expect(out).toBeEqualish([8, 10, 12, 14, 16, 18]); });
+            it("should return out", function() { expect(result).toBe(out); });
+            it("should not modify matA", function() { expect(matA).toBeEqualish(oldA); });
+            it("should not modify matB", function() { expect(matB).toBeEqualish(oldB); });
+        });
+
+        describe("when matA is the output matrix", function() {
+            beforeEach(function() { result = mat2d.add(matA, matA, matB); });
+
+            it("should place values into matA", function() { expect(matA).toBeEqualish([8, 10, 12, 14, 16, 18]); });
+            it("should return matA", function() { expect(result).toBe(matA); });
+            it("should not modify matB", function() { expect(matB).toBeEqualish(oldB); });
+        });
+
+        describe("when matB is the output matrix", function() {
+            beforeEach(function() { result = mat2d.add(matB, matA, matB); });
+
+            it("should place values into matB", function() { expect(matB).toBeEqualish([8, 10, 12, 14, 16, 18]); });
+            it("should return matB", function() { expect(result).toBe(matB); });
+            it("should not modify matA", function() { expect(matA).toBeEqualish(oldA); });
+        });
+    });
+
+    describe("subtract", function() {
+        it("should have an alias called 'sub'", function() { expect(mat2d.sub).toEqual(mat2d.subtract); });
+
+        describe("with a separate output matrix", function() {
+            beforeEach(function() { result = mat2d.subtract(out, matA, matB); });
+
+            it("should place values into out", function() { expect(out).toBeEqualish([-6, -6, -6, -6, -6, -6]); });
+            it("should return out", function() { expect(result).toBe(out); });
+            it("should not modify matA", function() { expect(matA).toBeEqualish(oldA); });
+            it("should not modify matB", function() { expect(matB).toBeEqualish(oldB); });
+        });
+
+        describe("when matA is the output matrix", function() {
+            beforeEach(function() { result = mat2d.subtract(matA, matA, matB); });
+
+            it("should place values into matA", function() { expect(matA).toBeEqualish([-6, -6, -6, -6, -6, -6]); });
+            it("should return matA", function() { expect(result).toBe(matA); });
+            it("should not modify matB", function() { expect(matB).toBeEqualish(oldB); });
+        });
+
+        describe("when matB is the output matrix", function() {
+            beforeEach(function() { result = mat2d.subtract(matB, matA, matB); });
+
+            it("should place values into matB", function() { expect(matB).toBeEqualish([-6, -6, -6, -6, -6, -6]); });
+            it("should return matB", function() { expect(result).toBe(matB); });
+            it("should not modify matA", function() { expect(matA).toBeEqualish(oldA); });
+        });
+    });
 });

--- a/spec/gl-matrix/mat3-spec.js
+++ b/spec/gl-matrix/mat3-spec.js
@@ -344,4 +344,70 @@ describe("mat3", function() {
         it("should return the Frobenius Norm of the matrix", function() { expect(result).toEqual( Math.sqrt(Math.pow(1, 2) + Math.pow(0, 2) + Math.pow(0, 2) + Math.pow(0, 2) + Math.pow(1, 2) + Math.pow(0, 2) + Math.pow(1, 2) + Math.pow(2, 2) + Math.pow(1, 2))); });
    });
 
+    describe("add", function() {
+        beforeEach(function() {
+            matA = [1, 2, 3, 4, 5, 6, 7, 8, 9];
+            matB = [10, 11, 12, 13, 14, 15, 16, 17, 18];
+        });
+        describe("with a separate output matrix", function() {
+            beforeEach(function() {
+                result = mat3.add(out, matA, matB);
+            });
+
+            it("should place values into out", function() { expect(out).toBeEqualish([11, 13, 15, 17, 19, 21, 23, 25, 27]); });
+            it("should return out", function() { expect(result).toBe(out); });
+            it("should not modify matA", function() { expect(matA).toBeEqualish([1, 2, 3, 4, 5, 6, 7, 8, 9]); });
+            it("should not modify matB", function() { expect(matB).toBeEqualish([10, 11, 12, 13, 14, 15, 16, 17, 18]); });
+        });
+
+        describe("when matA is the output matrix", function() {
+            beforeEach(function() { result = mat3.add(matA, matA, matB); });
+
+            it("should place values into matA", function() { expect(matA).toBeEqualish([11, 13, 15, 17, 19, 21, 23, 25, 27]); });
+            it("should return matA", function() { expect(result).toBe(matA); });
+            it("should not modify matB", function() { expect(matB).toBeEqualish([10, 11, 12, 13, 14, 15, 16, 17, 18]); });
+        });
+
+        describe("when matB is the output matrix", function() {
+            beforeEach(function() { result = mat3.add(matB, matA, matB); });
+
+            it("should place values into matB", function() { expect(matB).toBeEqualish([11, 13, 15, 17, 19, 21, 23, 25, 27]); });
+            it("should return matB", function() { expect(result).toBe(matB); });
+            it("should not modify matA", function() { expect(matA).toBeEqualish([1, 2, 3, 4, 5, 6, 7, 8, 9]); });
+        });
+    });
+
+    describe("subtract", function() {
+        beforeEach(function() {
+            matA = [1, 2, 3, 4, 5, 6, 7, 8, 9];
+            matB = [10, 11, 12, 13, 14, 15, 16, 17, 18];
+        });
+        it("should have an alias called 'sub'", function() { expect(mat3.sub).toEqual(mat3.subtract); });
+
+        describe("with a separate output matrix", function() {
+            beforeEach(function() { result = mat3.subtract(out, matA, matB); });
+
+            it("should place values into out", function() { expect(out).toBeEqualish([-9, -9, -9, -9, -9, -9, -9, -9, -9]); });
+            it("should return out", function() { expect(result).toBe(out); });
+            it("should not modify matA", function() { expect(matA).toBeEqualish([1, 2, 3, 4, 5, 6, 7, 8, 9]); });
+            it("should not modify matB", function() { expect(matB).toBeEqualish([10, 11, 12, 13, 14, 15, 16, 17, 18]); });
+        });
+
+        describe("when matA is the output matrix", function() {
+            beforeEach(function() { result = mat3.subtract(matA, matA, matB); });
+
+            it("should place values into matA", function() { expect(matA).toBeEqualish([-9, -9, -9, -9, -9, -9, -9, -9, -9]); });
+            it("should return matA", function() { expect(result).toBe(matA); });
+            it("should not modify matB", function() { expect(matB).toBeEqualish([10, 11, 12, 13, 14, 15, 16, 17, 18]); });
+        });
+
+        describe("when matB is the output matrix", function() {
+            beforeEach(function() { result = mat3.subtract(matB, matA, matB); });
+
+            it("should place values into matB", function() { expect(matB).toBeEqualish([-9, -9, -9, -9, -9, -9, -9, -9, -9]); });
+            it("should return matB", function() { expect(result).toBe(matB); });
+            it("should not modify matA", function() { expect(matA).toBeEqualish([1, 2, 3, 4, 5, 6, 7, 8, 9]); });
+        });
+    });
+
 });

--- a/spec/gl-matrix/mat4-spec.js
+++ b/spec/gl-matrix/mat4-spec.js
@@ -645,6 +645,72 @@ function buildMat4Tests(useSIMD) {
             it("should return the Frobenius Norm of the matrix", function() { expect(result).toEqual( Math.sqrt(Math.pow(1, 2) + Math.pow(1, 2) + Math.pow(1, 2) + Math.pow(1, 2) + Math.pow(1, 2) + Math.pow(2, 2) + Math.pow(3, 2) )); });
        });
     };
+
+    describe("add", function() {
+        beforeEach(function() {
+            matA = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
+            matB = [17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32];
+        });
+        describe("with a separate output matrix", function() {
+            beforeEach(function() {
+                result = mat3.add(out, matA, matB);
+            });
+
+            it("should place values into out", function() { expect(out).toBeEqualish([18, 20, 22, 24, 26, 28, 30, 32, 34, 36, 38, 40, 42, 44, 46, 48]); });
+            it("should return out", function() { expect(result).toBe(out); });
+            it("should not modify matA", function() { expect(matA).toBeEqualish([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]); });
+            it("should not modify matB", function() { expect(matB).toBeEqualish([17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32]); });
+        });
+
+        describe("when matA is the output matrix", function() {
+            beforeEach(function() { result = mat3.add(matA, matA, matB); });
+
+            it("should place values into matA", function() { expect(matA).toBeEqualish([18, 20, 22, 24, 26, 28, 30, 32, 34, 36, 38, 40, 42, 44, 46, 48]); });
+            it("should return matA", function() { expect(result).toBe(matA); });
+            it("should not modify matB", function() { expect(matB).toBeEqualish([17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32]); });
+        });
+
+        describe("when matB is the output matrix", function() {
+            beforeEach(function() { result = mat3.add(matB, matA, matB); });
+
+            it("should place values into matB", function() { expect(matB).toBeEqualish([18, 20, 22, 24, 26, 28, 30, 32, 34, 36, 38, 40, 42, 44, 46, 48]); });
+            it("should return matB", function() { expect(result).toBe(matB); });
+            it("should not modify matA", function() { expect(matA).toBeEqualish([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]); });
+        });
+    });
+
+    describe("subtract", function() {
+        beforeEach(function() {
+            matA = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
+            matB = [17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32];
+        });
+        it("should have an alias called 'sub'", function() { expect(mat3.sub).toEqual(mat3.subtract); });
+
+        describe("with a separate output matrix", function() {
+            beforeEach(function() { result = mat3.subtract(out, matA, matB); });
+
+            it("should place values into out", function() { expect(out).toBeEqualish([-16, -16, -16, -16, -16, -16, -16, -16, -16, -16, -16, -16, -16, -16, -16, -16]); });
+            it("should return out", function() { expect(result).toBe(out); });
+            it("should not modify matA", function() { expect(matA).toBeEqualish([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]); });
+            it("should not modify matB", function() { expect(matB).toBeEqualish([17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32]); });
+        });
+
+        describe("when matA is the output matrix", function() {
+            beforeEach(function() { result = mat3.subtract(matA, matA, matB); });
+
+            it("should place values into matA", function() { expect(matA).toBeEqualish([-16, -16, -16, -16, -16, -16, -16, -16, ]); });
+            it("should return matA", function() { expect(result).toBe(matA); });
+            it("should not modify matB", function() { expect(matB).toBeEqualish([17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32]); });
+        });
+
+        describe("when matB is the output matrix", function() {
+            beforeEach(function() { result = mat3.subtract(matB, matA, matB); });
+
+            it("should place values into matB", function() { expect(matB).toBeEqualish([-16, -16, -16, -16, -16, -16, -16, -16, ]); });
+            it("should return matB", function() { expect(result).toBe(matB); });
+            it("should not modify matA", function() { expect(matA).toBeEqualish([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]); });
+        });
+    });
 }
 
 describe("mat4 (SISD)", buildMat4Tests(false));

--- a/src/gl-matrix/mat2.js
+++ b/src/gl-matrix/mat2.js
@@ -298,5 +298,43 @@ mat2.LDU = function (L, D, U, a) {
     return [L, D, U];       
 }; 
 
+/**
+ * Adds two mat2's
+ *
+ * @param {mat2} out the receiving matrix
+ * @param {mat2} a the first operand
+ * @param {mat2} b the second operand
+ * @returns {mat2} out
+ */
+mat2.add = function(out, a, b) {
+    out[0] = a[0] + b[0];
+    out[1] = a[1] + b[1];
+    out[2] = a[2] + b[2];
+    out[3] = a[3] + b[3];
+    return out;
+};
+
+/**
+ * Subtracts matrix b from matrix a
+ *
+ * @param {mat2} out the receiving matrix
+ * @param {mat2} a the first operand
+ * @param {mat2} b the second operand
+ * @returns {mat2} out
+ */
+mat2.subtract = function(out, a, b) {
+    out[0] = a[0] - b[0];
+    out[1] = a[1] - b[1];
+    out[2] = a[2] - b[2];
+    out[3] = a[3] - b[3];
+    return out;
+};
+
+/**
+ * Alias for {@link mat2.subtract}
+ * @function
+ */
+mat2.sub = mat2.subtract;
+
 
 module.exports = mat2;

--- a/src/gl-matrix/mat2d.js
+++ b/src/gl-matrix/mat2d.js
@@ -314,4 +314,46 @@ mat2d.frob = function (a) {
     return(Math.sqrt(Math.pow(a[0], 2) + Math.pow(a[1], 2) + Math.pow(a[2], 2) + Math.pow(a[3], 2) + Math.pow(a[4], 2) + Math.pow(a[5], 2) + 1))
 }; 
 
+/**
+ * Adds two mat2d's
+ *
+ * @param {mat2d} out the receiving matrix
+ * @param {mat2d} a the first operand
+ * @param {mat2d} b the second operand
+ * @returns {mat2d} out
+ */
+mat2d.add = function(out, a, b) {
+    out[0] = a[0] + b[0];
+    out[1] = a[1] + b[1];
+    out[2] = a[2] + b[2];
+    out[3] = a[3] + b[3];
+    out[4] = a[4] + b[4];
+    out[5] = a[5] + b[5];
+    return out;
+};
+
+/**
+ * Subtracts matrix b from matrix a
+ *
+ * @param {mat2d} out the receiving matrix
+ * @param {mat2d} a the first operand
+ * @param {mat2d} b the second operand
+ * @returns {mat2d} out
+ */
+mat2d.subtract = function(out, a, b) {
+    out[0] = a[0] - b[0];
+    out[1] = a[1] - b[1];
+    out[2] = a[2] - b[2];
+    out[3] = a[3] - b[3];
+    out[4] = a[4] - b[4];
+    out[5] = a[5] - b[5];
+    return out;
+};
+
+/**
+ * Alias for {@link mat2d.subtract}
+ * @function
+ */
+mat2d.sub = mat2d.subtract;
+
 module.exports = mat2d;

--- a/src/gl-matrix/mat3.js
+++ b/src/gl-matrix/mat3.js
@@ -561,5 +561,52 @@ mat3.frob = function (a) {
     return(Math.sqrt(Math.pow(a[0], 2) + Math.pow(a[1], 2) + Math.pow(a[2], 2) + Math.pow(a[3], 2) + Math.pow(a[4], 2) + Math.pow(a[5], 2) + Math.pow(a[6], 2) + Math.pow(a[7], 2) + Math.pow(a[8], 2)))
 };
 
+/**
+ * Adds two mat3's
+ *
+ * @param {mat3} out the receiving matrix
+ * @param {mat3} a the first operand
+ * @param {mat3} b the second operand
+ * @returns {mat3} out
+ */
+mat3.add = function(out, a, b) {
+    out[0] = a[0] + b[0];
+    out[1] = a[1] + b[1];
+    out[2] = a[2] + b[2];
+    out[3] = a[3] + b[3];
+    out[4] = a[4] + b[4];
+    out[5] = a[5] + b[5];
+    out[6] = a[6] + b[6];
+    out[7] = a[7] + b[7];
+    out[8] = a[8] + b[8];
+    return out;
+};
+
+/**
+ * Subtracts matrix b from matrix a
+ *
+ * @param {mat3} out the receiving matrix
+ * @param {mat3} a the first operand
+ * @param {mat3} b the second operand
+ * @returns {mat3} out
+ */
+mat3.subtract = function(out, a, b) {
+    out[0] = a[0] - b[0];
+    out[1] = a[1] - b[1];
+    out[2] = a[2] - b[2];
+    out[3] = a[3] - b[3];
+    out[4] = a[4] - b[4];
+    out[5] = a[5] - b[5];
+    out[6] = a[6] - b[6];
+    out[7] = a[7] - b[7];
+    out[8] = a[8] - b[8];
+    return out;
+};
+
+/**
+ * Alias for {@link mat3.subtract}
+ * @function
+ */
+mat3.sub = mat3.subtract;
 
 module.exports = mat3;

--- a/src/gl-matrix/mat4.js
+++ b/src/gl-matrix/mat4.js
@@ -1817,5 +1817,67 @@ mat4.frob = function (a) {
     return(Math.sqrt(Math.pow(a[0], 2) + Math.pow(a[1], 2) + Math.pow(a[2], 2) + Math.pow(a[3], 2) + Math.pow(a[4], 2) + Math.pow(a[5], 2) + Math.pow(a[6], 2) + Math.pow(a[7], 2) + Math.pow(a[8], 2) + Math.pow(a[9], 2) + Math.pow(a[10], 2) + Math.pow(a[11], 2) + Math.pow(a[12], 2) + Math.pow(a[13], 2) + Math.pow(a[14], 2) + Math.pow(a[15], 2) ))
 };
 
+/**
+ * Adds two mat4's
+ *
+ * @param {mat4} out the receiving matrix
+ * @param {mat4} a the first operand
+ * @param {mat4} b the second operand
+ * @returns {mat4} out
+ */
+mat4.add = function(out, a, b) {
+    out[0] = a[0] + b[0];
+    out[1] = a[1] + b[1];
+    out[2] = a[2] + b[2];
+    out[3] = a[3] + b[3];
+    out[4] = a[4] + b[4];
+    out[5] = a[5] + b[5];
+    out[6] = a[6] + b[6];
+    out[7] = a[7] + b[7];
+    out[8] = a[8] + b[8];
+    out[9] = a[9] + b[9];
+    out[10] = a[10] + b[10];
+    out[11] = a[11] + b[11];
+    out[12] = a[12] + b[12];
+    out[13] = a[13] + b[13];
+    out[14] = a[14] + b[14];
+    out[15] = a[15] + b[15];
+    return out;
+};
+
+/**
+ * Subtracts matrix b from matrix a
+ *
+ * @param {mat4} out the receiving matrix
+ * @param {mat4} a the first operand
+ * @param {mat4} b the second operand
+ * @returns {mat4} out
+ */
+mat4.subtract = function(out, a, b) {
+    out[0] = a[0] - b[0];
+    out[1] = a[1] - b[1];
+    out[2] = a[2] - b[2];
+    out[3] = a[3] - b[3];
+    out[4] = a[4] - b[4];
+    out[5] = a[5] - b[5];
+    out[6] = a[6] - b[6];
+    out[7] = a[7] - b[7];
+    out[8] = a[8] - b[8];
+    out[9] = a[9] - b[9];
+    out[10] = a[10] - b[10];
+    out[11] = a[11] - b[11];
+    out[12] = a[12] - b[12];
+    out[13] = a[13] - b[13];
+    out[14] = a[14] - b[14];
+    out[15] = a[15] - b[15];
+    return out;
+};
+
+/**
+ * Alias for {@link mat4.subtract}
+ * @function
+ */
+mat4.sub = mat4.subtract;
+
 
 module.exports = mat4;


### PR DESCRIPTION
I only needed this for mat3 but added it for the rest for consistency. It's certainly not as commonly needed as matrix multiplication, but it comes up frequently in physics problems.

I only did a scalar implementation for mat4, largely since SIMD is not well supported at all and so it's not something that is worth doing for me.

I'd also like to add matrix equivalents to `vec{N}.addAndScale`, (e.g. taking a scalar and another matrix, and working equivalently to `A = A + B*c` where A and B are matrices, and c is a scalar), since this is another operation I find myself doing. I didn't do this because I felt it would cause confusion with `mat{N}.scale` (for that matter, I'd also like to add multiplication of a matrix by a scalar...). If you can come up with better names for those, I'd be willing to implement them.