### PR TITLE
Implement vec{2,3,4}.{ceil,floor,round}

### DIFF
--- a/spec/gl-matrix/vec2-spec.js
+++ b/spec/gl-matrix/vec2-spec.js
@@ -165,6 +165,44 @@ describe("vec2", function() {
             it("should not modify vecA", function() { expect(vecA).toBeEqualish([1, 2]); });
         });
     });
+    
+    describe("ceil", function() {
+        beforeEach(function() { vecA = [Math.E, Math.PI]; });
+        
+        describe("with a separate output vector", function() {
+            beforeEach(function() { result = vec2.ceil(out, vecA); });
+            
+            it("should place values into out", function() { expect(out).toBeEqualish([3, 4]); });
+            it("should return out", function() { expect(result).toBe(out); });
+            it("should not modify vecA", function() { expect(vecA).toBeEqualish([Math.E, Math.PI]); });
+        });
+        
+        describe("when vecA is the output vector", function() {
+            beforeEach(function() { result = vec2.ceil(vecA, vecA); });
+            
+            it("should place values into vecA", function() { expect(vecA).toBeEqualish([3, 4]); });
+            it("should return vecA", function() { expect(result).toBe(vecA); });
+        });
+    });
+    
+    describe("floor", function() {
+        beforeEach(function() { vecA = [Math.E, Math.PI]; });
+        
+        describe("with a separate output vector", function() {
+            beforeEach(function() { result = vec2.floor(out, vecA); });
+            
+            it("should place values into out", function() { expect(out).toBeEqualish([2, 3]); });
+            it("should return out", function() { expect(result).toBe(out); });
+            it("should not modify vecA", function() { expect(vecA).toBeEqualish([Math.E, Math.PI]); });
+        });
+        
+        describe("when vecA is the output vector", function() {
+            beforeEach(function() { result = vec2.floor(vecA, vecA); });
+            
+            it("should place values into vecA", function() { expect(vecA).toBeEqualish([2, 3]); });
+            it("should return vecA", function() { expect(result).toBe(vecA); });
+        });
+    });
 
     describe("min", function() {
         beforeEach(function() { vecA = [1, 4]; vecB = [3, 2]; });
@@ -221,6 +259,25 @@ describe("vec2", function() {
             it("should place values into vecB", function() { expect(vecB).toBeEqualish([3, 4]); });
             it("should return vecB", function() { expect(result).toBe(vecB); });
             it("should not modify vecA", function() { expect(vecA).toBeEqualish([1, 4]); });
+        });
+    });
+    
+    describe("round", function() {
+        beforeEach(function() { vecA = [Math.E, Math.PI]; });
+        
+        describe("with a separate output vector", function() {
+            beforeEach(function() { result = vec2.round(out, vecA); });
+            
+            it("should place values into out", function() { expect(out).toBeEqualish([3, 3]); });
+            it("should return out", function() { expect(result).toBe(out); });
+            it("should not modify vecA", function() { expect(vecA).toBeEqualish([Math.E, Math.PI]); });
+        });
+        
+        describe("when vecA is the output vector", function() {
+            beforeEach(function() { result = vec2.round(vecA, vecA); });
+            
+            it("should place values into vecA", function() { expect(vecA).toBeEqualish([3, 3]); });
+            it("should return vecA", function() { expect(result).toBe(vecA); });
         });
     });
 

--- a/spec/gl-matrix/vec3-spec.js
+++ b/spec/gl-matrix/vec3-spec.js
@@ -300,6 +300,44 @@ describe("vec3", function() {
             it("should not modify vecA", function() { expect(vecA).toBeEqualish([1, 2, 3]); });
         });
     });
+    
+    describe("ceil", function() {
+        beforeEach(function() { vecA = [Math.E, Math.PI, Math.SQRT2]; });
+        
+        describe("with a separate output vector", function() {
+            beforeEach(function() { result = vec3.ceil(out, vecA); });
+            
+            it("should place values into out", function() { expect(out).toBeEqualish([3, 4, 2]); });
+            it("should return out", function() { expect(result).toBe(out); });
+            it("should not modify vecA", function() { expect(vecA).toBeEqualish([Math.E, Math.PI, Math.SQRT2]); });
+        });
+        
+        describe("when vecA is the output vector", function() {
+            beforeEach(function() { result = vec3.ceil(vecA, vecA); });
+            
+            it("should place values into vecA", function() { expect(vecA).toBeEqualish([3, 4, 2]); });
+            it("should return vecA", function() { expect(result).toBe(vecA); });
+        });
+    });
+    
+    describe("floor", function() {
+        beforeEach(function() { vecA = [Math.E, Math.PI, Math.SQRT2]; });
+        
+        describe("with a separate output vector", function() {
+            beforeEach(function() { result = vec3.floor(out, vecA); });
+            
+            it("should place values into out", function() { expect(out).toBeEqualish([2, 3, 1]); });
+            it("should return out", function() { expect(result).toBe(out); });
+            it("should not modify vecA", function() { expect(vecA).toBeEqualish([Math.E, Math.PI, Math.SQRT2]); });
+        });
+        
+        describe("when vecA is the output vector", function() {
+            beforeEach(function() { result = vec3.floor(vecA, vecA); });
+            
+            it("should place values into vecA", function() { expect(vecA).toBeEqualish([2, 3, 1]); });
+            it("should return vecA", function() { expect(result).toBe(vecA); });
+        });
+    });
 
     describe("min", function() {
         beforeEach(function() { vecA = [1, 3, 1]; vecB = [3, 1, 3]; });
@@ -356,6 +394,25 @@ describe("vec3", function() {
             it("should place values into vecB", function() { expect(vecB).toBeEqualish([3, 3, 3]); });
             it("should return vecB", function() { expect(result).toBe(vecB); });
             it("should not modify vecA", function() { expect(vecA).toBeEqualish([1, 3, 1]); });
+        });
+    });
+    
+    describe("round", function() {
+        beforeEach(function() { vecA = [Math.E, Math.PI, Math.SQRT2]; });
+        
+        describe("with a separate output vector", function() {
+            beforeEach(function() { result = vec3.round(out, vecA); });
+            
+            it("should place values into out", function() { expect(out).toBeEqualish([3, 3, 1]); });
+            it("should return out", function() { expect(result).toBe(out); });
+            it("should not modify vecA", function() { expect(vecA).toBeEqualish([Math.E, Math.PI, Math.SQRT2]); });
+        });
+        
+        describe("when vecA is the output vector", function() {
+            beforeEach(function() { result = vec3.round(vecA, vecA); });
+            
+            it("should place values into vecA", function() { expect(vecA).toBeEqualish([3, 3, 1]); });
+            it("should return vecA", function() { expect(result).toBe(vecA); });
         });
     });
 

--- a/spec/gl-matrix/vec4-spec.js
+++ b/spec/gl-matrix/vec4-spec.js
@@ -166,6 +166,44 @@ describe("vec4", function() {
             it("should not modify vecA", function() { expect(vecA).toBeEqualish([1, 2, 3, 4]); });
         });
     });
+    
+    describe("ceil", function() {
+        beforeEach(function() { vecA = [Math.E, Math.PI, Math.SQRT2, Math.SQRT1_2]; });
+        
+        describe("with a separate output vector", function() {
+            beforeEach(function() { result = vec4.ceil(out, vecA); });
+            
+            it("should place values into out", function() { expect(out).toBeEqualish([3, 4, 2, 1]); });
+            it("should return out", function() { expect(result).toBe(out); });
+            it("should not modify vecA", function() { expect(vecA).toBeEqualish([Math.E, Math.PI, Math.SQRT2, Math.SQRT1_2]); });
+        });
+        
+        describe("when vecA is the output vector", function() {
+            beforeEach(function() { result = vec4.ceil(vecA, vecA); });
+            
+            it("should place values into vecA", function() { expect(vecA).toBeEqualish([3, 4, 2, 1]); });
+            it("should return vecA", function() { expect(result).toBe(vecA); });
+        });
+    });
+    
+    describe("floor", function() {
+        beforeEach(function() { vecA = [Math.E, Math.PI, Math.SQRT2, Math.SQRT1_2]; });
+        
+        describe("with a separate output vector", function() {
+            beforeEach(function() { result = vec4.floor(out, vecA); });
+            
+            it("should place values into out", function() { expect(out).toBeEqualish([2, 3, 1, 0]); });
+            it("should return out", function() { expect(result).toBe(out); });
+            it("should not modify vecA", function() { expect(vecA).toBeEqualish([Math.E, Math.PI, Math.SQRT2, Math.SQRT1_2]); });
+        });
+        
+        describe("when vecA is the output vector", function() {
+            beforeEach(function() { result = vec4.floor(vecA, vecA); });
+            
+            it("should place values into vecA", function() { expect(vecA).toBeEqualish([2, 3, 1, 0]); });
+            it("should return vecA", function() { expect(result).toBe(vecA); });
+        });
+    });
 
     describe("min", function() {
         beforeEach(function() { vecA = [1, 3, 1, 3]; vecB = [3, 1, 3, 1]; });
@@ -222,6 +260,25 @@ describe("vec4", function() {
             it("should place values into vecB", function() { expect(vecB).toBeEqualish([3, 3, 3, 3]); });
             it("should return vecB", function() { expect(result).toBe(vecB); });
             it("should not modify vecA", function() { expect(vecA).toBeEqualish([1, 3, 1, 3]); });
+        });
+    });
+    
+    describe("round", function() {
+        beforeEach(function() { vecA = [Math.E, Math.PI, Math.SQRT2, Math.SQRT1_2]; });
+        
+        describe("with a separate output vector", function() {
+            beforeEach(function() { result = vec4.round(out, vecA); });
+            
+            it("should place values into out", function() { expect(out).toBeEqualish([3, 3, 1, 1]); });
+            it("should return out", function() { expect(result).toBe(out); });
+            it("should not modify vecA", function() { expect(vecA).toBeEqualish([Math.E, Math.PI, Math.SQRT2, Math.SQRT1_2]); });
+        });
+        
+        describe("when vecA is the output vector", function() {
+            beforeEach(function() { result = vec4.round(vecA, vecA); });
+            
+            it("should place values into vecA", function() { expect(vecA).toBeEqualish([3, 3, 1, 1]); });
+            it("should return vecA", function() { expect(result).toBe(vecA); });
         });
     });
 

--- a/src/gl-matrix/vec2.js
+++ b/src/gl-matrix/vec2.js
@@ -167,6 +167,32 @@ vec2.divide = function(out, a, b) {
 vec2.div = vec2.divide;
 
 /**
+ * Math.ceil the components of a vec2
+ *
+ * @param {vec2} out the receiving vector
+ * @param {vec2} a vector to ceil
+ * @returns {vec2} out
+ */
+vec2.ceil = function (out, a) {
+    out[0] = Math.ceil(a[0]);
+    out[1] = Math.ceil(a[1]);
+    return out;
+};
+
+/**
+ * Math.floor the components of a vec2
+ *
+ * @param {vec2} out the receiving vector
+ * @param {vec2} a vector to floor
+ * @returns {vec2} out
+ */
+vec2.floor = function (out, a) {
+    out[0] = Math.floor(a[0]);
+    out[1] = Math.floor(a[1]);
+    return out;
+};
+
+/**
  * Returns the minimum of two vec2's
  *
  * @param {vec2} out the receiving vector
@@ -191,6 +217,19 @@ vec2.min = function(out, a, b) {
 vec2.max = function(out, a, b) {
     out[0] = Math.max(a[0], b[0]);
     out[1] = Math.max(a[1], b[1]);
+    return out;
+};
+
+/**
+ * Math.round the components of a vec2
+ *
+ * @param {vec2} out the receiving vector
+ * @param {vec2} a vector to round
+ * @returns {vec2} out
+ */
+vec2.round = function (out, a) {
+    out[0] = Math.round(a[0]);
+    out[1] = Math.round(a[1]);
     return out;
 };
 

--- a/src/gl-matrix/vec3.js
+++ b/src/gl-matrix/vec3.js
@@ -178,6 +178,34 @@ vec3.divide = function(out, a, b) {
 vec3.div = vec3.divide;
 
 /**
+ * Math.ceil the components of a vec3
+ *
+ * @param {vec3} out the receiving vector
+ * @param {vec3} a vector to ceil
+ * @returns {vec3} out
+ */
+vec3.ceil = function (out, a) {
+    out[0] = Math.ceil(a[0]);
+    out[1] = Math.ceil(a[1]);
+    out[2] = Math.ceil(a[2]);
+    return out;
+};
+
+/**
+ * Math.floor the components of a vec3
+ *
+ * @param {vec3} out the receiving vector
+ * @param {vec3} a vector to floor
+ * @returns {vec3} out
+ */
+vec3.floor = function (out, a) {
+    out[0] = Math.floor(a[0]);
+    out[1] = Math.floor(a[1]);
+    out[2] = Math.floor(a[2]);
+    return out;
+};
+
+/**
  * Returns the minimum of two vec3's
  *
  * @param {vec3} out the receiving vector
@@ -204,6 +232,20 @@ vec3.max = function(out, a, b) {
     out[0] = Math.max(a[0], b[0]);
     out[1] = Math.max(a[1], b[1]);
     out[2] = Math.max(a[2], b[2]);
+    return out;
+};
+
+/**
+ * Math.round the components of a vec3
+ *
+ * @param {vec3} out the receiving vector
+ * @param {vec3} a vector to round
+ * @returns {vec3} out
+ */
+vec3.round = function (out, a) {
+    out[0] = Math.round(a[0]);
+    out[1] = Math.round(a[1]);
+    out[2] = Math.round(a[2]);
     return out;
 };
 

--- a/src/gl-matrix/vec4.js
+++ b/src/gl-matrix/vec4.js
@@ -189,6 +189,36 @@ vec4.divide = function(out, a, b) {
 vec4.div = vec4.divide;
 
 /**
+ * Math.ceil the components of a vec4
+ *
+ * @param {vec4} out the receiving vector
+ * @param {vec4} a vector to ceil
+ * @returns {vec4} out
+ */
+vec4.ceil = function (out, a) {
+    out[0] = Math.ceil(a[0]);
+    out[1] = Math.ceil(a[1]);
+    out[2] = Math.ceil(a[2]);
+    out[3] = Math.ceil(a[3]);
+    return out;
+};
+
+/**
+ * Math.floor the components of a vec4
+ *
+ * @param {vec4} out the receiving vector
+ * @param {vec4} a vector to floor
+ * @returns {vec4} out
+ */
+vec4.floor = function (out, a) {
+    out[0] = Math.floor(a[0]);
+    out[1] = Math.floor(a[1]);
+    out[2] = Math.floor(a[2]);
+    out[3] = Math.floor(a[3]);
+    return out;
+};
+
+/**
  * Returns the minimum of two vec4's
  *
  * @param {vec4} out the receiving vector
@@ -217,6 +247,21 @@ vec4.max = function(out, a, b) {
     out[1] = Math.max(a[1], b[1]);
     out[2] = Math.max(a[2], b[2]);
     out[3] = Math.max(a[3], b[3]);
+    return out;
+};
+
+/**
+ * Math.round the components of a vec4
+ *
+ * @param {vec4} out the receiving vector
+ * @param {vec4} a vector to round
+ * @returns {vec4} out
+ */
+vec4.round = function (out, a) {
+    out[0] = Math.round(a[0]);
+    out[1] = Math.round(a[1]);
+    out[2] = Math.round(a[2]);
+    out[3] = Math.round(a[3]);
     return out;
 };
 


### PR DESCRIPTION
I've been monkey-patching these into `gl-matrix` for years; it's time they're merged in.

They're particularly useful when working with 2D grids, 3D lattices and bounding volumes.

The vec4 variants are useful for ray-casting in 4D; where a surface exists only for an interval in time. 

I've attempted to logically sequence the methods within the appropriate files.

I've also provided tests utilising constants from the `Math` object.

Let me know if you require any adjustments before merging.