### PR TITLE
Add decomposition methods to mat4 and quat

### DIFF
--- a/spec/gl-matrix/mat4-spec.js
+++ b/spec/gl-matrix/mat4-spec.js
@@ -594,7 +594,7 @@ function buildMat4Tests(useSIMD) {
                     result = quat.fromValues(2, 3, 4, 6);
                     mat4.getRotation(result, out);
                     var outaxis = vec3.create();
-                    var outangle = quat.getAxisAngle(result, outaxis);
+                    var outangle = quat.getAxisAngle(outaxis, result);
 
                     expect(outaxis).toBeEqualish(testVec);
                     expect(outangle).toBeEqualish(ang);

--- a/spec/gl-matrix/mat4-spec.js
+++ b/spec/gl-matrix/mat4-spec.js
@@ -514,6 +514,42 @@ function buildMat4Tests(useSIMD) {
         });
 
         // TODO: fromRotationTranslation
+        
+        describe("getTranslation", function() {
+            describe("from the identity matrix", function() {
+                beforeEach(function() {
+                    result = vec3.fromValues(1, 2, 3);
+                    out = vec3.fromValues(1, 2, 3);
+                    result = mat4.getTranslation(out, identity);
+                });
+                it("should place result both in result and out", function() { expect(result).toBe(out); });
+                it("should return the zero vector", function() { expect(result).toBeEqualish([0, 0, 0]); });
+            });
+
+            describe("from a translation-only matrix", function() {
+                beforeEach(function() {
+                    result = vec3.fromValues(1, 2, 3);
+                    out = vec3.fromValues(1, 2, 3);
+                    result = mat4.getTranslation(out, matB);
+                });
+                it("should return translation vector", function() { expect(out).toBeEqualish([4, 5, 6]); });
+            });
+
+            describe("from a translation and rotation matrix", function() {
+                beforeEach(function() {
+                    var q = quat.create();
+                    var v = vec3.fromValues(5, 6, 7);
+                    q = quat.setAxisAngle(q, [0.26726124, 0.534522474, 0.8017837], 0.55);
+                    mat4.fromRotationTranslation(out, q, v);
+
+                    result = vec3.create();
+                    mat4.getTranslation(result, out);
+                });
+                it("should keep the same translation matrix, regardless of rotation", function() {
+                    expect(result).toBeEqualish([5, 6, 7]);
+                });
+            });
+        });
 
         describe("frustum", function() {
             beforeEach(function() { result = mat4.frustum(out, -1, 1, -1, 1, -1, 1); });

--- a/spec/gl-matrix/mat4-spec.js
+++ b/spec/gl-matrix/mat4-spec.js
@@ -21,6 +21,7 @@ THE SOFTWARE. */
 var glMatrix = require("../../src/gl-matrix/common.js");
 var mat4 = require("../../src/gl-matrix/mat4.js");
 var vec3 = require("../../src/gl-matrix/vec3.js");
+var quat = require("../../src/gl-matrix/quat.js");
 
 // Inject the polyfill for testing
 if (!glMatrix.SIMD_AVAILABLE) {
@@ -545,8 +546,58 @@ function buildMat4Tests(useSIMD) {
                     result = vec3.create();
                     mat4.getTranslation(result, out);
                 });
-                it("should keep the same translation matrix, regardless of rotation", function() {
+                it("should keep the same translation vector, regardless of rotation", function() {
                     expect(result).toBeEqualish([5, 6, 7]);
+                });
+            });
+        });
+
+        describe("getRotation", function() {
+            describe("from the identity matrix", function() {
+                beforeEach(function() {
+                    result = quat.fromValues(1, 2, 3, 4);
+                    out = quat.fromValues(1, 2, 3, 4);
+                    result = mat4.getRotation(out, identity);
+                });
+                it("should place result both in result and out", function() { expect(result).toBe(out); });
+                it("should return the unit quaternion", function() {
+                    var unitQuat = quat.create();
+                    quat.identity(unitQuat);
+                    expect(result).toBeEqualish(unitQuat);
+                });
+            });
+
+            describe("from a translation-only matrix", function() {
+                beforeEach(function() {
+                    result = quat.fromValues(1, 2, 3, 4);
+                    out = quat.fromValues(1, 2, 3, 4);
+                    result = mat4.getRotation(out, matB);
+                });
+                it("should return the unit quaternion", function() {
+                    var unitQuat = quat.create();
+                    quat.identity(unitQuat);
+                    expect(result).toBeEqualish(unitQuat);
+                });
+            });
+
+            describe("from a translation and rotation matrix", function() {
+                it("should keep the same rotation as when created", function() {
+                    var q = quat.create();
+                    var outVec = vec3.fromValues(5, 6, 7);
+                    var testVec = vec3.fromValues(1, 5, 2);
+                    var ang = 0.78972;
+
+                    vec3.normalize(testVec, testVec);
+                    q = quat.setAxisAngle(q, testVec, ang);
+                    mat4.fromRotationTranslation(out, q, outVec);
+
+                    result = quat.fromValues(2, 3, 4, 6);
+                    mat4.getRotation(result, out);
+                    var outaxis = vec3.create();
+                    var outangle = quat.getAxisAngle(result, outaxis);
+
+                    expect(outaxis).toBeEqualish(testVec);
+                    expect(outangle).toBeEqualish(ang);
                 });
             });
         });

--- a/spec/gl-matrix/quat-spec.js
+++ b/spec/gl-matrix/quat-spec.js
@@ -352,6 +352,47 @@ describe("quat", function() {
         it("should place values into out", function() { expect(result).toBeEqualish([0.707106, 0, 0, 0.707106]); });
         it("should return out", function() { expect(result).toBe(out); });
     });
+
+    describe("getAxisAngle", function() {
+        describe("for a quaternion representing no rotation", function() {
+            beforeEach(function() { result = quat.setAxisAngle(out, [0, 1, 0], 0.0); deg90 = quat.getAxisAngle(out, vec); });
+            it("should return a multiple of 2*PI as the angle component", function() { expect(deg90 % (Math.PI * 2.0)).toBeEqualish(0.0); });
+        });
+
+        describe("for a simple rotation about X axis", function() {
+            beforeEach(function() { result = quat.setAxisAngle(out, [1, 0, 0], 0.7778); deg90 = quat.getAxisAngle(out, vec); });
+            it("should return the same provided angle", function() { expect(deg90).toBeEqualish(0.7778); });
+            it("should return the X axis as the angle", function() { expect(vec).toBeEqualish([1, 0, 0]); });
+        });
+
+        describe("for a simple rotation about Y axis", function() {
+            beforeEach(function() { result = quat.setAxisAngle(out, [0, 1, 0], 0.879546); deg90 = quat.getAxisAngle(out, vec); });
+            it("should return the same provided angle", function() { expect(deg90).toBeEqualish(0.879546); });
+            it("should return the X axis as the angle", function() { expect(vec).toBeEqualish([0, 1, 0]); });
+        });
+
+        describe("for a simple rotation about Z axis", function() {
+            beforeEach(function() { result = quat.setAxisAngle(out, [0, 0, 1], 0.123456); deg90 = quat.getAxisAngle(out, vec); });
+            it("should return the same provided angle", function() { expect(deg90).toBeEqualish(0.123456); });
+            it("should return the X axis as the angle", function() { expect(vec).toBeEqualish([0, 0, 1]); });
+        });
+
+        describe("for a slightly irregular axis and right angle", function() {
+            beforeEach(function() { result = quat.setAxisAngle(out, [0.707106, 0, 0.707106], Math.PI * 0.5); deg90 = quat.getAxisAngle(out, vec); });
+            it("should place values into vec", function() { expect(vec).toBeEqualish([0.707106, 0, 0.707106]); });
+            it("should return a numeric angle", function() { expect(deg90).toBeEqualish(Math.PI * 0.5); });
+        });
+
+        describe("for a very irregular axis and negative input angle", function() {
+            beforeEach(function() {
+                quatA = quat.setAxisAngle(quatA, [0.65538555, 0.49153915, 0.57346237], 8.8888);
+                deg90 = quat.getAxisAngle(quatA, vec);
+                quatB = quat.setAxisAngle(quatB, vec, deg90);
+            });
+            it("should return an angle between 0 and 2*PI", function() { expect(deg90).toBeGreaterThan(0.0); expect(deg90).toBeLessThan(Math.PI * 2.0); });
+            it("should create the same quaternion from axis and angle extracted", function() { expect(quatA).toBeEqualish(quatB); });
+        });
+    });
     
     describe("add", function() {
         describe("with a separate output quaternion", function() {

--- a/spec/gl-matrix/quat-spec.js
+++ b/spec/gl-matrix/quat-spec.js
@@ -355,30 +355,30 @@ describe("quat", function() {
 
     describe("getAxisAngle", function() {
         describe("for a quaternion representing no rotation", function() {
-            beforeEach(function() { result = quat.setAxisAngle(out, [0, 1, 0], 0.0); deg90 = quat.getAxisAngle(out, vec); });
+            beforeEach(function() { result = quat.setAxisAngle(out, [0, 1, 0], 0.0); deg90 = quat.getAxisAngle(vec, out); });
             it("should return a multiple of 2*PI as the angle component", function() { expect(deg90 % (Math.PI * 2.0)).toBeEqualish(0.0); });
         });
 
         describe("for a simple rotation about X axis", function() {
-            beforeEach(function() { result = quat.setAxisAngle(out, [1, 0, 0], 0.7778); deg90 = quat.getAxisAngle(out, vec); });
+            beforeEach(function() { result = quat.setAxisAngle(out, [1, 0, 0], 0.7778); deg90 = quat.getAxisAngle(vec, out); });
             it("should return the same provided angle", function() { expect(deg90).toBeEqualish(0.7778); });
             it("should return the X axis as the angle", function() { expect(vec).toBeEqualish([1, 0, 0]); });
         });
 
         describe("for a simple rotation about Y axis", function() {
-            beforeEach(function() { result = quat.setAxisAngle(out, [0, 1, 0], 0.879546); deg90 = quat.getAxisAngle(out, vec); });
+            beforeEach(function() { result = quat.setAxisAngle(out, [0, 1, 0], 0.879546); deg90 = quat.getAxisAngle(vec, out); });
             it("should return the same provided angle", function() { expect(deg90).toBeEqualish(0.879546); });
             it("should return the X axis as the angle", function() { expect(vec).toBeEqualish([0, 1, 0]); });
         });
 
         describe("for a simple rotation about Z axis", function() {
-            beforeEach(function() { result = quat.setAxisAngle(out, [0, 0, 1], 0.123456); deg90 = quat.getAxisAngle(out, vec); });
+            beforeEach(function() { result = quat.setAxisAngle(out, [0, 0, 1], 0.123456); deg90 = quat.getAxisAngle(vec, out); });
             it("should return the same provided angle", function() { expect(deg90).toBeEqualish(0.123456); });
             it("should return the X axis as the angle", function() { expect(vec).toBeEqualish([0, 0, 1]); });
         });
 
         describe("for a slightly irregular axis and right angle", function() {
-            beforeEach(function() { result = quat.setAxisAngle(out, [0.707106, 0, 0.707106], Math.PI * 0.5); deg90 = quat.getAxisAngle(out, vec); });
+            beforeEach(function() { result = quat.setAxisAngle(out, [0.707106, 0, 0.707106], Math.PI * 0.5); deg90 = quat.getAxisAngle(vec, out); });
             it("should place values into vec", function() { expect(vec).toBeEqualish([0.707106, 0, 0.707106]); });
             it("should return a numeric angle", function() { expect(deg90).toBeEqualish(Math.PI * 0.5); });
         });
@@ -386,7 +386,7 @@ describe("quat", function() {
         describe("for a very irregular axis and negative input angle", function() {
             beforeEach(function() {
                 quatA = quat.setAxisAngle(quatA, [0.65538555, 0.49153915, 0.57346237], 8.8888);
-                deg90 = quat.getAxisAngle(quatA, vec);
+                deg90 = quat.getAxisAngle(vec, quatA);
                 quatB = quat.setAxisAngle(quatB, vec, deg90);
             });
             it("should return an angle between 0 and 2*PI", function() { expect(deg90).toBeGreaterThan(0.0); expect(deg90).toBeLessThan(Math.PI * 2.0); });

--- a/src/gl-matrix/mat4.js
+++ b/src/gl-matrix/mat4.js
@@ -1501,6 +1501,49 @@ mat4.getTranslation = function (out, mat) {
 };
 
 /**
+ * Returns a quaternion representing the rotational component
+ *  of a transformation matrix. If a matrix is built with
+ *  fromRotationTranslation, the returned quaternion will be the
+ *  same as the quaternion originally supplied.
+ * @param {quat} out Quaternion to receive the rotation component
+ * @param {mat4} mat Matrix to be decomposed (input)
+ * @return {quat} out
+ */
+mat4.getRotation = function (out, mat) {
+  // Algorithm taken from http://www.euclideanspace.com/maths/geometry/rotations/conversions/matrixToQuaternion/index.htm
+  var trace = mat[0] + mat[5] + mat[10];
+  var S = 0;
+
+  if (trace > 0) { 
+    S = Math.sqrt(trace + 1.0) * 2;
+    out[3] = 0.25 * S;
+    out[0] = (mat[6] - mat[9]) / S;
+    out[1] = (mat[8] - mat[2]) / S; 
+    out[2] = (mat[1] - mat[4]) / S; 
+  } else if ((mat[0] > mat[5])&(mat[0] > mat[10])) { 
+    S = Math.sqrt(1.0 + mat[0] - mat[5] - mat[10]) * 2;
+    out[3] = (mat[6] - mat[9]) / S;
+    out[0] = 0.25 * S;
+    out[1] = (mat[1] + mat[4]) / S; 
+    out[2] = (mat[8] + mat[2]) / S; 
+  } else if (mat[5] > mat[10]) { 
+    S = Math.sqrt(1.0 + mat[5] - mat[0] - mat[10]) * 2;
+    out[3] = (mat[8] - mat[2]) / S;
+    out[0] = (mat[1] + mat[4]) / S; 
+    out[1] = 0.25 * S;
+    out[2] = (mat[6] + mat[9]) / S; 
+  } else { 
+    S = Math.sqrt(1.0 + mat[10] - mat[0] - mat[5]) * 2;
+    out[3] = (mat[1] - mat[4]) / S;
+    out[0] = (mat[8] + mat[2]) / S;
+    out[1] = (mat[6] + mat[9]) / S;
+    out[2] = 0.25 * S;
+  }
+
+  return out;
+};
+
+/**
  * Creates a matrix from a quaternion rotation, vector translation and vector scale
  * This is equivalent to (but much faster than):
  *

--- a/src/gl-matrix/mat4.js
+++ b/src/gl-matrix/mat4.js
@@ -1484,6 +1484,23 @@ mat4.fromRotationTranslation = function (out, q, v) {
 };
 
 /**
+ * Returns the translation vector component of a transformation
+ *  matrix. If a matrix is built with fromRotationTranslation,
+ *  the returned vector will be the same as the translation vector
+ *  originally supplied.
+ * @param  {vec3} out Vector to receive translation component
+ * @param  {mat4} mat Matrix to be decomposed (input)
+ * @return {vec3} out
+ */
+mat4.getTranslation = function (out, mat) {
+  out[0] = mat[12];
+  out[1] = mat[13];
+  out[2] = mat[14];
+
+  return out;
+};
+
+/**
  * Creates a matrix from a quaternion rotation, vector translation and vector scale
  * This is equivalent to (but much faster than):
  *

--- a/src/gl-matrix/quat.js
+++ b/src/gl-matrix/quat.js
@@ -193,6 +193,35 @@ quat.setAxisAngle = function(out, axis, rad) {
 };
 
 /**
+ * Gets the rotation axis and angle for a given
+ *  quaternion. If a quaternion is created with
+ *  setAxisAngle, this method will return the same
+ *  values as providied in the original parameter list
+ *  OR functionally equivalent values.
+ * Example: The quaternion formed by axis [0, 0, 1] and
+ *  angle -90 is the same as the quaternion formed by
+ *  [0, 0, 1] and 270. This method favors the latter.
+ * @param  {quat} q     Quaternion to be decomposed
+ * @param  {vec3} axis  Vector receiving the axis of rotation
+ * @return {Number}     Angle, in radians, of the rotation
+ */
+quat.getAxisAngle = function(q, axis) {
+    var rad = Math.acos(q[3]) * 2.0;
+    var s = Math.sin(rad / 2.0);
+    if (s != 0.0) {
+        axis[0] = q[0] / s;
+        axis[1] = q[1] / s;
+        axis[2] = q[2] / s;
+    } else {
+        // If s is zero, return any axis (no rotation - axis does not matter)
+        axis[0] = 1;
+        axis[1] = 0;
+        axis[2] = 0;
+    }
+    return rad;
+};
+
+/**
  * Adds two quat's
  *
  * @param {quat} out the receiving quaternion

--- a/src/gl-matrix/quat.js
+++ b/src/gl-matrix/quat.js
@@ -201,22 +201,22 @@ quat.setAxisAngle = function(out, axis, rad) {
  * Example: The quaternion formed by axis [0, 0, 1] and
  *  angle -90 is the same as the quaternion formed by
  *  [0, 0, 1] and 270. This method favors the latter.
+ * @param  {vec3} out_axis  Vector receiving the axis of rotation
  * @param  {quat} q     Quaternion to be decomposed
- * @param  {vec3} axis  Vector receiving the axis of rotation
  * @return {Number}     Angle, in radians, of the rotation
  */
-quat.getAxisAngle = function(q, axis) {
+quat.getAxisAngle = function(out_axis, q) {
     var rad = Math.acos(q[3]) * 2.0;
     var s = Math.sin(rad / 2.0);
     if (s != 0.0) {
-        axis[0] = q[0] / s;
-        axis[1] = q[1] / s;
-        axis[2] = q[2] / s;
+        out_axis[0] = q[0] / s;
+        out_axis[1] = q[1] / s;
+        out_axis[2] = q[2] / s;
     } else {
         // If s is zero, return any axis (no rotation - axis does not matter)
-        axis[0] = 1;
-        axis[1] = 0;
-        axis[2] = 0;
+        out_axis[0] = 1;
+        out_axis[1] = 0;
+        out_axis[2] = 0;
     }
     return rad;
 };


### PR DESCRIPTION
**OVERVIEW**

I added methods for extracting useful information from mat4 and quat objects. This addresses issue https://github.com/toji/gl-matrix/issues/136 (which is also an issue I faced using gl-matrix in my own work).

For mat4, I added a mat4.getTranslation and mat4.getRotation method. They return the vec3 translation and quat rotation stored in a transformation matrix, respectively.

For quat, I added a quat.getAxisAngle method. This returns the unit vector axis and angle (radians) rotation stored by the input quaternion.

**MATHEMATICAL CONSIDERATIONS**

A single axis/angle rotation may be stored by at least two different quaternions. If an axis of rotation is [a, b, c] and the angle of rotation d, the same rotation may be described by an axis of rotation [-a, -b, -c] and an angle 2*PI - 2. The axis and angle returned by quat.getAxisAngle are not guaranteed to be the same that were provided to a quat.setAxisAngle call, but they are guaranteed to represent the same rotation.

A quaternion storing no rotation will always return the axis [1, 0, 0] and angle 0, arbitrarily - the axis itself is not important in this case.

Decomposing a quaternion into its axis and angle components has a potential to yield floating point error. This also applies to decomposing a transformation matrix into its rotational component. Any who use this method should be aware of this limitation. During testing with random values, I came across several cases which were off a relatively large degree of error for 64 bit floating point values after repeated composing and decomposing.

**POTENTIAL ISSUES**

I'm not extremely familiar with this project, so these are things I was unsure about. If you prefer a different style, let me know and I can make the appropriate changes.

quat.getAxisAngle cannot mutate a passed in Number parameter by reference. Currently, I have the method returning the angle and mutating the axis array passed in the parameter list. Of several less than ideal alternatives, I thought this the most elegant, but it doesn't fit the style of the rest of the code.

Unit tests for mat4.getRotation use more newlines than many other unit tests in the file. This was done for clarity, though if brevity is preferred I can easily make those changes.

**EXTERNAL SOURCES USED**
Extract rotation quaternion from 3x3 matrix: http://www.euclideanspace.com/maths/geometry/rotations/conversions/matrixToQuaternion/index.htm