### PR TITLE
Replace babel-preset-2015 with babel-preset-env

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,3 @@
 {
-  "presets": ["es2015"]
+  "presets": ["env"]
 }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "babel-core": "^6.25.0",
     "babel-loader": "^7.1.1",
-    "babel-preset-es2015": "^6.24.1",
+    "babel-preset-env": "^1.6.1",
     "babel-register": "^6.24.1",
     "jsdoc": "^3.4.3",
     "mocha": "^3.4.2",


### PR DESCRIPTION
Babel has moved to a system of instead of using yearly presets to a more long term solution that incorporates all yearly presets in a single preset. This helps with creating a more future proof solution.

This pull request replaces the current `babel-preset-es2015` with `babel-preset-env` for the reasons as explained in the dialog upon install:

> We're super 😸  excited that you're trying to use ES2015 syntax, but instead of making more yearly presets 😭 , Babel now has a better preset that we recommend you use instead: npm install babel-preset-env --save-dev. preset-env without options will compile ES2015+ down to ES5 just like using all the presets together and thus is more future proof. It also allows you to target specific browsers so that Babel can do less work and you can ship native ES2015+ to user 😎 ! We are also in the process of releasing v7, so please give http://babeljs.io/blog/2017/09/12/planning-for-7.0 a read and help test it out in beta! Thanks so much for using Babel 🙏, please give us a follow on Twitter @babeljs for news on Babel, join slack.babeljs.io for discussion/development and help support the project at opencollective.com/babel

This has the advantage of packages that build parts of `gl-matrix` not having to install `babel-preset-es2015` just for `gl-matrix` when the rest of the build tools are already using `babel-preset-env`.