### PR TITLE
Should move `npm` to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "babel-register": "^6.24.1",
     "jsdoc": "^3.4.3",
     "mocha": "^4.0.1",
+    "npm": "^5.8.0",
     "node-libs-browser": "^2.0.0",
     "webpack": "^3.11.0"
   },
@@ -42,6 +43,5 @@
     "build-all": "webpack && webpack --config webpack.config.min.js"
   },
   "dependencies": {
-    "npm": "^5.8.0"
   }
 }


### PR DESCRIPTION
instead to put it into `dependencies` @stefnotch 

I'm upgrading Node to v10 and NPM to v6 yesterday but I found that this module installs a local out-dated npm in my `node_modules` directory which does not compatible with Node v10.

I do not understand why we need to install an npm module localy, but I believe that move it to `devDependeicnes` will solve my problem(and potential others')