### PR TITLE
fixed precision issues in vec3 angle function

### DIFF
--- a/src/gl-matrix/vec3.js
+++ b/src/gl-matrix/vec3.js
@@ -731,8 +731,11 @@ vec3.angle = function(a, b) {
  
     var cosine = vec3.dot(tempA, tempB);
 
-    if(cosine > 1.0){
+    if(cosine > 1.0) {
         return 0;
+    }
+    else if(cosine < -1.0) {
+        return Math.PI;
     } else {
         return Math.acos(cosine);
     }     


### PR DESCRIPTION
Example:
var vec1 = [0.024432172998785973, 1.3685636623961273e-8, 0.9997014999389648]
var vec2 = [-0.024432172998785973, -8.114220406696404e-9, -0.9997014999389648]

dot(vec1, vec2) will be -1.0000000200576589

=> For values smaller than -1, the `Math.acos`function returns `NaN` (at least in my Chromium browser), therefore the additional check ensures that the cosine value from the dot product is clamped (as it was already done for values greater 1)
