### PR TITLE
Implement equals function for all types

### DIFF
--- a/spec/gl-matrix/common-spec.js
+++ b/spec/gl-matrix/common-spec.js
@@ -11,4 +11,17 @@ describe("glMatrix", function(){
     beforeEach(function(){ result = glMatrix.toRadian(180); });
     it("should return a value of 3.141592654(Math.PI)", function(){ expect(result).toBeEqualish(Math.PI); });
   });
+
+  describe("equals", function() {
+    var r0, r1, r2;
+    beforeEach(function() {
+      r0 = glMatrix.equals(1.0, 0.0);
+      r1 = glMatrix.equals(1.0, 1.0);
+      r2 = glMatrix.equals(1.0+glMatrix.EPSILON/2, 1.0);
+    });
+    it("should return false for different numbers", function() { expect(r0).toBe(false); });
+    it("should return true for the same number", function() { expect(r1).toBe(true); });
+    it("should return true for numbers that are close", function() { expect(r2).toBe(true); });
+  });
+
 });

--- a/spec/gl-matrix/mat2-spec.js
+++ b/spec/gl-matrix/mat2-spec.js
@@ -318,4 +318,37 @@ describe("mat2", function() {
         });
     });
 
+    describe("exactEquals", function() {
+        var matC, r0, r1, r2;
+        beforeEach(function() {
+            matA = [0, 1, 2, 3];
+            matB = [0, 1, 2, 3];
+            matC = [1, 2, 3, 4];
+            r0 = mat2.exactEquals(matA, matB);
+            r1 = mat2.exactEquals(matA, matC);
+        });
+        it("should return true for identical matrices", function() { expect(r0).toBe(true); });
+        it("should return false for different matrices", function() { expect(r1).toBe(false); });
+        it("should not modify matA", function() { expect(matA).toBeEqualish([0, 1, 2, 3]); });
+        it("should not modify matB", function() { expect(matB).toBeEqualish([0, 1, 2, 3]); });
+    });
+
+    describe("equals", function() {
+        var matC, matD, r0, r1, r2;
+        beforeEach(function() {
+            matA = [0, 1, 2, 3];
+            matB = [0, 1, 2, 3];
+            matC = [1, 2, 3, 4];
+            matD = [1e-16, 1, 2, 3];
+            r0 = mat2.equals(matA, matB);
+            r1 = mat2.equals(matA, matC);
+            r2 = mat2.equals(matA, matD);
+        });
+        it("should return true for identical matrices", function() { expect(r0).toBe(true); });
+        it("should return false for different matrices", function() { expect(r1).toBe(false); });
+        it("should return true for close but not identical matrices", function() { expect(r2).toBe(true); });
+        it("should not modify matA", function() { expect(matA).toBeEqualish([0, 1, 2, 3]); });
+        it("should not modify matB", function() { expect(matB).toBeEqualish([0, 1, 2, 3]); });
+    });
+
 });

--- a/spec/gl-matrix/mat2d-spec.js
+++ b/spec/gl-matrix/mat2d-spec.js
@@ -302,5 +302,38 @@ describe("mat2d", function() {
         });
     });
 
+    describe("exactEquals", function() {
+        var matC, r0, r1;
+        beforeEach(function() {
+            matA = [0, 1, 2, 3, 4, 5];
+            matB = [0, 1, 2, 3, 4, 5];
+            matC = [1, 2, 3, 4, 5, 6];
+            r0 = mat2d.exactEquals(matA, matB);
+            r1 = mat2d.exactEquals(matA, matC);
+        });
+
+        it("should return true for identical matrices", function() { expect(r0).toBe(true); });
+        it("should return false for different matrices", function() { expect(r1).toBe(false); });
+        it("should not modify matA", function() { expect(matA).toBeEqualish([0, 1, 2, 3, 4, 5]); });
+        it("should not modify matB", function() { expect(matB).toBeEqualish([0, 1, 2, 3, 4, 5]); });
+    });
+
+    describe("equals", function() {
+        var matC, matD, r0, r1, r2;
+        beforeEach(function() {
+            matA = [0, 1, 2, 3, 4, 5];
+            matB = [0, 1, 2, 3, 4, 5];
+            matC = [1, 2, 3, 4, 5, 6];
+            matD = [1e-16, 1, 2, 3, 4, 5];
+            r0 = mat2d.equals(matA, matB);
+            r1 = mat2d.equals(matA, matC);
+            r2 = mat2d.equals(matA, matD);
+        });
+        it("should return true for identical matrices", function() { expect(r0).toBe(true); });
+        it("should return false for different matrices", function() { expect(r1).toBe(false); });
+        it("should return true for close but not identical matrices", function() { expect(r2).toBe(true); });
+        it("should not modify matA", function() { expect(matA).toBeEqualish([0, 1, 2, 3, 4, 5]); });
+        it("should not modify matB", function() { expect(matB).toBeEqualish([0, 1, 2, 3, 4, 5]); });
+    });
 
 });

--- a/spec/gl-matrix/mat3-spec.js
+++ b/spec/gl-matrix/mat3-spec.js
@@ -472,5 +472,38 @@ describe("mat3", function() {
         });
     });
 
+    describe("exactEquals", function() {
+        var matC, r0, r1;
+        beforeEach(function() {
+            matA = [0, 1, 2, 3, 4, 5, 6, 7, 8];
+            matB = [0, 1, 2, 3, 4, 5, 6, 7, 8];
+            matC = [1, 2, 3, 4, 5, 6, 7, 8, 9];
+            r0 = mat3.exactEquals(matA, matB);
+            r1 = mat3.exactEquals(matA, matC);
+        });
+
+        it("should return true for identical matrices", function() { expect(r0).toBe(true); });
+        it("should return false for different matrices", function() { expect(r1).toBe(false); });
+        it("should not modify matA", function() { expect(matA).toBeEqualish([0, 1, 2, 3, 4, 5, 6, 7, 8]); });
+        it("should not modify matB", function() { expect(matB).toBeEqualish([0, 1, 2, 3, 4, 5, 6, 7, 8]); });
+    });
+
+    describe("equals", function() {
+        var matC, matD, r0, r1, r2;
+        beforeEach(function() {
+            matA = [0, 1, 2, 3, 4, 5, 6, 7, 8];
+            matB = [0, 1, 2, 3, 4, 5, 6, 7, 8];
+            matC = [1, 2, 3, 4, 5, 6, 7, 8, 9];
+            matD = [1e-16, 1, 2, 3, 4, 5, 6, 7, 8];
+            r0 = mat3.equals(matA, matB);
+            r1 = mat3.equals(matA, matC);
+            r2 = mat3.equals(matA, matD);
+        });
+        it("should return true for identical matrices", function() { expect(r0).toBe(true); });
+        it("should return false for different matrices", function() { expect(r1).toBe(false); });
+        it("should return true for close but not identical matrices", function() { expect(r2).toBe(true); });
+        it("should not modify matA", function() { expect(matA).toBeEqualish([0, 1, 2, 3, 4, 5, 6, 7, 8]); });
+        it("should not modify matB", function() { expect(matB).toBeEqualish([0, 1, 2, 3, 4, 5, 6, 7, 8]); });
+    });
 
 });

--- a/spec/gl-matrix/mat4-spec.js
+++ b/spec/gl-matrix/mat4-spec.js
@@ -773,6 +773,40 @@ function buildMat4Tests(useSIMD) {
             it("should not modify matA", function() { expect(matA).toBeEqualish([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]); });
         });
     });
+
+    describe("exactEquals", function() {
+        var matC, r0, r1;
+        beforeEach(function() {
+            matA = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
+            matB = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
+            matC = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
+            r0 = mat4.exactEquals(matA, matB);
+            r1 = mat4.exactEquals(matA, matC);
+        });
+
+        it("should return true for identical matrices", function() { expect(r0).toBe(true); });
+        it("should return false for different matrices", function() { expect(r1).toBe(false); });
+        it("should not modify matA", function() { expect(matA).toBeEqualish([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]); });
+        it("should not modify matB", function() { expect(matB).toBeEqualish([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]); });
+    });
+
+    describe("equals", function() {
+        var matC, matD, r0, r1, r2;
+        beforeEach(function() {
+            matA = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
+            matB = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
+            matC = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
+            matD = [1e-16, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
+            r0 = mat4.equals(matA, matB);
+            r1 = mat4.equals(matA, matC);
+            r2 = mat4.equals(matA, matD);
+        });
+        it("should return true for identical matrices", function() { expect(r0).toBe(true); });
+        it("should return false for different matrices", function() { expect(r1).toBe(false); });
+        it("should return true for close but not identical matrices", function() { expect(r2).toBe(true); });
+        it("should not modify matA", function() { expect(matA).toBeEqualish([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]); });
+        it("should not modify matB", function() { expect(matB).toBeEqualish([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]); });
+    });
 }
 
 describe("mat4 (SISD)", buildMat4Tests(false));

--- a/spec/gl-matrix/quat-spec.js
+++ b/spec/gl-matrix/quat-spec.js
@@ -556,4 +556,38 @@ describe("quat", function() {
         
         it("should return a string representation of the quaternion", function() { expect(result).toEqual("quat(1, 2, 3, 4)"); });
     });
+
+    describe("exactEquals", function() {
+        var quatC, r0, r1;
+        beforeEach(function() {
+            quatA = [0, 1, 2, 3];
+            quatB = [0, 1, 2, 3];
+            quatC = [1, 2, 3, 4];
+            r0 = quat.exactEquals(quatA, quatB);
+            r1 = quat.exactEquals(quatA, quatC);
+        });
+
+        it("should return true for identical quaternions", function() { expect(r0).toBe(true); });
+        it("should return false for different quaternions", function() { expect(r1).toBe(false); });
+        it("should not modify quatA", function() { expect(quatA).toBeEqualish([0, 1, 2, 3]); });
+        it("should not modify quatB", function() { expect(quatB).toBeEqualish([0, 1, 2, 3]); });
+    });
+
+    describe("equals", function() {
+        var quatC, quatD, r0, r1, r2;
+        beforeEach(function() {
+            quatA = [0, 1, 2, 3];
+            quatB = [0, 1, 2, 3];
+            quatC = [1, 2, 3, 4];
+            quatD = [1e-16, 1, 2, 3];
+            r0 = quat.equals(quatA, quatB);
+            r1 = quat.equals(quatA, quatC);
+            r2 = quat.equals(quatA, quatD);
+        });
+        it("should return true for identical quaternions", function() { expect(r0).toBe(true); });
+        it("should return false for different quaternions", function() { expect(r1).toBe(false); });
+        it("should return true for close but not identical quaternions", function() { expect(r2).toBe(true); });
+        it("should not modify quatA", function() { expect(quatA).toBeEqualish([0, 1, 2, 3]); });
+        it("should not modify quatB", function() { expect(quatB).toBeEqualish([0, 1, 2, 3]); });
+    });
 });

--- a/spec/gl-matrix/vec2-spec.js
+++ b/spec/gl-matrix/vec2-spec.js
@@ -546,4 +546,38 @@ describe("vec2", function() {
         
         it("should return a string representation of the vector", function() { expect(result).toEqual("vec2(1, 2)"); });
     });
+
+    describe("exactEquals", function() {
+        var vecC, r0, r1;
+        beforeEach(function() {
+            vecA = [0, 1];
+            vecB = [0, 1];
+            vecC = [1, 2];
+            r0 = vec2.exactEquals(vecA, vecB);
+            r1 = vec2.exactEquals(vecA, vecC);
+        });
+
+        it("should return true for identical vectors", function() { expect(r0).toBe(true); });
+        it("should return false for different vectors", function() { expect(r1).toBe(false); });
+        it("should not modify vecA", function() { expect(vecA).toBeEqualish([0, 1]); });
+        it("should not modify vecB", function() { expect(vecB).toBeEqualish([0, 1]); });
+    });
+
+    describe("equals", function() {
+        var vecC, vecD, r0, r1, r2;
+        beforeEach(function() {
+            vecA = [0, 1];
+            vecB = [0, 1];
+            vecC = [1, 2];
+            vecD = [1e-16, 1];
+            r0 = vec2.equals(vecA, vecB);
+            r1 = vec2.equals(vecA, vecC);
+            r2 = vec2.equals(vecA, vecD);
+        });
+        it("should return true for identical vectors", function() { expect(r0).toBe(true); });
+        it("should return false for different vectors", function() { expect(r1).toBe(false); });
+        it("should return true for close but not identical vectors", function() { expect(r2).toBe(true); });
+        it("should not modify vecA", function() { expect(vecA).toBeEqualish([0, 1]); });
+        it("should not modify vecB", function() { expect(vecB).toBeEqualish([0, 1]); });
+    });
 });

--- a/spec/gl-matrix/vec3-spec.js
+++ b/spec/gl-matrix/vec3-spec.js
@@ -658,4 +658,38 @@ describe("vec3", function() {
         
         it("should return a string representation of the vector", function() { expect(result).toEqual("vec3(1, 2, 3)"); });
     });
+
+    describe("exactEquals", function() {
+        var vecC, r0, r1;
+        beforeEach(function() {
+            vecA = [0, 1, 2];
+            vecB = [0, 1, 2];
+            vecC = [1, 2, 3];
+            r0 = vec3.exactEquals(vecA, vecB);
+            r1 = vec3.exactEquals(vecA, vecC);
+        });
+
+        it("should return true for identical vectors", function() { expect(r0).toBe(true); });
+        it("should return false for different vectors", function() { expect(r1).toBe(false); });
+        it("should not modify vecA", function() { expect(vecA).toBeEqualish([0, 1, 2]); });
+        it("should not modify vecB", function() { expect(vecB).toBeEqualish([0, 1, 2]); });
+    });
+
+    describe("equals", function() {
+        var vecC, vecD, r0, r1, r2;
+        beforeEach(function() {
+            vecA = [0, 1, 2];
+            vecB = [0, 1, 2];
+            vecC = [1, 2, 3];
+            vecD = [1e-16, 1, 2];
+            r0 = vec3.equals(vecA, vecB);
+            r1 = vec3.equals(vecA, vecC);
+            r2 = vec3.equals(vecA, vecD);
+        });
+        it("should return true for identical vectors", function() { expect(r0).toBe(true); });
+        it("should return false for different vectors", function() { expect(r1).toBe(false); });
+        it("should return true for close but not identical vectors", function() { expect(r2).toBe(true); });
+        it("should not modify vecA", function() { expect(vecA).toBeEqualish([0, 1, 2]); });
+        it("should not modify vecB", function() { expect(vecB).toBeEqualish([0, 1, 2]); });
+    });
 });

--- a/spec/gl-matrix/vec4-spec.js
+++ b/spec/gl-matrix/vec4-spec.js
@@ -489,4 +489,38 @@ describe("vec4", function() {
         
         it("should return a string representation of the vector", function() { expect(result).toEqual("vec4(1, 2, 3, 4)"); });
     });
+
+    describe("exactEquals", function() {
+        var vecC, r0, r1;
+        beforeEach(function() {
+            vecA = [0, 1, 2, 3];
+            vecB = [0, 1, 2, 3];
+            vecC = [1, 2, 3, 4];
+            r0 = vec4.exactEquals(vecA, vecB);
+            r1 = vec4.exactEquals(vecA, vecC);
+        });
+
+        it("should return true for identical vectors", function() { expect(r0).toBe(true); });
+        it("should return false for different vectors", function() { expect(r1).toBe(false); });
+        it("should not modify vecA", function() { expect(vecA).toBeEqualish([0, 1, 2, 3]); });
+        it("should not modify vecB", function() { expect(vecB).toBeEqualish([0, 1, 2, 3]); });
+    });
+
+    describe("equals", function() {
+        var vecC, vecD, r0, r1, r2;
+        beforeEach(function() {
+            vecA = [0, 1, 2, 3];
+            vecB = [0, 1, 2, 3];
+            vecC = [1, 2, 3, 4];
+            vecD = [1e-16, 1, 2, 3];
+            r0 = vec4.equals(vecA, vecB);
+            r1 = vec4.equals(vecA, vecC);
+            r2 = vec4.equals(vecA, vecD);
+        });
+        it("should return true for identical vectors", function() { expect(r0).toBe(true); });
+        it("should return false for different vectors", function() { expect(r1).toBe(false); });
+        it("should return true for close but not identical vectors", function() { expect(r2).toBe(true); });
+        it("should not modify vecA", function() { expect(vecA).toBeEqualish([0, 1, 2, 3]); });
+        it("should not modify vecB", function() { expect(vecB).toBeEqualish([0, 1, 2, 3]); });
+    });
 });

--- a/src/gl-matrix/common.js
+++ b/src/gl-matrix/common.js
@@ -54,4 +54,17 @@ glMatrix.toRadian = function(a){
      return a * degree;
 }
 
+/**
+ * Tests whether or not the arguments have approximately the same value, within an absolute
+ * or relative tolerance of glMatrix.EPSILON (an absolute tolerance is used for values less 
+ * than or equal to 1.0, and a relative tolerance is used for larger values)
+ * 
+ * @param {Number} a The first number to test.
+ * @param {Number} b The second number to test.
+ * @returns {Boolean} True if the numbers are approximately equal, false otherwise.
+ */
+glMatrix.equals = function(a, b) {
+	return Math.abs(a - b) <= glMatrix.EPSILON*Math.max(1.0, Math.abs(a), Math.abs(b));
+}
+
 module.exports = glMatrix;

--- a/src/gl-matrix/mat2.js
+++ b/src/gl-matrix/mat2.js
@@ -373,6 +373,32 @@ mat2.subtract = function(out, a, b) {
  */
 mat2.sub = mat2.subtract;
 
+/**
+ * Returns whether or not the matrices have exactly the same elements in the same position (when compared with ===)
+ *
+ * @param {mat2} a The first matrix.
+ * @param {mat2} b The second matrix.
+ * @returns {Boolean} True if the matrices are equal, false otherwise.
+ */
+mat2.exactEquals = function (a, b) {
+    return a[0] === b[0] && a[1] === b[1] && a[2] === b[2] && a[3] === b[3];
+};
+
+/**
+ * Returns whether or not the matrices have approximately the same elements in the same position.
+ *
+ * @param {mat2} a The first matrix.
+ * @param {mat2} b The second matrix.
+ * @returns {Boolean} True if the matrices are equal, false otherwise.
+ */
+mat2.equals = function (a, b) {
+    var a0 = a[0], a1 = a[1], a2 = a[2], a3 = a[3];
+    var b0 = b[0], b1 = b[1], b2 = b[2], b3 = b[3];
+    return (Math.abs(a0 - b0) <= glMatrix.EPSILON*Math.max(1.0, Math.abs(a0), Math.abs(b0)) &&
+            Math.abs(a1 - b1) <= glMatrix.EPSILON*Math.max(1.0, Math.abs(a1), Math.abs(b1)) &&
+            Math.abs(a2 - b2) <= glMatrix.EPSILON*Math.max(1.0, Math.abs(a2), Math.abs(b2)) &&
+            Math.abs(a3 - b3) <= glMatrix.EPSILON*Math.max(1.0, Math.abs(a3), Math.abs(b3)));
+};
 
 /**
  * Multiply each element of the matrix by a scalar.

--- a/src/gl-matrix/mat2d.js
+++ b/src/gl-matrix/mat2d.js
@@ -437,4 +437,33 @@ mat2d.multiplyScalarAndAdd = function(out, a, b, scale) {
     return out;
 };
 
+/**
+ * Returns whether or not the matrices have exactly the same elements in the same position (when compared with ===)
+ *
+ * @param {mat2d} a The first matrix.
+ * @param {mat2d} b The second matrix.
+ * @returns {Boolean} True if the matrices are equal, false otherwise.
+ */
+mat2d.exactEquals = function (a, b) {
+    return a[0] === b[0] && a[1] === b[1] && a[2] === b[2] && a[3] === b[3] && a[4] === b[4] && a[5] === b[5];
+};
+
+/**
+ * Returns whether or not the matrices have approximately the same elements in the same position.
+ *
+ * @param {mat2d} a The first matrix.
+ * @param {mat2d} b The second matrix.
+ * @returns {Boolean} True if the matrices are equal, false otherwise.
+ */
+mat2d.equals = function (a, b) {
+    var a0 = a[0], a1 = a[1], a2 = a[2], a3 = a[3], a4 = a[4], a5 = a[5];
+    var b0 = b[0], b1 = b[1], b2 = b[2], b3 = b[3], b4 = b[4], b5 = b[5];
+    return (Math.abs(a0 - b0) <= glMatrix.EPSILON*Math.max(1.0, Math.abs(a0), Math.abs(b0)) &&
+            Math.abs(a1 - b1) <= glMatrix.EPSILON*Math.max(1.0, Math.abs(a1), Math.abs(b1)) &&
+            Math.abs(a2 - b2) <= glMatrix.EPSILON*Math.max(1.0, Math.abs(a2), Math.abs(b2)) &&
+            Math.abs(a3 - b3) <= glMatrix.EPSILON*Math.max(1.0, Math.abs(a3), Math.abs(b3)) &&
+            Math.abs(a4 - b4) <= glMatrix.EPSILON*Math.max(1.0, Math.abs(a4), Math.abs(b4)) &&
+            Math.abs(a5 - b5) <= glMatrix.EPSILON*Math.max(1.0, Math.abs(a5), Math.abs(b5)));
+};
+
 module.exports = mat2d;

--- a/src/gl-matrix/mat3.js
+++ b/src/gl-matrix/mat3.js
@@ -708,4 +708,39 @@ mat3.multiplyScalarAndAdd = function(out, a, b, scale) {
     return out;
 };
 
+/*
+ * Returns whether or not the matrices have exactly the same elements in the same position (when compared with ===)
+ *
+ * @param {mat3} a The first matrix.
+ * @param {mat3} b The second matrix.
+ * @returns {Boolean} True if the matrices are equal, false otherwise.
+ */
+mat3.exactEquals = function (a, b) {
+    return a[0] === b[0] && a[1] === b[1] && a[2] === b[2] && 
+           a[3] === b[3] && a[4] === b[4] && a[5] === b[5] &&
+           a[6] === b[6] && a[7] === b[7] && a[8] === b[8];
+};
+
+/**
+ * Returns whether or not the matrices have approximately the same elements in the same position.
+ *
+ * @param {mat3} a The first matrix.
+ * @param {mat3} b The second matrix.
+ * @returns {Boolean} True if the matrices are equal, false otherwise.
+ */
+mat3.equals = function (a, b) {
+    var a0 = a[0], a1 = a[1], a2 = a[2], a3 = a[3], a4 = a[4], a5 = a[5], a6 = a[6], a7 = a[7], a8 = a[8];
+    var b0 = b[0], b1 = b[1], b2 = b[2], b3 = b[3], b4 = b[4], b5 = b[5], b6 = a[6], b7 = b[7], b8 = b[8];
+    return (Math.abs(a0 - b0) <= glMatrix.EPSILON*Math.max(1.0, Math.abs(a0), Math.abs(b0)) &&
+            Math.abs(a1 - b1) <= glMatrix.EPSILON*Math.max(1.0, Math.abs(a1), Math.abs(b1)) &&
+            Math.abs(a2 - b2) <= glMatrix.EPSILON*Math.max(1.0, Math.abs(a2), Math.abs(b2)) &&
+            Math.abs(a3 - b3) <= glMatrix.EPSILON*Math.max(1.0, Math.abs(a3), Math.abs(b3)) &&
+            Math.abs(a4 - b4) <= glMatrix.EPSILON*Math.max(1.0, Math.abs(a4), Math.abs(b4)) &&
+            Math.abs(a5 - b5) <= glMatrix.EPSILON*Math.max(1.0, Math.abs(a5), Math.abs(b5)) &&
+            Math.abs(a6 - b6) <= glMatrix.EPSILON*Math.max(1.0, Math.abs(a6), Math.abs(b6)) &&
+            Math.abs(a7 - b7) <= glMatrix.EPSILON*Math.max(1.0, Math.abs(a7), Math.abs(b7)) &&
+            Math.abs(a8 - b8) <= glMatrix.EPSILON*Math.max(1.0, Math.abs(a8), Math.abs(b8)));
+};
+
+
 module.exports = mat3;

--- a/src/gl-matrix/mat4.js
+++ b/src/gl-matrix/mat4.js
@@ -2021,5 +2021,56 @@ mat4.multiplyScalarAndAdd = function(out, a, b, scale) {
     return out;
 };
 
+/**
+ * Returns whether or not the matrices have exactly the same elements in the same position (when compared with ===)
+ *
+ * @param {mat4} a The first matrix.
+ * @param {mat4} b The second matrix.
+ * @returns {Boolean} True if the matrices are equal, false otherwise.
+ */
+mat4.exactEquals = function (a, b) {
+    return a[0] === b[0] && a[1] === b[1] && a[2] === b[2] && a[3] === b[3] && 
+           a[4] === b[4] && a[5] === b[5] && a[6] === b[6] && a[7] === b[7] && 
+           a[8] === b[8] && a[9] === b[9] && a[10] === b[10] && a[11] === b[11] &&
+           a[12] === b[12] && a[13] === b[13] && a[14] === b[14] && a[15] === b[15];
+};
+
+/**
+ * Returns whether or not the matrices have approximately the same elements in the same position.
+ *
+ * @param {mat4} a The first matrix.
+ * @param {mat4} b The second matrix.
+ * @returns {Boolean} True if the matrices are equal, false otherwise.
+ */
+mat4.equals = function (a, b) {
+    var a0  = a[0],  a1  = a[1],  a2  = a[2],  a3  = a[3],
+        a4  = a[4],  a5  = a[5],  a6  = a[6],  a7  = a[7], 
+        a8  = a[8],  a9  = a[9],  a10 = a[10], a11 = a[11], 
+        a12 = a[12], a13 = a[13], a14 = a[14], a15 = a[15];
+
+    var b0  = b[0],  b1  = b[1],  b2  = b[2],  b3  = b[3],
+        b4  = b[4],  b5  = b[5],  b6  = b[6],  b7  = b[7], 
+        b8  = b[8],  b9  = b[9],  b10 = b[10], b11 = b[11], 
+        b12 = b[12], b13 = b[13], b14 = b[14], b15 = b[15];
+
+    return (Math.abs(a0 - b0) <= glMatrix.EPSILON*Math.max(1.0, Math.abs(a0), Math.abs(b0)) &&
+            Math.abs(a1 - b1) <= glMatrix.EPSILON*Math.max(1.0, Math.abs(a1), Math.abs(b1)) &&
+            Math.abs(a2 - b2) <= glMatrix.EPSILON*Math.max(1.0, Math.abs(a2), Math.abs(b2)) &&
+            Math.abs(a3 - b3) <= glMatrix.EPSILON*Math.max(1.0, Math.abs(a3), Math.abs(b3)) &&
+            Math.abs(a4 - b4) <= glMatrix.EPSILON*Math.max(1.0, Math.abs(a4), Math.abs(b4)) &&
+            Math.abs(a5 - b5) <= glMatrix.EPSILON*Math.max(1.0, Math.abs(a5), Math.abs(b5)) &&
+            Math.abs(a6 - b6) <= glMatrix.EPSILON*Math.max(1.0, Math.abs(a6), Math.abs(b6)) &&
+            Math.abs(a7 - b7) <= glMatrix.EPSILON*Math.max(1.0, Math.abs(a7), Math.abs(b7)) &&
+            Math.abs(a8 - b8) <= glMatrix.EPSILON*Math.max(1.0, Math.abs(a8), Math.abs(b8)) &&
+            Math.abs(a9 - b9) <= glMatrix.EPSILON*Math.max(1.0, Math.abs(a9), Math.abs(b9)) &&
+            Math.abs(a10 - b10) <= glMatrix.EPSILON*Math.max(1.0, Math.abs(a10), Math.abs(b10)) &&
+            Math.abs(a11 - b11) <= glMatrix.EPSILON*Math.max(1.0, Math.abs(a11), Math.abs(b11)) &&
+            Math.abs(a12 - b12) <= glMatrix.EPSILON*Math.max(1.0, Math.abs(a12), Math.abs(b12)) &&
+            Math.abs(a13 - b13) <= glMatrix.EPSILON*Math.max(1.0, Math.abs(a13), Math.abs(b13)) &&
+            Math.abs(a14 - b14) <= glMatrix.EPSILON*Math.max(1.0, Math.abs(a14), Math.abs(b14)) &&
+            Math.abs(a15 - b15) <= glMatrix.EPSILON*Math.max(1.0, Math.abs(a15), Math.abs(b15)));
+};
+
+
 
 module.exports = mat4;

--- a/src/gl-matrix/quat.js
+++ b/src/gl-matrix/quat.js
@@ -550,4 +550,22 @@ quat.str = function (a) {
     return 'quat(' + a[0] + ', ' + a[1] + ', ' + a[2] + ', ' + a[3] + ')';
 };
 
+/**
+ * Returns whether or not the quaternions have exactly the same elements in the same position (when compared with ===)
+ *
+ * @param {quat} a The first quaternion.
+ * @param {quat} b The second quaternion.
+ * @returns {Boolean} True if the vectors are equal, false otherwise.
+ */
+quat.exactEquals = vec4.exactEquals;
+
+/**
+ * Returns whether or not the quaternions have approximately the same elements in the same position.
+ *
+ * @param {quat} a The first vector.
+ * @param {quat} b The second vector.
+ * @returns {Boolean} True if the vectors are equal, false otherwise.
+ */
+quat.equals = vec4.equals;
+
 module.exports = quat;

--- a/src/gl-matrix/vec2.js
+++ b/src/gl-matrix/vec2.js
@@ -520,4 +520,29 @@ vec2.str = function (a) {
     return 'vec2(' + a[0] + ', ' + a[1] + ')';
 };
 
+/**
+ * Returns whether or not the vectors exactly have the same elements in the same position (when compared with ===)
+ *
+ * @param {vec2} a The first vector.
+ * @param {vec2} b The second vector.
+ * @returns {Boolean} True if the vectors are equal, false otherwise.
+ */
+vec2.exactEquals = function (a, b) {
+    return a[0] === b[0] && a[1] === b[1];
+};
+
+/**
+ * Returns whether or not the vectors have approximately the same elements in the same position.
+ *
+ * @param {vec2} a The first vector.
+ * @param {vec2} b The second vector.
+ * @returns {Boolean} True if the vectors are equal, false otherwise.
+ */
+vec2.equals = function (a, b) {
+    var a0 = a[0], a1 = a[1];
+    var b0 = b[0], b1 = b[1];
+    return (Math.abs(a0 - b0) <= glMatrix.EPSILON*Math.max(1.0, Math.abs(a0), Math.abs(b0)) &&
+            Math.abs(a1 - b1) <= glMatrix.EPSILON*Math.max(1.0, Math.abs(a1), Math.abs(b1)));
+};
+
 module.exports = vec2;

--- a/src/gl-matrix/vec3.js
+++ b/src/gl-matrix/vec3.js
@@ -706,4 +706,30 @@ vec3.str = function (a) {
     return 'vec3(' + a[0] + ', ' + a[1] + ', ' + a[2] + ')';
 };
 
+/**
+ * Returns whether or not the vectors have exactly the same elements in the same position (when compared with ===)
+ *
+ * @param {vec3} a The first vector.
+ * @param {vec3} b The second vector.
+ * @returns {Boolean} True if the vectors are equal, false otherwise.
+ */
+vec3.exactEquals = function (a, b) {
+    return a[0] === b[0] && a[1] === b[1] && a[2] === b[2];
+};
+
+/**
+ * Returns whether or not the vectors have approximately the same elements in the same position.
+ *
+ * @param {vec3} a The first vector.
+ * @param {vec3} b The second vector.
+ * @returns {Boolean} True if the vectors are equal, false otherwise.
+ */
+vec3.equals = function (a, b) {
+    var a0 = a[0], a1 = a[1], a2 = a[2];
+    var b0 = b[0], b1 = b[1], b2 = b[2];
+    return (Math.abs(a0 - b0) <= glMatrix.EPSILON*Math.max(1.0, Math.abs(a0), Math.abs(b0)) &&
+            Math.abs(a1 - b1) <= glMatrix.EPSILON*Math.max(1.0, Math.abs(a1), Math.abs(b1)) &&
+            Math.abs(a2 - b2) <= glMatrix.EPSILON*Math.max(1.0, Math.abs(a2), Math.abs(b2)));
+};
+
 module.exports = vec3;

--- a/src/gl-matrix/vec4.js
+++ b/src/gl-matrix/vec4.js
@@ -534,4 +534,31 @@ vec4.str = function (a) {
     return 'vec4(' + a[0] + ', ' + a[1] + ', ' + a[2] + ', ' + a[3] + ')';
 };
 
+/**
+ * Returns whether or not the vectors have exactly the same elements in the same position (when compared with ===)
+ *
+ * @param {vec4} a The first vector.
+ * @param {vec4} b The second vector.
+ * @returns {Boolean} True if the vectors are equal, false otherwise.
+ */
+vec4.exactEquals = function (a, b) {
+    return a[0] === b[0] && a[1] === b[1] && a[2] === b[2] && a[3] === b[3];
+};
+
+/**
+ * Returns whether or not the vectors have approximately the same elements in the same position.
+ *
+ * @param {vec4} a The first vector.
+ * @param {vec4} b The second vector.
+ * @returns {Boolean} True if the vectors are equal, false otherwise.
+ */
+vec4.equals = function (a, b) {
+    var a0 = a[0], a1 = a[1], a2 = a[2], a3 = a[3];
+    var b0 = b[0], b1 = b[1], b2 = b[2], b3 = b[3];
+    return (Math.abs(a0 - b0) <= glMatrix.EPSILON*Math.max(1.0, Math.abs(a0), Math.abs(b0)) &&
+            Math.abs(a1 - b1) <= glMatrix.EPSILON*Math.max(1.0, Math.abs(a1), Math.abs(b1)) &&
+            Math.abs(a2 - b2) <= glMatrix.EPSILON*Math.max(1.0, Math.abs(a2), Math.abs(b2)) &&
+            Math.abs(a3 - b3) <= glMatrix.EPSILON*Math.max(1.0, Math.abs(a3), Math.abs(b3)));
+};
+
 module.exports = vec4;


### PR DESCRIPTION
Strict equality comparison, e.g. ===. So this might do the wrong thing for NaNs, depending on your perspective.  

I considered adding a matching approxEquals as well, but considering that I didn't need it, and that the way to do accurately has some overhead that a lot of people might find undesirable (the obvious `Math.abs(x-y) < epsilon` fails for large x and y, so you need to do  `Math.abs(x-y) < epsilon*Math.max(1.0, Math.abs(x), Math.abs(y))`)... I punted on it.