### PR TITLE
Include src folder in bower package

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -11,7 +11,6 @@
     "**/.*",
     "jsdoc-template",
     "spec",
-    "src",
     "tasks",
     "Gemfile",
     "Gemfile.lock",


### PR DESCRIPTION
Hey, great library.
It would be nice if you would include the src folder in the bower package, that way I can load (and bundle) the modules I need directly in my application.