### PR TITLE
Adding Vector.zero method

### DIFF
--- a/spec/gl-matrix/vec2-spec.js
+++ b/spec/gl-matrix/vec2-spec.js
@@ -640,4 +640,12 @@ describe("vec2", function() {
         it("should not modify vecA", function() { expect(vecA).toBeEqualish([0, 1]); });
         it("should not modify vecB", function() { expect(vecB).toBeEqualish([0, 1]); });
     });
+
+    describe("zero", function() {
+        beforeEach(function() {
+            vecA = [1, 2];
+            result = vec2.zero(vecA);
+        });
+        it("should result in a 2 element vector with zeros", function() { expect(result).toBeEqualish([0, 0]); });
+    });
 });

--- a/spec/gl-matrix/vec3-spec.js
+++ b/spec/gl-matrix/vec3-spec.js
@@ -735,4 +735,12 @@ describe("vec3", function() {
         it("should not modify vecA", function() { expect(vecA).toBeEqualish([0, 1, 2]); });
         it("should not modify vecB", function() { expect(vecB).toBeEqualish([0, 1, 2]); });
     });
+
+    describe("zero", function() {
+        beforeEach(function() {
+            vecA = [1, 2, 3];
+            result = vec3.zero(vecA);
+        });
+        it("should result in a 3 element vector with zeros", function() { expect(result).toBeEqualish([0, 0, 0]); });
+    });
 });

--- a/spec/gl-matrix/vec4-spec.js
+++ b/spec/gl-matrix/vec4-spec.js
@@ -560,4 +560,12 @@ describe("vec4", function() {
         it("should not modify vecA", function() { expect(vecA).toBeEqualish([0, 1, 2, 3]); });
         it("should not modify vecB", function() { expect(vecB).toBeEqualish([0, 1, 2, 3]); });
     });
+
+    describe("zero", function() {
+        beforeEach(function() {
+            vecA = [1, 2, 3, 4];
+            result = vec4.zero(vecA);
+        });
+        it("should result in a 4 element vector with zeros", function() { expect(result).toBeEqualish([0, 0, 0, 0]); });
+    });
 });

--- a/src/vec2.js
+++ b/src/vec2.js
@@ -507,6 +507,18 @@ export function angle(a, b) {
 }
 
 /**
+ * Set the components of a vec2 to zero
+ *
+ * @param {vec2} out the receiving vector
+ * @returns {vec2} out
+ */
+export function zero(out) {
+  out[0] = 0.0;
+  out[1] = 0.0;
+  return out;
+}
+
+/**
  * Returns a string representation of a vector
  *
  * @param {vec2} a vector to represent as a string

--- a/src/vec3.js
+++ b/src/vec3.js
@@ -650,6 +650,19 @@ export function angle(a, b) {
 }
 
 /**
+ * Set the components of a vec3 to zero
+ *
+ * @param {vec3} out the receiving vector
+ * @returns {vec3} out
+ */
+export function zero(out) {
+  out[0] = 0.0;
+  out[1] = 0.0;
+  out[2] = 0.0;
+  return out;
+}
+
+/**
  * Returns a string representation of a vector
  *
  * @param {vec3} a vector to represent as a string

--- a/src/vec4.js
+++ b/src/vec4.js
@@ -482,6 +482,20 @@ export function transformQuat(out, a, q) {
 }
 
 /**
+ * Set the components of a vec4 to zero
+ *
+ * @param {vec4} out the receiving vector
+ * @returns {vec4} out
+ */
+export function zero(out) {
+  out[0] = 0.0;
+  out[1] = 0.0;
+  out[2] = 0.0;
+  out[3] = 0.0;
+  return out;
+}
+
+/**
  * Returns a string representation of a vector
  *
  * @param {vec4} a vector to represent as a string


### PR DESCRIPTION
Adding method to set all components of a vector to zero.

I often encounter this when working with cached vectors. Having a ``Vector.zero`` method is a more clear and probably faster way than calling ``Vector.set(out, 0, ..)``.