### PR TITLE
Remove extra comma in mat4.js

### DIFF
--- a/src/gl-matrix/mat4.js
+++ b/src/gl-matrix/mat4.js
@@ -26,7 +26,7 @@ var glMatrix = require("./common.js");
  */
 var mat4 = {
   scalar: {},
-  SIMD: {},
+  SIMD: {}
 };
 
 /**


### PR DESCRIPTION
To support old browsers. (However, I do not know what is the intended support.)