### PR TITLE
Specify sideEffects=false in package.json to facilitate tree shaking

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,5 +44,6 @@
     "webpack-cli": "^2.1.3",
     "webpack": "^4.8.3"
   },
-  "dependencies": {}
+  "dependencies": {},
+  "sideEffects": false
 }


### PR DESCRIPTION
For webpack and potentially other bundlers to be able to remove unused
code, it is necessary to declare that this package does not contain
side-effects when it is loaded.

For that, webpack introduced the "sideEffects" property in the
package.json file as described in

https://webpack.js.org/guides/tree-shaking/#mark-the-file-as-side-effect-free

This fixes #326 