### PR TITLE
Move NPM to `peerDependencies`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,9 +29,11 @@
     "babel-register": "^6.24.1",
     "jsdoc": "^3.4.3",
     "mocha": "^4.0.1",
-    "npm": "^5.8.0",
     "node-libs-browser": "^2.0.0",
     "webpack": "^3.11.0"
+  },
+  "peerDependencies": {
+    "npm": "^5.8.0"
   },
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
Fixes #300.

I'm wondering though if it's needed to be listed as a dependency at all? I did a repo wide search and it seems the only dependency on NPM is being able to do `npm run`?