### PR TITLE
Prevent Float32Array undefined error on missing typed array support.

### DIFF
--- a/src/gl-matrix/common.js
+++ b/src/gl-matrix/common.js
@@ -31,7 +31,7 @@ glMatrix.RANDOM = Math.random;
 glMatrix.ENABLE_SIMD = false;
 
 // Capability detection
-glMatrix.SIMD_AVAILABLE = (glMatrix.ARRAY_TYPE === Float32Array) && ('SIMD' in this);
+glMatrix.SIMD_AVAILABLE = (glMatrix.ARRAY_TYPE === this.Float32Array) && ('SIMD' in this);
 glMatrix.USE_SIMD = glMatrix.ENABLE_SIMD && glMatrix.SIMD_AVAILABLE;
 
 /**


### PR DESCRIPTION
Fix for missing typed array support in old browsers.