### PR TITLE
create() performance improvements

### DIFF
--- a/src/gl-matrix/mat2.js
+++ b/src/gl-matrix/mat2.js
@@ -12,9 +12,11 @@ import * as glMatrix from "./common.js"
  */
 export function create() {
   let out = new glMatrix.ARRAY_TYPE(4);
+  if(glMatrix.ARRAY_TYPE != Float32Array) {
+    out[1] = 0;
+    out[2] = 0;
+  }
   out[0] = 1;
-  out[1] = 0;
-  out[2] = 0;
   out[3] = 1;
   return out;
 }

--- a/src/gl-matrix/mat2d.js
+++ b/src/gl-matrix/mat2d.js
@@ -26,12 +26,14 @@ import * as glMatrix from "./common.js";
  */
 export function create() {
   let out = new glMatrix.ARRAY_TYPE(6);
+  if(glMatrix.ARRAY_TYPE != Float32Array) {
+    out[1] = 0;
+    out[2] = 0;
+    out[4] = 0;
+    out[5] = 0;
+  }
   out[0] = 1;
-  out[1] = 0;
-  out[2] = 0;
   out[3] = 1;
-  out[4] = 0;
-  out[5] = 0;
   return out;
 }
 

--- a/src/gl-matrix/mat3.js
+++ b/src/gl-matrix/mat3.js
@@ -12,14 +12,16 @@ import * as glMatrix from "./common.js";
  */
 export function create() {
   let out = new glMatrix.ARRAY_TYPE(9);
+  if(glMatrix.ARRAY_TYPE != Float32Array) {
+    out[1] = 0;
+    out[2] = 0;
+    out[3] = 0;
+    out[5] = 0;
+    out[6] = 0;
+    out[7] = 0;
+  }
   out[0] = 1;
-  out[1] = 0;
-  out[2] = 0;
-  out[3] = 0;
   out[4] = 1;
-  out[5] = 0;
-  out[6] = 0;
-  out[7] = 0;
   out[8] = 1;
   return out;
 }

--- a/src/gl-matrix/mat4.js
+++ b/src/gl-matrix/mat4.js
@@ -12,21 +12,23 @@ import * as glMatrix from "./common.js";
  */
 export function create() {
   let out = new glMatrix.ARRAY_TYPE(16);
+  if(glMatrix.ARRAY_TYPE != Float32Array) {
+    out[1] = 0;
+    out[2] = 0;
+    out[3] = 0;
+    out[4] = 0;
+    out[6] = 0;
+    out[7] = 0;
+    out[8] = 0;
+    out[9] = 0;
+    out[11] = 0;
+    out[12] = 0;
+    out[13] = 0;
+    out[14] = 0;
+  }
   out[0] = 1;
-  out[1] = 0;
-  out[2] = 0;
-  out[3] = 0;
-  out[4] = 0;
   out[5] = 1;
-  out[6] = 0;
-  out[7] = 0;
-  out[8] = 0;
-  out[9] = 0;
   out[10] = 1;
-  out[11] = 0;
-  out[12] = 0;
-  out[13] = 0;
-  out[14] = 0;
   out[15] = 1;
   return out;
 }

--- a/src/gl-matrix/quat.js
+++ b/src/gl-matrix/quat.js
@@ -15,9 +15,11 @@ import * as vec4 from "./vec4.js"
  */
 export function create() {
   let out = new glMatrix.ARRAY_TYPE(4);
-  out[0] = 0;
-  out[1] = 0;
-  out[2] = 0;
+  if(glMatrix.ARRAY_TYPE != Float32Array) {
+    out[0] = 0;
+    out[1] = 0;
+    out[2] = 0;
+  }
   out[3] = 1;
   return out;
 }

--- a/src/gl-matrix/quat2.js
+++ b/src/gl-matrix/quat2.js
@@ -18,14 +18,16 @@ import * as mat4 from "./mat4.js";
  */
 export function create() {
   let dq = new glMatrix.ARRAY_TYPE(8);
-  dq[0] = 0;
-  dq[1] = 0;
-  dq[2] = 0;
+  if(glMatrix.ARRAY_TYPE != Float32Array) {
+    dq[0] = 0;
+    dq[1] = 0;
+    dq[2] = 0;
+    dq[4] = 0;
+    dq[5] = 0;
+    dq[6] = 0;
+    dq[7] = 0;
+  }
   dq[3] = 1;
-  dq[4] = 0;
-  dq[5] = 0;
-  dq[6] = 0;
-  dq[7] = 0;
   return dq;
 }
 

--- a/src/gl-matrix/vec2.js
+++ b/src/gl-matrix/vec2.js
@@ -12,8 +12,10 @@ import * as glMatrix from "./common.js";
  */
 export function create() {
   let out = new glMatrix.ARRAY_TYPE(2);
-  out[0] = 0;
-  out[1] = 0;
+  if(glMatrix.ARRAY_TYPE != Float32Array) {
+    out[0] = 0;
+    out[1] = 0;
+  }
   return out;
 }
 

--- a/src/gl-matrix/vec3.js
+++ b/src/gl-matrix/vec3.js
@@ -12,9 +12,11 @@ import * as glMatrix from "./common.js";
  */
 export function create() {
   let out = new glMatrix.ARRAY_TYPE(3);
-  out[0] = 0;
-  out[1] = 0;
-  out[2] = 0;
+  if(glMatrix.ARRAY_TYPE != Float32Array) {
+    out[0] = 0;
+    out[1] = 0;
+    out[2] = 0;
+  }
   return out;
 }
 

--- a/src/gl-matrix/vec4.js
+++ b/src/gl-matrix/vec4.js
@@ -12,10 +12,12 @@ import * as glMatrix from "./common.js";
  */
 export function create() {
   let out = new glMatrix.ARRAY_TYPE(4);
-  out[0] = 0;
-  out[1] = 0;
-  out[2] = 0;
-  out[3] = 0;
+  if(glMatrix.ARRAY_TYPE != Float32Array) {
+    out[0] = 0;
+    out[1] = 0;
+    out[2] = 0;
+    out[3] = 0;
+  }
   return out;
 }
 


### PR DESCRIPTION
Since Float32Arrays are filled with 0s by default, we do not have to do that again. The cost of the `if` is negligible, compared to the potential performance gains.

Resolves: https://github.com/toji/gl-matrix/issues/301#issuecomment-394049372