### PR TITLE
Fix expect.toBeEqualish and vec4.random bug

### DIFF
--- a/spec/helpers/spec-helper.js
+++ b/spec/helpers/spec-helper.js
@@ -63,11 +63,12 @@ global.expect = function(e) {
          */
         toBeEqualish: function(a) {
 
-            if (typeof(e) == 'number'){
+            if (typeof(e) == 'number') {
                 if(isNaN(e) !== isNaN(a))
                     expected(e, "to be equalish to", a);
                 if(Math.abs(e - a) >= EPSILON)
                     expected(e, "to be equalish to", a);
+            }
 
             if (e.length != a.length)
                 assert.fail(e.length, a.length, "length mismatch");

--- a/src/gl-matrix/vec4.js
+++ b/src/gl-matrix/vec4.js
@@ -409,8 +409,8 @@ export function lerp(out, a, b, t) {
  * @param {Number} [scale] Length of the resulting vector. If ommitted, a unit vector will be returned
  * @returns {vec4} out
  */
-export function random(out, vectorScale) {
-  vectorScale = vectorScale || 1.0;
+export function random(out, scale) {
+  scale = scale || 1.0;
 
   // Marsaglia, George. Choosing a Point from the Surface of a
   // Sphere. Ann. Math. Statist. 43 (1972), no. 2, 645--646.


### PR DESCRIPTION
```toBeEqualish``` not check the ```NaN``` value.
```vec4.random``` return `NaN` value, it`s wrong but pass the test.