### PR TITLE
add getScaling function for mat4

### DIFF
--- a/spec/gl-matrix/mat4-spec.js
+++ b/spec/gl-matrix/mat4-spec.js
@@ -552,6 +552,56 @@ function buildMat4Tests(useSIMD) {
             });
         });
 
+        describe("getScaling", function() {
+            describe("from the identity matrix", function() {
+                beforeEach(function() {
+                    result = vec3.fromValues(1, 2, 3);
+                    out = vec3.fromValues(1, 2, 3);
+                    result = mat4.getScaling(out, identity);
+                });
+                it("should place result both in result and out", function() { expect(result).toBe(out); });
+                it("should return the identity vector", function() { expect(result).toBeEqualish([1, 1, 1]); });
+            });
+
+            describe("from a scale-only matrix", function() {
+                beforeEach(function() {
+                    var v = vec3.fromValues(4, 5, 6);
+                    result = vec3.fromValues(1, 2, 3)
+                    out = vec3.fromValues(1, 2, 3);
+                    mat4.fromScaling(matA, v);
+                    result = mat4.getScaling(out, matA);
+                });
+                it("should return translation vector", function() { expect(out).toBeEqualish([4, 5, 6]); });
+            });
+
+            describe("from a translation and rotation matrix", function() {
+                beforeEach(function() {
+                    var q = quat.create();
+                    var v = vec3.fromValues(5, 6, 7);
+                    q = quat.setAxisAngle(q, [1, 0, 0], 0.5);
+                    mat4.fromRotationTranslation(out, q, v);
+
+                    result = vec3.fromValues(1, 2, 3);
+                    mat4.getScaling(result, out);
+                })
+                it("should return the identity vector", function() { expect(result).toBeEqualish([1, 1, 1]); });
+            });
+
+            describe("from a translation, rotation and scale matrix", function() {
+                beforeEach(function() {
+                    var q = quat.create();
+                    var t = vec3.fromValues(1, 2, 3);
+                    var s = vec3.fromValues(5, 6, 7);
+                    q = quat.setAxisAngle(q, [0, 1, 0], 0.7);
+                    mat4.fromRotationTranslationScale(out, q, t, s);
+                    result = vec3.fromValues(5, 6, 7);
+                    mat4.getScaling(result, out);
+                })
+                it("should return the same scaling factor when created", function() { expect(result).toBeEqualish([5, 6, 7]); });
+            });
+            
+        });
+
         describe("getRotation", function() {
             describe("from the identity matrix", function() {
                 beforeEach(function() {

--- a/src/gl-matrix/mat4.js
+++ b/src/gl-matrix/mat4.js
@@ -1501,6 +1501,34 @@ mat4.getTranslation = function (out, mat) {
 };
 
 /**
+ * Returns the scaling factor component of a transformation
+ *  matrix. If a matrix is built with fromRotationTranslationScale
+ *  with a normalized Quaternion paramter, the returned vector will be 
+ *  the same as the scaling vector
+ *  originally supplied.
+ * @param  {vec3} out Vector to receive scaling factor component
+ * @param  {mat4} mat Matrix to be decomposed (input)
+ * @return {vec3} out
+ */
+mat4.getScaling = function (out, mat) {
+  var m11 = mat[0],
+      m12 = mat[1],
+      m13 = mat[2],
+      m21 = mat[4],
+      m22 = mat[5],
+      m23 = mat[6],
+      m31 = mat[8],
+      m32 = mat[9],
+      m33 = mat[10];
+
+  out[0] = Math.sqrt(m11 * m11 + m12 * m12 + m13 * m13);
+  out[1] = Math.sqrt(m21 * m21 + m22 * m22 + m23 * m23);
+  out[2] = Math.sqrt(m31 * m31 + m32 * m32 + m33 * m33);
+
+  return out;
+};
+
+/**
  * Returns a quaternion representing the rotational component
  *  of a transformation matrix. If a matrix is built with
  *  fromRotationTranslation, the returned quaternion will be the


### PR DESCRIPTION
The decompose methods seem to forget a getScaling implementation for mat4
