### PR TITLE
Add multiplyScalar and multiplyScalarAndAdd functions for matrices

### DIFF
--- a/spec/gl-matrix/mat2-spec.js
+++ b/spec/gl-matrix/mat2-spec.js
@@ -273,4 +273,49 @@ describe("mat2", function() {
         it("should place values into out", function() { expect(out).toBeEqualish([1, 2, 3, 4]); });
         it("should return out", function() { expect(result).toBe(out); });
     });
+
+    describe("multiplyScalar", function() {
+        describe("with a separate output matrix", function() {
+            beforeEach(function() { result = mat2.multiplyScalar(out, matA, 2); });
+            
+            it("should place values into out", function() { expect(out).toBeEqualish([2, 4, 6, 8]); });
+            it("should return out", function() { expect(result).toBe(out); });
+            it("should not modify matA", function() { expect(matA).toBeEqualish([1, 2, 3, 4]); });
+        });
+
+        describe("when matA is the output matrix", function() {
+            beforeEach(function() { result = mat2.multiplyScalar(matA, matA, 2); });
+            
+            it("should place values into matA", function() { expect(matA).toBeEqualish([2, 4, 6, 8]); });
+            it("should return matA", function() { expect(result).toBe(matA); });
+        });
+    });
+
+    describe("multiplyScalarAndAdd", function() {
+        describe("with a separate output matrix", function() {
+            beforeEach(function() { result = mat2.multiplyScalarAndAdd(out, matA, matB, 0.5); });
+            
+            it("should place values into out", function() { expect(out).toBeEqualish([3.5, 5, 6.5, 8]); });
+            it("should return out", function() { expect(result).toBe(out); });
+            it("should not modify matA", function() { expect(matA).toBeEqualish([1, 2, 3, 4]); });
+            it("should not modify matB", function() { expect(matB).toBeEqualish([5, 6, 7, 8]); });
+        });
+
+        describe("when matA is the output matrix", function() {
+            beforeEach(function() { result = mat2.multiplyScalarAndAdd(matA, matA, matB, 0.5); });
+            
+            it("should place values into matA", function() { expect(matA).toBeEqualish([3.5, 5, 6.5, 8]); });
+            it("should return matA", function() { expect(result).toBe(matA); });
+            it("should not modify matB", function() { expect(matB).toBeEqualish([5, 6, 7, 8]); });
+        });
+
+        describe("when matB is the output matrix", function() {
+            beforeEach(function() { result = mat2.multiplyScalarAndAdd(matB, matA, matB, 0.5); });
+            
+            it("should place values into matB", function() { expect(matB).toBeEqualish([3.5, 5, 6.5, 8]); });
+            it("should return matB", function() { expect(result).toBe(matB); });
+            it("should not modify matA", function() { expect(matA).toBeEqualish([1, 2, 3, 4]); });
+        });
+    });
+
 });

--- a/spec/gl-matrix/mat2d-spec.js
+++ b/spec/gl-matrix/mat2d-spec.js
@@ -257,4 +257,50 @@ describe("mat2d", function() {
         it("should place values into out", function() { expect(out).toBeEqualish([1, 2, 3, 4, 5, 6]); });
         it("should return out", function() { expect(result).toBe(out); });
     });
+
+    describe("multiplyScalar", function() {
+        describe("with a separate output matrix", function() {
+            beforeEach(function() { result = mat2d.multiplyScalar(out, matA, 2); });
+            
+            it("should place values into out", function() { expect(out).toBeEqualish([2, 4, 6, 8, 10, 12]); });
+            it("should return out", function() { expect(result).toBe(out); });
+            it("should not modify matA", function() { expect(matA).toBeEqualish([1, 2, 3, 4, 5, 6]); });
+        });
+
+        describe("when matA is the output matrix", function() {
+            beforeEach(function() { result = mat2d.multiplyScalar(matA, matA, 2); });
+            
+            it("should place values into matA", function() { expect(matA).toBeEqualish([2, 4, 6, 8, 10, 12]); });
+            it("should return matA", function() { expect(result).toBe(matA); });
+        });
+    });
+
+    describe("multiplyScalarAndAdd", function() {
+        describe("with a separate output matrix", function() {
+            beforeEach(function() { result = mat2d.multiplyScalarAndAdd(out, matA, matB, 0.5); });
+            
+            it("should place values into out", function() { expect(out).toBeEqualish([4.5, 6, 7.5, 9, 10.5, 12]); });
+            it("should return out", function() { expect(result).toBe(out); });
+            it("should not modify matA", function() { expect(matA).toBeEqualish([1, 2, 3, 4, 5, 6]); });
+            it("should not modify matB", function() { expect(matB).toBeEqualish([7, 8, 9, 10, 11, 12]); });
+        });
+
+        describe("when matA is the output matrix", function() {
+            beforeEach(function() { result = mat2d.multiplyScalarAndAdd(matA, matA, matB, 0.5); });
+            
+            it("should place values into matA", function() { expect(matA).toBeEqualish([4.5, 6, 7.5, 9, 10.5, 12]); });
+            it("should return matA", function() { expect(result).toBe(matA); });
+            it("should not modify matB", function() { expect(matB).toBeEqualish([7, 8, 9, 10, 11, 12]); });
+        });
+
+        describe("when matB is the output matrix", function() {
+            beforeEach(function() { result = mat2d.multiplyScalarAndAdd(matB, matA, matB, 0.5); });
+            
+            it("should place values into matB", function() { expect(matB).toBeEqualish([4.5, 6, 7.5, 9, 10.5, 12]); });
+            it("should return matB", function() { expect(result).toBe(matB); });
+            it("should not modify matA", function() { expect(matA).toBeEqualish([1, 2, 3, 4, 5, 6]); });
+        });
+    });
+
+
 });

--- a/spec/gl-matrix/mat3-spec.js
+++ b/spec/gl-matrix/mat3-spec.js
@@ -421,4 +421,56 @@ describe("mat3", function() {
         it("should return out", function() { expect(result).toBe(out); });
     });
 
+    describe("multiplyScalar", function() {
+        beforeEach(function() {
+            matA = [1, 2, 3, 4, 5, 6, 7, 8, 9];
+        });
+        describe("with a separate output matrix", function() {
+            beforeEach(function() { result = mat3.multiplyScalar(out, matA, 2); });
+            
+            it("should place values into out", function() { expect(out).toBeEqualish([2, 4, 6, 8, 10, 12, 14, 16, 18]); });
+            it("should return out", function() { expect(result).toBe(out); });
+            it("should not modify matA", function() { expect(matA).toBeEqualish([1, 2, 3, 4, 5, 6, 7, 8, 9]); });
+        });
+
+        describe("when matA is the output matrix", function() {
+            beforeEach(function() { result = mat3.multiplyScalar(matA, matA, 2); });
+            
+            it("should place values into matA", function() { expect(matA).toBeEqualish([2, 4, 6, 8, 10, 12, 14, 16, 18]); });
+            it("should return matA", function() { expect(result).toBe(matA); });
+        });
+    });
+
+    describe("multiplyScalarAndAdd", function() {
+        beforeEach(function() {
+            matA = [1, 2, 3, 4, 5, 6, 7, 8, 9];
+            matB = [10, 11, 12, 13, 14, 15, 16, 17, 18];
+        });
+        describe("with a separate output matrix", function() {
+            beforeEach(function() { result = mat3.multiplyScalarAndAdd(out, matA, matB, 0.5); });
+            
+            it("should place values into out", function() { expect(out).toBeEqualish([6, 7.5, 9, 10.5, 12, 13.5, 15, 16.5, 18]); });
+            it("should return out", function() { expect(result).toBe(out); });
+            it("should not modify matA", function() { expect(matA).toBeEqualish([1, 2, 3, 4, 5, 6, 7, 8, 9]); });
+            it("should not modify matB", function() { expect(matB).toBeEqualish([10, 11, 12, 13, 14, 15, 16, 17, 18]); });
+        });
+
+        describe("when matA is the output matrix", function() {
+            beforeEach(function() { result = mat3.multiplyScalarAndAdd(matA, matA, matB, 0.5); });
+            
+            it("should place values into matA", function() { expect(matA).toBeEqualish([6, 7.5, 9, 10.5, 12, 13.5, 15, 16.5, 18]); });
+            it("should return matA", function() { expect(result).toBe(matA); });
+            it("should not modify matB", function() { expect(matB).toBeEqualish([10, 11, 12, 13, 14, 15, 16, 17, 18]); });
+        });
+
+        describe("when matB is the output matrix", function() {
+            beforeEach(function() { result = mat3.multiplyScalarAndAdd(matB, matA, matB, 0.5); });
+            
+            it("should place values into matB", function() { expect(matB).toBeEqualish([6, 7.5, 9, 10.5, 12, 13.5, 15, 16.5, 18]); });
+            it("should return matB", function() { expect(result).toBe(matB); });
+            it("should not modify matA", function() { expect(matA).toBeEqualish([1, 2, 3, 4, 5, 6, 7, 8, 9]); });
+        });
+    });
+
+
 });

--- a/spec/gl-matrix/mat4-spec.js
+++ b/spec/gl-matrix/mat4-spec.js
@@ -722,6 +722,57 @@ function buildMat4Tests(useSIMD) {
         it("should place values into out", function() { expect(out).toBeEqualish([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]); });
         it("should return out", function() { expect(result).toBe(out); });
     });
+
+    describe("multiplyScalar", function() {
+        beforeEach(function() {
+            matA = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
+        });
+        describe("with a separate output matrix", function() {
+            beforeEach(function() { result = mat3.multiplyScalar(out, matA, 2); });
+            
+            it("should place values into out", function() { expect(out).toBeEqualish([2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32]); });
+            it("should return out", function() { expect(result).toBe(out); });
+            it("should not modify matA", function() { expect(matA).toBeEqualish([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]); });
+        });
+
+        describe("when matA is the output matrix", function() {
+            beforeEach(function() { result = mat3.multiplyScalar(matA, matA, 2); });
+            
+            it("should place values into matA", function() { expect(matA).toBeEqualish([2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32]); });
+            it("should return matA", function() { expect(result).toBe(matA); });
+        });
+    });
+
+    describe("multiplyScalarAndAdd", function() {
+        beforeEach(function() {
+            matA = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
+            matB = [17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32];
+        });
+        describe("with a separate output matrix", function() {
+            beforeEach(function() { result = mat3.multiplyScalarAndAdd(out, matA, matB, 0.5); });
+            
+            it("should place values into out", function() { expect(out).toBeEqualish([9.5, 11, 12.5, 14, 15.5, 17, 18.5, 20, 21.5, 23, 24.5, 26, 27.5, 29, 30.5, 32]); });
+            it("should return out", function() { expect(result).toBe(out); });
+            it("should not modify matA", function() { expect(matA).toBeEqualish([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]); });
+            it("should not modify matB", function() { expect(matB).toBeEqualish([17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32]); });
+        });
+
+        describe("when matA is the output matrix", function() {
+            beforeEach(function() { result = mat3.multiplyScalarAndAdd(matA, matA, matB, 0.5); });
+            
+            it("should place values into matA", function() { expect(matA).toBeEqualish([9.5, 11, 12.5, 14, 15.5, 17, 18.5, 20, 21.5, 23, 24.5, 26, 27.5, 29, 30.5, 32]); });
+            it("should return matA", function() { expect(result).toBe(matA); });
+            it("should not modify matB", function() { expect(matB).toBeEqualish([17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32]); });
+        });
+
+        describe("when matB is the output matrix", function() {
+            beforeEach(function() { result = mat3.multiplyScalarAndAdd(matB, matA, matB, 0.5); });
+            
+            it("should place values into matB", function() { expect(matB).toBeEqualish([9.5, 11, 12.5, 14, 15.5, 17, 18.5, 20, 21.5, 23, 24.5, 26, 27.5, 29, 30.5, 32]); });
+            it("should return matB", function() { expect(result).toBe(matB); });
+            it("should not modify matA", function() { expect(matA).toBeEqualish([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]); });
+        });
+    });
 }
 
 describe("mat4 (SISD)", buildMat4Tests(false));

--- a/src/gl-matrix/mat2.js
+++ b/src/gl-matrix/mat2.js
@@ -374,4 +374,37 @@ mat2.subtract = function(out, a, b) {
 mat2.sub = mat2.subtract;
 
 
+/**
+ * Multiply each element of the matrix by a scalar.
+ *
+ * @param {mat2} out the receiving matrix
+ * @param {mat2} a the matrix to scale
+ * @param {Number} b amount to scale the matrix's elements by
+ * @returns {mat2} out
+ */
+mat2.multiplyScalar = function(out, a, b) {
+    out[0] = a[0] * b;
+    out[1] = a[1] * b;
+    out[2] = a[2] * b;
+    out[3] = a[3] * b;
+    return out;
+};
+
+/**
+ * Adds two mat2's after multiplying each element of the second operand by a scalar value.
+ *
+ * @param {mat2} out the receiving vector
+ * @param {mat2} a the first operand
+ * @param {mat2} b the second operand
+ * @param {Number} scale the amount to scale b's elements by before adding
+ * @returns {mat2} out
+ */
+mat2.multiplyScalarAndAdd = function(out, a, b, scale) {
+    out[0] = a[0] + (b[0] * scale);
+    out[1] = a[1] + (b[1] * scale);
+    out[2] = a[2] + (b[2] * scale);
+    out[3] = a[3] + (b[3] * scale);
+    return out;
+};
+
 module.exports = mat2;

--- a/src/gl-matrix/mat2d.js
+++ b/src/gl-matrix/mat2d.js
@@ -400,4 +400,41 @@ mat2d.subtract = function(out, a, b) {
  */
 mat2d.sub = mat2d.subtract;
 
+/**
+ * Multiply each element of the matrix by a scalar.
+ *
+ * @param {mat2d} out the receiving matrix
+ * @param {mat2d} a the matrix to scale
+ * @param {Number} b amount to scale the matrix's elements by
+ * @returns {mat2d} out
+ */
+mat2d.multiplyScalar = function(out, a, b) {
+    out[0] = a[0] * b;
+    out[1] = a[1] * b;
+    out[2] = a[2] * b;
+    out[3] = a[3] * b;
+    out[4] = a[4] * b;
+    out[5] = a[5] * b;
+    return out;
+};
+
+/**
+ * Adds two mat2d's after multiplying each element of the second operand by a scalar value.
+ *
+ * @param {mat2d} out the receiving vector
+ * @param {mat2d} a the first operand
+ * @param {mat2d} b the second operand
+ * @param {Number} scale the amount to scale b's elements by before adding
+ * @returns {mat2d} out
+ */
+mat2d.multiplyScalarAndAdd = function(out, a, b, scale) {
+    out[0] = a[0] + (b[0] * scale);
+    out[1] = a[1] + (b[1] * scale);
+    out[2] = a[2] + (b[2] * scale);
+    out[3] = a[3] + (b[3] * scale);
+    out[4] = a[4] + (b[4] * scale);
+    out[5] = a[5] + (b[5] * scale);
+    return out;
+};
+
 module.exports = mat2d;

--- a/src/gl-matrix/mat3.js
+++ b/src/gl-matrix/mat3.js
@@ -665,4 +665,47 @@ mat3.subtract = function(out, a, b) {
  */
 mat3.sub = mat3.subtract;
 
+/**
+ * Multiply each element of the matrix by a scalar.
+ *
+ * @param {mat3} out the receiving matrix
+ * @param {mat3} a the matrix to scale
+ * @param {Number} b amount to scale the matrix's elements by
+ * @returns {mat3} out
+ */
+mat3.multiplyScalar = function(out, a, b) {
+    out[0] = a[0] * b;
+    out[1] = a[1] * b;
+    out[2] = a[2] * b;
+    out[3] = a[3] * b;
+    out[4] = a[4] * b;
+    out[5] = a[5] * b;
+    out[6] = a[6] * b;
+    out[7] = a[7] * b;
+    out[8] = a[8] * b;
+    return out;
+};
+
+/**
+ * Adds two mat3's after multiplying each element of the second operand by a scalar value.
+ *
+ * @param {mat3} out the receiving vector
+ * @param {mat3} a the first operand
+ * @param {mat3} b the second operand
+ * @param {Number} scale the amount to scale b's elements by before adding
+ * @returns {mat3} out
+ */
+mat3.multiplyScalarAndAdd = function(out, a, b, scale) {
+    out[0] = a[0] + (b[0] * scale);
+    out[1] = a[1] + (b[1] * scale);
+    out[2] = a[2] + (b[2] * scale);
+    out[3] = a[3] + (b[3] * scale);
+    out[4] = a[4] + (b[4] * scale);
+    out[5] = a[5] + (b[5] * scale);
+    out[6] = a[6] + (b[6] * scale);
+    out[7] = a[7] + (b[7] * scale);
+    out[8] = a[8] + (b[8] * scale);
+    return out;
+};
+
 module.exports = mat3;

--- a/src/gl-matrix/mat4.js
+++ b/src/gl-matrix/mat4.js
@@ -1964,5 +1964,62 @@ mat4.subtract = function(out, a, b) {
  */
 mat4.sub = mat4.subtract;
 
+/**
+ * Multiply each element of the matrix by a scalar.
+ *
+ * @param {mat4} out the receiving matrix
+ * @param {mat4} a the matrix to scale
+ * @param {Number} b amount to scale the matrix's elements by
+ * @returns {mat4} out
+ */
+mat4.multiplyScalar = function(out, a, b) {
+    out[0] = a[0] * b;
+    out[1] = a[1] * b;
+    out[2] = a[2] * b;
+    out[3] = a[3] * b;
+    out[4] = a[4] * b;
+    out[5] = a[5] * b;
+    out[6] = a[6] * b;
+    out[7] = a[7] * b;
+    out[8] = a[8] * b;
+    out[9] = a[9] * b;
+    out[10] = a[10] * b;
+    out[11] = a[11] * b;
+    out[12] = a[12] * b;
+    out[13] = a[13] * b;
+    out[14] = a[14] * b;
+    out[15] = a[15] * b;
+    return out;
+};
+
+/**
+ * Adds two mat4's after multiplying each element of the second operand by a scalar value.
+ *
+ * @param {mat4} out the receiving vector
+ * @param {mat4} a the first operand
+ * @param {mat4} b the second operand
+ * @param {Number} scale the amount to scale b's elements by before adding
+ * @returns {mat4} out
+ */
+mat4.multiplyScalarAndAdd = function(out, a, b, scale) {
+    out[0] = a[0] + (b[0] * scale);
+    out[1] = a[1] + (b[1] * scale);
+    out[2] = a[2] + (b[2] * scale);
+    out[3] = a[3] + (b[3] * scale);
+    out[4] = a[4] + (b[4] * scale);
+    out[5] = a[5] + (b[5] * scale);
+    out[6] = a[6] + (b[6] * scale);
+    out[7] = a[7] + (b[7] * scale);
+    out[8] = a[8] + (b[8] * scale);
+    out[9] = a[9] + (b[9] * scale);
+    out[10] = a[10] + (b[10] * scale);
+    out[11] = a[11] + (b[11] * scale);
+    out[12] = a[12] + (b[12] * scale);
+    out[13] = a[13] + (b[13] * scale);
+    out[14] = a[14] + (b[14] * scale);
+    out[15] = a[15] + (b[15] * scale);
+    return out;
+};
+
 
 module.exports = mat4;


### PR DESCRIPTION
Basically the matrix versions of `vec{N}.scale` and `vec{N}.scaleAndAdd` respectively. The name difference is due to the fact that `mat{N}.scale` is already taken.