### PR TITLE
Add an element-wise 'abs' method for vectors

### DIFF
--- a/spec/gl-matrix/vec2-spec.js
+++ b/spec/gl-matrix/vec2-spec.js
@@ -242,6 +242,25 @@ describe("vec2", function() {
         });
     });
 
+    describe("abs", function() {
+        beforeEach(function() { vecA = [-1, -2]; });
+
+        describe("with a separate output vector", function() {
+            beforeEach(function() { result = vec2.abs(out, vecA); });
+
+            it("should place values into out", function() { expect(out).toBeEqualish([1, 2]); });
+            it("should return out", function() { expect(result).toBe(out); });
+            it("should not modify vecA", function() { expect(vecA).toBeEqualish([-1, -2]); });
+        });
+
+        describe("when vecA is the output vector", function() {
+            beforeEach(function() { result = vec2.abs(vecA, vecA); });
+
+            it("should place values into vecA", function() { expect(vecA).toBeEqualish([1, 2]); });
+            it("should return vecA", function() { expect(result).toBe(vecA); });
+        });
+    });
+
     describe("round", function() {
         beforeEach(function() { vecA = [Math.E, Math.PI]; });
 

--- a/spec/gl-matrix/vec3-spec.js
+++ b/spec/gl-matrix/vec3-spec.js
@@ -383,6 +383,25 @@ describe("vec3", function() {
         });
     });
 
+    describe("abs", function() {
+        beforeEach(function() { vecA = [-1, -2, -3]; });
+
+        describe("with a separate output vector", function() {
+            beforeEach(function() { result = vec3.abs(out, vecA); });
+
+            it("should place values into out", function() { expect(out).toBeEqualish([1, 2, 3]); });
+            it("should return out", function() { expect(result).toBe(out); });
+            it("should not modify vecA", function() { expect(vecA).toBeEqualish([-1, -2, -3]); });
+        });
+
+        describe("when vecA is the output vector", function() {
+            beforeEach(function() { result = vec3.abs(vecA, vecA); });
+
+            it("should place values into vecA", function() { expect(vecA).toBeEqualish([1, 2, 3]); });
+            it("should return vecA", function() { expect(result).toBe(vecA); });
+        });
+    });
+
     describe("round", function() {
         beforeEach(function() { vecA = [Math.E, Math.PI, Math.SQRT2]; });
 

--- a/spec/gl-matrix/vec4-spec.js
+++ b/spec/gl-matrix/vec4-spec.js
@@ -243,6 +243,25 @@ describe("vec4", function() {
         });
     });
 
+    describe("abs", function() {
+        beforeEach(function() { vecA = [-1, -2, -3, -4]; });
+
+        describe("with a separate output vector", function() {
+            beforeEach(function() { result = vec4.abs(out, vecA); });
+
+            it("should place values into out", function() { expect(out).toBeEqualish([1, 2, 3, 4]); });
+            it("should return out", function() { expect(result).toBe(out); });
+            it("should not modify vecA", function() { expect(vecA).toBeEqualish([-1, -2, -3, -4]); });
+        });
+
+        describe("when vecA is the output vector", function() {
+            beforeEach(function() { result = vec4.abs(vecA, vecA); });
+
+            it("should place values into vecA", function() { expect(vecA).toBeEqualish([1, 2, 3, 4]); });
+            it("should return vecA", function() { expect(result).toBe(vecA); });
+        });
+    });
+
     describe("round", function() {
         beforeEach(function() { vecA = [Math.E, Math.PI, Math.SQRT2, Math.SQRT1_2]; });
 

--- a/src/gl-matrix/vec2.js
+++ b/src/gl-matrix/vec2.js
@@ -184,6 +184,19 @@ export function max(out, a, b) {
 }
 
 /**
+ * Math.abs the components of a vec2
+ *
+ * @param {vec2} out the receiving vector
+ * @param {vec2} a vector to abs
+ * @returns {vec2} out
+ */
+export function abs(out, a) {
+  out[0] = Math.abs(a[0]);
+  out[1] = Math.abs(a[1]);
+  return out;
+}
+
+/**
  * Math.round the components of a vec2
  *
  * @param {vec2} out the receiving vector

--- a/src/gl-matrix/vec3.js
+++ b/src/gl-matrix/vec3.js
@@ -212,6 +212,20 @@ export function max(out, a, b) {
 }
 
 /**
+ * Math.abs the components of a vec3
+ *
+ * @param {vec3} out the receiving vector
+ * @param {vec3} a vector to abs
+ * @returns {vec3} out
+ */
+export function abs(out, a) {
+  out[0] = Math.abs(a[0]);
+  out[1] = Math.abs(a[1]);
+  out[2] = Math.abs(a[2]);
+  return out;
+}
+
+/**
  * Math.round the components of a vec3
  *
  * @param {vec3} out the receiving vector

--- a/src/gl-matrix/vec4.js
+++ b/src/gl-matrix/vec4.js
@@ -214,6 +214,21 @@ export function max(out, a, b) {
 }
 
 /**
+ * Math.abs the components of a vec4
+ *
+ * @param {vec4} out the receiving vector
+ * @param {vec4} a vector to abs
+ * @returns {vec4} out
+ */
+export function abs(out, a) {
+  out[0] = Math.abs(a[0]);
+  out[1] = Math.abs(a[1]);
+  out[2] = Math.abs(a[2]);
+  out[3] = Math.abs(a[3]);
+  return out;
+}
+
+/**
  * Math.round the components of a vec4
  *
  * @param {vec4} out the receiving vector


### PR DESCRIPTION
Adding a unary op that will set each of the output vector's elements to the absolute value of the corresponding input element.

Useful for mapping a bounding box half diagonal vector into the positive quadrant/octant 