### PR TITLE
Ignore .babelrc for NPM release

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,1 @@
+.babelrc


### PR DESCRIPTION
Closes #284

This PR simply ignores `.babelrc` for NPM released package, avoiding redundant babel transpiling on user's bundle process.

See also https://github.com/ianstormtaylor/slate/pull/1020
