### PR TITLE
Update JSDocs to allow correct type checks

### DIFF
--- a/docs/mat2.js.html
+++ b/docs/mat2.js.html
@@ -36,7 +36,7 @@
 /**
  * Creates a new identity mat2
  *
- * @returns {mat2} a new 2x2 matrix
+ * @returns {Mat2} a new 2x2 matrix
  */
 export function create() {
   let out = new glMatrix.ARRAY_TYPE(4);
@@ -52,8 +52,8 @@ export function create() {
 /**
  * Creates a new mat2 initialized with values from an existing matrix
  *
- * @param {mat2} a matrix to clone
- * @returns {mat2} a new 2x2 matrix
+ * @param {Mat2} a matrix to clone
+ * @returns {Mat2} a new 2x2 matrix
  */
 export function clone(a) {
   let out = new glMatrix.ARRAY_TYPE(4);
@@ -67,9 +67,9 @@ export function clone(a) {
 /**
  * Copy the values from one mat2 to another
  *
- * @param {mat2} out the receiving matrix
- * @param {mat2} a the source matrix
- * @returns {mat2} out
+ * @param {Mat2} out the receiving matrix
+ * @param {Mat2} a the source matrix
+ * @returns {Mat2} out
  */
 export function copy(out, a) {
   out[0] = a[0];
@@ -82,8 +82,8 @@ export function copy(out, a) {
 /**
  * Set a mat2 to the identity matrix
  *
- * @param {mat2} out the receiving matrix
- * @returns {mat2} out
+ * @param {Mat2} out the receiving matrix
+ * @returns {Mat2} out
  */
 export function identity(out) {
   out[0] = 1;
@@ -100,7 +100,7 @@ export function identity(out) {
  * @param {Number} m01 Component in column 0, row 1 position (index 1)
  * @param {Number} m10 Component in column 1, row 0 position (index 2)
  * @param {Number} m11 Component in column 1, row 1 position (index 3)
- * @returns {mat2} out A new 2x2 matrix
+ * @returns {Mat2} out A new 2x2 matrix
  */
 export function fromValues(m00, m01, m10, m11) {
   let out = new glMatrix.ARRAY_TYPE(4);
@@ -114,12 +114,12 @@ export function fromValues(m00, m01, m10, m11) {
 /**
  * Set the components of a mat2 to the given values
  *
- * @param {mat2} out the receiving matrix
+ * @param {Mat2} out the receiving matrix
  * @param {Number} m00 Component in column 0, row 0 position (index 0)
  * @param {Number} m01 Component in column 0, row 1 position (index 1)
  * @param {Number} m10 Component in column 1, row 0 position (index 2)
  * @param {Number} m11 Component in column 1, row 1 position (index 3)
- * @returns {mat2} out
+ * @returns {Mat2} out
  */
 export function set(out, m00, m01, m10, m11) {
   out[0] = m00;
@@ -132,9 +132,9 @@ export function set(out, m00, m01, m10, m11) {
 /**
  * Transpose the values of a mat2
  *
- * @param {mat2} out the receiving matrix
- * @param {mat2} a the source matrix
- * @returns {mat2} out
+ * @param {Mat2} out the receiving matrix
+ * @param {Mat2} a the source matrix
+ * @returns {Mat2} out
  */
 export function transpose(out, a) {
   // If we are transposing ourselves we can skip a few steps but have to cache
@@ -156,9 +156,9 @@ export function transpose(out, a) {
 /**
  * Inverts a mat2
  *
- * @param {mat2} out the receiving matrix
- * @param {mat2} a the source matrix
- * @returns {mat2} out
+ * @param {Mat2} out the receiving matrix
+ * @param {Mat2} a the source matrix
+ * @returns {Mat2} out
  */
 export function invert(out, a) {
   let a0 = a[0], a1 = a[1], a2 = a[2], a3 = a[3];
@@ -182,9 +182,9 @@ export function invert(out, a) {
 /**
  * Calculates the adjugate of a mat2
  *
- * @param {mat2} out the receiving matrix
- * @param {mat2} a the source matrix
- * @returns {mat2} out
+ * @param {Mat2} out the receiving matrix
+ * @param {Mat2} a the source matrix
+ * @returns {Mat2} out
  */
 export function adjoint(out, a) {
   // Caching this value is nessecary if out == a
@@ -200,7 +200,7 @@ export function adjoint(out, a) {
 /**
  * Calculates the determinant of a mat2
  *
- * @param {mat2} a the source matrix
+ * @param {Mat2} a the source matrix
  * @returns {Number} determinant of a
  */
 export function determinant(a) {
@@ -210,10 +210,10 @@ export function determinant(a) {
 /**
  * Multiplies two mat2's
  *
- * @param {mat2} out the receiving matrix
- * @param {mat2} a the first operand
- * @param {mat2} b the second operand
- * @returns {mat2} out
+ * @param {Mat2} out the receiving matrix
+ * @param {Mat2} a the first operand
+ * @param {Mat2} b the second operand
+ * @returns {Mat2} out
  */
 export function multiply(out, a, b) {
   let a0 = a[0], a1 = a[1], a2 = a[2], a3 = a[3];
@@ -228,10 +228,10 @@ export function multiply(out, a, b) {
 /**
  * Rotates a mat2 by the given angle
  *
- * @param {mat2} out the receiving matrix
- * @param {mat2} a the matrix to rotate
+ * @param {Mat2} out the receiving matrix
+ * @param {Mat2} a the matrix to rotate
  * @param {Number} rad the angle to rotate the matrix by
- * @returns {mat2} out
+ * @returns {Mat2} out
  */
 export function rotate(out, a, rad) {
   let a0 = a[0], a1 = a[1], a2 = a[2], a3 = a[3];
@@ -247,10 +247,10 @@ export function rotate(out, a, rad) {
 /**
  * Scales the mat2 by the dimensions in the given vec2
  *
- * @param {mat2} out the receiving matrix
- * @param {mat2} a the matrix to rotate
- * @param {vec2} v the vec2 to scale the matrix by
- * @returns {mat2} out
+ * @param {Mat2} out the receiving matrix
+ * @param {Mat2} a the matrix to rotate
+ * @param {Vec2} v the vec2 to scale the matrix by
+ * @returns {Mat2} out
  **/
 export function scale(out, a, v) {
   let a0 = a[0], a1 = a[1], a2 = a[2], a3 = a[3];
@@ -269,9 +269,9 @@ export function scale(out, a, v) {
  *     mat2.identity(dest);
  *     mat2.rotate(dest, dest, rad);
  *
- * @param {mat2} out mat2 receiving operation result
+ * @param {Mat2} out mat2 receiving operation result
  * @param {Number} rad the angle to rotate the matrix by
- * @returns {mat2} out
+ * @returns {Mat2} out
  */
 export function fromRotation(out, rad) {
   let s = Math.sin(rad);
@@ -290,9 +290,9 @@ export function fromRotation(out, rad) {
  *     mat2.identity(dest);
  *     mat2.scale(dest, dest, vec);
  *
- * @param {mat2} out mat2 receiving operation result
- * @param {vec2} v Scaling vector
- * @returns {mat2} out
+ * @param {Mat2} out mat2 receiving operation result
+ * @param {Vec2} v Scaling vector
+ * @returns {Mat2} out
  */
 export function fromScaling(out, v) {
   out[0] = v[0];
@@ -305,7 +305,7 @@ export function fromScaling(out, v) {
 /**
  * Returns a string representation of a mat2
  *
- * @param {mat2} a matrix to represent as a string
+ * @param {Mat2} a matrix to represent as a string
  * @returns {String} string representation of the matrix
  */
 export function str(a) {
@@ -315,7 +315,7 @@ export function str(a) {
 /**
  * Returns Frobenius norm of a mat2
  *
- * @param {mat2} a the matrix to calculate Frobenius norm of
+ * @param {Mat2} a the matrix to calculate Frobenius norm of
  * @returns {Number} Frobenius norm
  */
 export function frob(a) {
@@ -324,10 +324,10 @@ export function frob(a) {
 
 /**
  * Returns L, D and U matrices (Lower triangular, Diagonal and Upper triangular) by factorizing the input matrix
- * @param {mat2} L the lower triangular matrix
- * @param {mat2} D the diagonal matrix
- * @param {mat2} U the upper triangular matrix
- * @param {mat2} a the input matrix to factorize
+ * @param {Mat2} L the lower triangular matrix
+ * @param {Mat2} D the diagonal matrix
+ * @param {Mat2} U the upper triangular matrix
+ * @param {Mat2} a the input matrix to factorize
  */
 
 export function LDU(L, D, U, a) {
@@ -341,10 +341,10 @@ export function LDU(L, D, U, a) {
 /**
  * Adds two mat2's
  *
- * @param {mat2} out the receiving matrix
- * @param {mat2} a the first operand
- * @param {mat2} b the second operand
- * @returns {mat2} out
+ * @param {Mat2} out the receiving matrix
+ * @param {Mat2} a the first operand
+ * @param {Mat2} b the second operand
+ * @returns {Mat2} out
  */
 export function add(out, a, b) {
   out[0] = a[0] + b[0];
@@ -357,10 +357,10 @@ export function add(out, a, b) {
 /**
  * Subtracts matrix b from matrix a
  *
- * @param {mat2} out the receiving matrix
- * @param {mat2} a the first operand
- * @param {mat2} b the second operand
- * @returns {mat2} out
+ * @param {Mat2} out the receiving matrix
+ * @param {Mat2} a the first operand
+ * @param {Mat2} b the second operand
+ * @returns {Mat2} out
  */
 export function subtract(out, a, b) {
   out[0] = a[0] - b[0];
@@ -373,8 +373,8 @@ export function subtract(out, a, b) {
 /**
  * Returns whether or not the matrices have exactly the same elements in the same position (when compared with ===)
  *
- * @param {mat2} a The first matrix.
- * @param {mat2} b The second matrix.
+ * @param {Mat2} a The first matrix.
+ * @param {Mat2} b The second matrix.
  * @returns {Boolean} True if the matrices are equal, false otherwise.
  */
 export function exactEquals(a, b) {
@@ -384,8 +384,8 @@ export function exactEquals(a, b) {
 /**
  * Returns whether or not the matrices have approximately the same elements in the same position.
  *
- * @param {mat2} a The first matrix.
- * @param {mat2} b The second matrix.
+ * @param {Mat2} a The first matrix.
+ * @param {Mat2} b The second matrix.
  * @returns {Boolean} True if the matrices are equal, false otherwise.
  */
 export function equals(a, b) {
@@ -400,10 +400,10 @@ export function equals(a, b) {
 /**
  * Multiply each element of the matrix by a scalar.
  *
- * @param {mat2} out the receiving matrix
- * @param {mat2} a the matrix to scale
+ * @param {Mat2} out the receiving matrix
+ * @param {Mat2} a the matrix to scale
  * @param {Number} b amount to scale the matrix's elements by
- * @returns {mat2} out
+ * @returns {Mat2} out
  */
 export function multiplyScalar(out, a, b) {
   out[0] = a[0] * b;
@@ -416,11 +416,11 @@ export function multiplyScalar(out, a, b) {
 /**
  * Adds two mat2's after multiplying each element of the second operand by a scalar value.
  *
- * @param {mat2} out the receiving vector
- * @param {mat2} a the first operand
- * @param {mat2} b the second operand
+ * @param {Mat2} out the receiving vector
+ * @param {Mat2} a the first operand
+ * @param {Mat2} b the second operand
  * @param {Number} scale the amount to scale b's elements by before adding
- * @returns {mat2} out
+ * @returns {Mat2} out
  */
 export function multiplyScalarAndAdd(out, a, b, scale) {
   out[0] = a[0] + (b[0] * scale);

--- a/docs/mat2d.js.html
+++ b/docs/mat2d.js.html
@@ -50,7 +50,7 @@
 /**
  * Creates a new identity mat2d
  *
- * @returns {mat2d} a new 2x3 matrix
+ * @returns {Mat2d} a new 2x3 matrix
  */
 export function create() {
   let out = new glMatrix.ARRAY_TYPE(6);
@@ -68,8 +68,8 @@ export function create() {
 /**
  * Creates a new mat2d initialized with values from an existing matrix
  *
- * @param {mat2d} a matrix to clone
- * @returns {mat2d} a new 2x3 matrix
+ * @param {Mat2d} a matrix to clone
+ * @returns {Mat2d} a new 2x3 matrix
  */
 export function clone(a) {
   let out = new glMatrix.ARRAY_TYPE(6);
@@ -85,9 +85,9 @@ export function clone(a) {
 /**
  * Copy the values from one mat2d to another
  *
- * @param {mat2d} out the receiving matrix
- * @param {mat2d} a the source matrix
- * @returns {mat2d} out
+ * @param {Mat2d} out the receiving matrix
+ * @param {Mat2d} a the source matrix
+ * @returns {Mat2d} out
  */
 export function copy(out, a) {
   out[0] = a[0];
@@ -102,8 +102,8 @@ export function copy(out, a) {
 /**
  * Set a mat2d to the identity matrix
  *
- * @param {mat2d} out the receiving matrix
- * @returns {mat2d} out
+ * @param {Mat2d} out the receiving matrix
+ * @returns {Mat2d} out
  */
 export function identity(out) {
   out[0] = 1;
@@ -124,7 +124,7 @@ export function identity(out) {
  * @param {Number} d Component D (index 3)
  * @param {Number} tx Component TX (index 4)
  * @param {Number} ty Component TY (index 5)
- * @returns {mat2d} A new mat2d
+ * @returns {Mat2d} A new mat2d
  */
 export function fromValues(a, b, c, d, tx, ty) {
   let out = new glMatrix.ARRAY_TYPE(6);
@@ -140,14 +140,14 @@ export function fromValues(a, b, c, d, tx, ty) {
 /**
  * Set the components of a mat2d to the given values
  *
- * @param {mat2d} out the receiving matrix
+ * @param {Mat2d} out the receiving matrix
  * @param {Number} a Component A (index 0)
  * @param {Number} b Component B (index 1)
  * @param {Number} c Component C (index 2)
  * @param {Number} d Component D (index 3)
  * @param {Number} tx Component TX (index 4)
  * @param {Number} ty Component TY (index 5)
- * @returns {mat2d} out
+ * @returns {Mat2d} out
  */
 export function set(out, a, b, c, d, tx, ty) {
   out[0] = a;
@@ -162,9 +162,9 @@ export function set(out, a, b, c, d, tx, ty) {
 /**
  * Inverts a mat2d
  *
- * @param {mat2d} out the receiving matrix
- * @param {mat2d} a the source matrix
- * @returns {mat2d} out
+ * @param {Mat2d} out the receiving matrix
+ * @param {Mat2d} a the source matrix
+ * @returns {Mat2d} out
  */
 export function invert(out, a) {
   let aa = a[0], ab = a[1], ac = a[2], ad = a[3];
@@ -188,7 +188,7 @@ export function invert(out, a) {
 /**
  * Calculates the determinant of a mat2d
  *
- * @param {mat2d} a the source matrix
+ * @param {Mat2d} a the source matrix
  * @returns {Number} determinant of a
  */
 export function determinant(a) {
@@ -198,10 +198,10 @@ export function determinant(a) {
 /**
  * Multiplies two mat2d's
  *
- * @param {mat2d} out the receiving matrix
- * @param {mat2d} a the first operand
- * @param {mat2d} b the second operand
- * @returns {mat2d} out
+ * @param {Mat2d} out the receiving matrix
+ * @param {Mat2d} a the first operand
+ * @param {Mat2d} b the second operand
+ * @returns {Mat2d} out
  */
 export function multiply(out, a, b) {
   let a0 = a[0], a1 = a[1], a2 = a[2], a3 = a[3], a4 = a[4], a5 = a[5];
@@ -218,10 +218,10 @@ export function multiply(out, a, b) {
 /**
  * Rotates a mat2d by the given angle
  *
- * @param {mat2d} out the receiving matrix
- * @param {mat2d} a the matrix to rotate
+ * @param {Mat2d} out the receiving matrix
+ * @param {Mat2d} a the matrix to rotate
  * @param {Number} rad the angle to rotate the matrix by
- * @returns {mat2d} out
+ * @returns {Mat2d} out
  */
 export function rotate(out, a, rad) {
   let a0 = a[0], a1 = a[1], a2 = a[2], a3 = a[3], a4 = a[4], a5 = a[5];
@@ -239,10 +239,10 @@ export function rotate(out, a, rad) {
 /**
  * Scales the mat2d by the dimensions in the given vec2
  *
- * @param {mat2d} out the receiving matrix
- * @param {mat2d} a the matrix to translate
- * @param {vec2} v the vec2 to scale the matrix by
- * @returns {mat2d} out
+ * @param {Mat2d} out the receiving matrix
+ * @param {Mat2d} a the matrix to translate
+ * @param {Vec2} v the vec2 to scale the matrix by
+ * @returns {Mat2d} out
  **/
 export function scale(out, a, v) {
   let a0 = a[0], a1 = a[1], a2 = a[2], a3 = a[3], a4 = a[4], a5 = a[5];
@@ -259,10 +259,10 @@ export function scale(out, a, v) {
 /**
  * Translates the mat2d by the dimensions in the given vec2
  *
- * @param {mat2d} out the receiving matrix
- * @param {mat2d} a the matrix to translate
- * @param {vec2} v the vec2 to translate the matrix by
- * @returns {mat2d} out
+ * @param {Mat2d} out the receiving matrix
+ * @param {Mat2d} a the matrix to translate
+ * @param {Vec2} v the vec2 to translate the matrix by
+ * @returns {Mat2d} out
  **/
 export function translate(out, a, v) {
   let a0 = a[0], a1 = a[1], a2 = a[2], a3 = a[3], a4 = a[4], a5 = a[5];
@@ -283,9 +283,9 @@ export function translate(out, a, v) {
  *     mat2d.identity(dest);
  *     mat2d.rotate(dest, dest, rad);
  *
- * @param {mat2d} out mat2d receiving operation result
+ * @param {Mat2d} out mat2d receiving operation result
  * @param {Number} rad the angle to rotate the matrix by
- * @returns {mat2d} out
+ * @returns {Mat2d} out
  */
 export function fromRotation(out, rad) {
   let s = Math.sin(rad), c = Math.cos(rad);
@@ -305,9 +305,9 @@ export function fromRotation(out, rad) {
  *     mat2d.identity(dest);
  *     mat2d.scale(dest, dest, vec);
  *
- * @param {mat2d} out mat2d receiving operation result
- * @param {vec2} v Scaling vector
- * @returns {mat2d} out
+ * @param {Mat2d} out mat2d receiving operation result
+ * @param {Vec2} v Scaling vector
+ * @returns {Mat2d} out
  */
 export function fromScaling(out, v) {
   out[0] = v[0];
@@ -326,9 +326,9 @@ export function fromScaling(out, v) {
  *     mat2d.identity(dest);
  *     mat2d.translate(dest, dest, vec);
  *
- * @param {mat2d} out mat2d receiving operation result
- * @param {vec2} v Translation vector
- * @returns {mat2d} out
+ * @param {Mat2d} out mat2d receiving operation result
+ * @param {Vec2} v Translation vector
+ * @returns {Mat2d} out
  */
 export function fromTranslation(out, v) {
   out[0] = 1;
@@ -343,7 +343,7 @@ export function fromTranslation(out, v) {
 /**
  * Returns a string representation of a mat2d
  *
- * @param {mat2d} a matrix to represent as a string
+ * @param {Mat2d} a matrix to represent as a string
  * @returns {String} string representation of the matrix
  */
 export function str(a) {
@@ -354,7 +354,7 @@ export function str(a) {
 /**
  * Returns Frobenius norm of a mat2d
  *
- * @param {mat2d} a the matrix to calculate Frobenius norm of
+ * @param {Mat2d} a the matrix to calculate Frobenius norm of
  * @returns {Number} Frobenius norm
  */
 export function frob(a) {
@@ -364,10 +364,10 @@ export function frob(a) {
 /**
  * Adds two mat2d's
  *
- * @param {mat2d} out the receiving matrix
- * @param {mat2d} a the first operand
- * @param {mat2d} b the second operand
- * @returns {mat2d} out
+ * @param {Mat2d} out the receiving matrix
+ * @param {Mat2d} a the first operand
+ * @param {Mat2d} b the second operand
+ * @returns {Mat2d} out
  */
 export function add(out, a, b) {
   out[0] = a[0] + b[0];
@@ -382,10 +382,10 @@ export function add(out, a, b) {
 /**
  * Subtracts matrix b from matrix a
  *
- * @param {mat2d} out the receiving matrix
- * @param {mat2d} a the first operand
- * @param {mat2d} b the second operand
- * @returns {mat2d} out
+ * @param {Mat2d} out the receiving matrix
+ * @param {Mat2d} a the first operand
+ * @param {Mat2d} b the second operand
+ * @returns {Mat2d} out
  */
 export function subtract(out, a, b) {
   out[0] = a[0] - b[0];
@@ -400,10 +400,10 @@ export function subtract(out, a, b) {
 /**
  * Multiply each element of the matrix by a scalar.
  *
- * @param {mat2d} out the receiving matrix
- * @param {mat2d} a the matrix to scale
+ * @param {Mat2d} out the receiving matrix
+ * @param {Mat2d} a the matrix to scale
  * @param {Number} b amount to scale the matrix's elements by
- * @returns {mat2d} out
+ * @returns {Mat2d} out
  */
 export function multiplyScalar(out, a, b) {
   out[0] = a[0] * b;
@@ -418,11 +418,11 @@ export function multiplyScalar(out, a, b) {
 /**
  * Adds two mat2d's after multiplying each element of the second operand by a scalar value.
  *
- * @param {mat2d} out the receiving vector
- * @param {mat2d} a the first operand
- * @param {mat2d} b the second operand
+ * @param {Mat2d} out the receiving vector
+ * @param {Mat2d} a the first operand
+ * @param {Mat2d} b the second operand
  * @param {Number} scale the amount to scale b's elements by before adding
- * @returns {mat2d} out
+ * @returns {Mat2d} out
  */
 export function multiplyScalarAndAdd(out, a, b, scale) {
   out[0] = a[0] + (b[0] * scale);
@@ -437,8 +437,8 @@ export function multiplyScalarAndAdd(out, a, b, scale) {
 /**
  * Returns whether or not the matrices have exactly the same elements in the same position (when compared with ===)
  *
- * @param {mat2d} a The first matrix.
- * @param {mat2d} b The second matrix.
+ * @param {Mat2d} a The first matrix.
+ * @param {Mat2d} b The second matrix.
  * @returns {Boolean} True if the matrices are equal, false otherwise.
  */
 export function exactEquals(a, b) {
@@ -448,8 +448,8 @@ export function exactEquals(a, b) {
 /**
  * Returns whether or not the matrices have approximately the same elements in the same position.
  *
- * @param {mat2d} a The first matrix.
- * @param {mat2d} b The second matrix.
+ * @param {Mat2d} a The first matrix.
+ * @param {Mat2d} b The second matrix.
  * @returns {Boolean} True if the matrices are equal, false otherwise.
  */
 export function equals(a, b) {

--- a/docs/mat3.js.html
+++ b/docs/mat3.js.html
@@ -36,7 +36,7 @@
 /**
  * Creates a new identity mat3
  *
- * @returns {mat3} a new 3x3 matrix
+ * @returns {Mat3} a new 3x3 matrix
  */
 export function create() {
   let out = new glMatrix.ARRAY_TYPE(9);
@@ -57,9 +57,9 @@ export function create() {
 /**
  * Copies the upper-left 3x3 values into the given mat3.
  *
- * @param {mat3} out the receiving 3x3 matrix
- * @param {mat4} a   the source 4x4 matrix
- * @returns {mat3} out
+ * @param {Mat3} out the receiving 3x3 matrix
+ * @param {Mat4} a   the source 4x4 matrix
+ * @returns {Mat3} out
  */
 export function fromMat4(out, a) {
   out[0] = a[0];
@@ -77,8 +77,8 @@ export function fromMat4(out, a) {
 /**
  * Creates a new mat3 initialized with values from an existing matrix
  *
- * @param {mat3} a matrix to clone
- * @returns {mat3} a new 3x3 matrix
+ * @param {Mat3} a matrix to clone
+ * @returns {Mat3} a new 3x3 matrix
  */
 export function clone(a) {
   let out = new glMatrix.ARRAY_TYPE(9);
@@ -97,9 +97,9 @@ export function clone(a) {
 /**
  * Copy the values from one mat3 to another
  *
- * @param {mat3} out the receiving matrix
- * @param {mat3} a the source matrix
- * @returns {mat3} out
+ * @param {Mat3} out the receiving matrix
+ * @param {Mat3} a the source matrix
+ * @returns {Mat3} out
  */
 export function copy(out, a) {
   out[0] = a[0];
@@ -126,7 +126,7 @@ export function copy(out, a) {
  * @param {Number} m20 Component in column 2, row 0 position (index 6)
  * @param {Number} m21 Component in column 2, row 1 position (index 7)
  * @param {Number} m22 Component in column 2, row 2 position (index 8)
- * @returns {mat3} A new mat3
+ * @returns {Mat3} A new mat3
  */
 export function fromValues(m00, m01, m02, m10, m11, m12, m20, m21, m22) {
   let out = new glMatrix.ARRAY_TYPE(9);
@@ -145,7 +145,7 @@ export function fromValues(m00, m01, m02, m10, m11, m12, m20, m21, m22) {
 /**
  * Set the components of a mat3 to the given values
  *
- * @param {mat3} out the receiving matrix
+ * @param {Mat3} out the receiving matrix
  * @param {Number} m00 Component in column 0, row 0 position (index 0)
  * @param {Number} m01 Component in column 0, row 1 position (index 1)
  * @param {Number} m02 Component in column 0, row 2 position (index 2)
@@ -155,7 +155,7 @@ export function fromValues(m00, m01, m02, m10, m11, m12, m20, m21, m22) {
  * @param {Number} m20 Component in column 2, row 0 position (index 6)
  * @param {Number} m21 Component in column 2, row 1 position (index 7)
  * @param {Number} m22 Component in column 2, row 2 position (index 8)
- * @returns {mat3} out
+ * @returns {Mat3} out
  */
 export function set(out, m00, m01, m02, m10, m11, m12, m20, m21, m22) {
   out[0] = m00;
@@ -173,8 +173,8 @@ export function set(out, m00, m01, m02, m10, m11, m12, m20, m21, m22) {
 /**
  * Set a mat3 to the identity matrix
  *
- * @param {mat3} out the receiving matrix
- * @returns {mat3} out
+ * @param {Mat3} out the receiving matrix
+ * @returns {Mat3} out
  */
 export function identity(out) {
   out[0] = 1;
@@ -192,9 +192,9 @@ export function identity(out) {
 /**
  * Transpose the values of a mat3
  *
- * @param {mat3} out the receiving matrix
- * @param {mat3} a the source matrix
- * @returns {mat3} out
+ * @param {Mat3} out the receiving matrix
+ * @param {Mat3} a the source matrix
+ * @returns {Mat3} out
  */
 export function transpose(out, a) {
   // If we are transposing ourselves we can skip a few steps but have to cache some values
@@ -224,9 +224,9 @@ export function transpose(out, a) {
 /**
  * Inverts a mat3
  *
- * @param {mat3} out the receiving matrix
- * @param {mat3} a the source matrix
- * @returns {mat3} out
+ * @param {Mat3} out the receiving matrix
+ * @param {Mat3} a the source matrix
+ * @returns {Mat3} out
  */
 export function invert(out, a) {
   let a00 = a[0], a01 = a[1], a02 = a[2];
@@ -260,9 +260,9 @@ export function invert(out, a) {
 /**
  * Calculates the adjugate of a mat3
  *
- * @param {mat3} out the receiving matrix
- * @param {mat3} a the source matrix
- * @returns {mat3} out
+ * @param {Mat3} out the receiving matrix
+ * @param {Mat3} a the source matrix
+ * @returns {Mat3} out
  */
 export function adjoint(out, a) {
   let a00 = a[0], a01 = a[1], a02 = a[2];
@@ -284,7 +284,7 @@ export function adjoint(out, a) {
 /**
  * Calculates the determinant of a mat3
  *
- * @param {mat3} a the source matrix
+ * @param {Mat3} a the source matrix
  * @returns {Number} determinant of a
  */
 export function determinant(a) {
@@ -298,10 +298,10 @@ export function determinant(a) {
 /**
  * Multiplies two mat3's
  *
- * @param {mat3} out the receiving matrix
- * @param {mat3} a the first operand
- * @param {mat3} b the second operand
- * @returns {mat3} out
+ * @param {Mat3} out the receiving matrix
+ * @param {Mat3} a the first operand
+ * @param {Mat3} b the second operand
+ * @returns {Mat3} out
  */
 export function multiply(out, a, b) {
   let a00 = a[0], a01 = a[1], a02 = a[2];
@@ -329,10 +329,10 @@ export function multiply(out, a, b) {
 /**
  * Translate a mat3 by the given vector
  *
- * @param {mat3} out the receiving matrix
- * @param {mat3} a the matrix to translate
- * @param {vec2} v vector to translate by
- * @returns {mat3} out
+ * @param {Mat3} out the receiving matrix
+ * @param {Mat3} a the matrix to translate
+ * @param {Vec2} v vector to translate by
+ * @returns {Mat3} out
  */
 export function translate(out, a, v) {
   let a00 = a[0], a01 = a[1], a02 = a[2],
@@ -357,10 +357,10 @@ export function translate(out, a, v) {
 /**
  * Rotates a mat3 by the given angle
  *
- * @param {mat3} out the receiving matrix
- * @param {mat3} a the matrix to rotate
+ * @param {Mat3} out the receiving matrix
+ * @param {Mat3} a the matrix to rotate
  * @param {Number} rad the angle to rotate the matrix by
- * @returns {mat3} out
+ * @returns {Mat3} out
  */
 export function rotate(out, a, rad) {
   let a00 = a[0], a01 = a[1], a02 = a[2],
@@ -387,10 +387,10 @@ export function rotate(out, a, rad) {
 /**
  * Scales the mat3 by the dimensions in the given vec2
  *
- * @param {mat3} out the receiving matrix
- * @param {mat3} a the matrix to rotate
- * @param {vec2} v the vec2 to scale the matrix by
- * @returns {mat3} out
+ * @param {Mat3} out the receiving matrix
+ * @param {Mat3} a the matrix to rotate
+ * @param {Vec2} v the vec2 to scale the matrix by
+ * @returns {Mat3} out
  **/
 export function scale(out, a, v) {
   let x = v[0], y = v[1];
@@ -416,9 +416,9 @@ export function scale(out, a, v) {
  *     mat3.identity(dest);
  *     mat3.translate(dest, dest, vec);
  *
- * @param {mat3} out mat3 receiving operation result
- * @param {vec2} v Translation vector
- * @returns {mat3} out
+ * @param {Mat3} out mat3 receiving operation result
+ * @param {Vec2} v Translation vector
+ * @returns {Mat3} out
  */
 export function fromTranslation(out, v) {
   out[0] = 1;
@@ -440,9 +440,9 @@ export function fromTranslation(out, v) {
  *     mat3.identity(dest);
  *     mat3.rotate(dest, dest, rad);
  *
- * @param {mat3} out mat3 receiving operation result
+ * @param {Mat3} out mat3 receiving operation result
  * @param {Number} rad the angle to rotate the matrix by
- * @returns {mat3} out
+ * @returns {Mat3} out
  */
 export function fromRotation(out, rad) {
   let s = Math.sin(rad), c = Math.cos(rad);
@@ -468,9 +468,9 @@ export function fromRotation(out, rad) {
  *     mat3.identity(dest);
  *     mat3.scale(dest, dest, vec);
  *
- * @param {mat3} out mat3 receiving operation result
- * @param {vec2} v Scaling vector
- * @returns {mat3} out
+ * @param {Mat3} out mat3 receiving operation result
+ * @param {Vec2} v Scaling vector
+ * @returns {Mat3} out
  */
 export function fromScaling(out, v) {
   out[0] = v[0];
@@ -490,9 +490,9 @@ export function fromScaling(out, v) {
 /**
  * Copies the values from a mat2d into a mat3
  *
- * @param {mat3} out the receiving matrix
- * @param {mat2d} a the matrix to copy
- * @returns {mat3} out
+ * @param {Mat3} out the receiving matrix
+ * @param {Mat2d} a the matrix to copy
+ * @returns {Mat3} out
  **/
 export function fromMat2d(out, a) {
   out[0] = a[0];
@@ -512,10 +512,10 @@ export function fromMat2d(out, a) {
 /**
 * Calculates a 3x3 matrix from the given quaternion
 *
-* @param {mat3} out mat3 receiving operation result
-* @param {quat} q Quaternion to create matrix from
+* @param {Mat3} out mat3 receiving operation result
+* @param {Quat} q Quaternion to create matrix from
 *
-* @returns {mat3} out
+* @returns {Mat3} out
 */
 export function fromQuat(out, q) {
   let x = q[0], y = q[1], z = q[2], w = q[3];
@@ -551,10 +551,10 @@ export function fromQuat(out, q) {
 /**
 * Calculates a 3x3 normal matrix (transpose inverse) from the 4x4 matrix
 *
-* @param {mat3} out mat3 receiving operation result
-* @param {mat4} a Mat4 to derive the normal matrix from
+* @param {Mat3} out mat3 receiving operation result
+* @param {Mat4} a Mat4 to derive the normal matrix from
 *
-* @returns {mat3} out
+* @returns {Mat3} out
 */
 export function normalFromMat4(out, a) {
   let a00 = a[0], a01 = a[1], a02 = a[2], a03 = a[3];
@@ -601,10 +601,10 @@ export function normalFromMat4(out, a) {
 /**
  * Generates a 2D projection matrix with the given bounds
  *
- * @param {mat3} out mat3 frustum matrix will be written into
+ * @param {Mat3} out mat3 frustum matrix will be written into
  * @param {number} width Width of your gl context
  * @param {number} height Height of gl context
- * @returns {mat3} out
+ * @returns {Mat3} out
  */
 export function projection(out, width, height) {
     out[0] = 2 / width;
@@ -622,7 +622,7 @@ export function projection(out, width, height) {
 /**
  * Returns a string representation of a mat3
  *
- * @param {mat3} a matrix to represent as a string
+ * @param {Mat3} a matrix to represent as a string
  * @returns {String} string representation of the matrix
  */
 export function str(a) {
@@ -634,7 +634,7 @@ export function str(a) {
 /**
  * Returns Frobenius norm of a mat3
  *
- * @param {mat3} a the matrix to calculate Frobenius norm of
+ * @param {Mat3} a the matrix to calculate Frobenius norm of
  * @returns {Number} Frobenius norm
  */
 export function frob(a) {
@@ -644,10 +644,10 @@ export function frob(a) {
 /**
  * Adds two mat3's
  *
- * @param {mat3} out the receiving matrix
- * @param {mat3} a the first operand
- * @param {mat3} b the second operand
- * @returns {mat3} out
+ * @param {Mat3} out the receiving matrix
+ * @param {Mat3} a the first operand
+ * @param {Mat3} b the second operand
+ * @returns {Mat3} out
  */
 export function add(out, a, b) {
   out[0] = a[0] + b[0];
@@ -665,10 +665,10 @@ export function add(out, a, b) {
 /**
  * Subtracts matrix b from matrix a
  *
- * @param {mat3} out the receiving matrix
- * @param {mat3} a the first operand
- * @param {mat3} b the second operand
- * @returns {mat3} out
+ * @param {Mat3} out the receiving matrix
+ * @param {Mat3} a the first operand
+ * @param {Mat3} b the second operand
+ * @returns {Mat3} out
  */
 export function subtract(out, a, b) {
   out[0] = a[0] - b[0];
@@ -688,10 +688,10 @@ export function subtract(out, a, b) {
 /**
  * Multiply each element of the matrix by a scalar.
  *
- * @param {mat3} out the receiving matrix
- * @param {mat3} a the matrix to scale
+ * @param {Mat3} out the receiving matrix
+ * @param {Mat3} a the matrix to scale
  * @param {Number} b amount to scale the matrix's elements by
- * @returns {mat3} out
+ * @returns {Mat3} out
  */
 export function multiplyScalar(out, a, b) {
   out[0] = a[0] * b;
@@ -709,11 +709,11 @@ export function multiplyScalar(out, a, b) {
 /**
  * Adds two mat3's after multiplying each element of the second operand by a scalar value.
  *
- * @param {mat3} out the receiving vector
- * @param {mat3} a the first operand
- * @param {mat3} b the second operand
+ * @param {Mat3} out the receiving vector
+ * @param {Mat3} a the first operand
+ * @param {Mat3} b the second operand
  * @param {Number} scale the amount to scale b's elements by before adding
- * @returns {mat3} out
+ * @returns {Mat3} out
  */
 export function multiplyScalarAndAdd(out, a, b, scale) {
   out[0] = a[0] + (b[0] * scale);
@@ -731,8 +731,8 @@ export function multiplyScalarAndAdd(out, a, b, scale) {
 /**
  * Returns whether or not the matrices have exactly the same elements in the same position (when compared with ===)
  *
- * @param {mat3} a The first matrix.
- * @param {mat3} b The second matrix.
+ * @param {Mat3} a The first matrix.
+ * @param {Mat3} b The second matrix.
  * @returns {Boolean} True if the matrices are equal, false otherwise.
  */
 export function exactEquals(a, b) {
@@ -744,8 +744,8 @@ export function exactEquals(a, b) {
 /**
  * Returns whether or not the matrices have approximately the same elements in the same position.
  *
- * @param {mat3} a The first matrix.
- * @param {mat3} b The second matrix.
+ * @param {Mat3} a The first matrix.
+ * @param {Mat3} b The second matrix.
  * @returns {Boolean} True if the matrices are equal, false otherwise.
  */
 export function equals(a, b) {

--- a/docs/mat4.js.html
+++ b/docs/mat4.js.html
@@ -36,7 +36,7 @@
 /**
  * Creates a new identity mat4
  *
- * @returns {mat4} a new 4x4 matrix
+ * @returns {Mat4} a new 4x4 matrix
  */
 export function create() {
   let out = new glMatrix.ARRAY_TYPE(16);
@@ -64,8 +64,8 @@ export function create() {
 /**
  * Creates a new mat4 initialized with values from an existing matrix
  *
- * @param {mat4} a matrix to clone
- * @returns {mat4} a new 4x4 matrix
+ * @param {Mat4} a matrix to clone
+ * @returns {Mat4} a new 4x4 matrix
  */
 export function clone(a) {
   let out = new glMatrix.ARRAY_TYPE(16);
@@ -91,9 +91,9 @@ export function clone(a) {
 /**
  * Copy the values from one mat4 to another
  *
- * @param {mat4} out the receiving matrix
- * @param {mat4} a the source matrix
- * @returns {mat4} out
+ * @param {Mat4} out the receiving matrix
+ * @param {Mat4} a the source matrix
+ * @returns {Mat4} out
  */
 export function copy(out, a) {
   out[0] = a[0];
@@ -134,7 +134,7 @@ export function copy(out, a) {
  * @param {Number} m31 Component in column 3, row 1 position (index 13)
  * @param {Number} m32 Component in column 3, row 2 position (index 14)
  * @param {Number} m33 Component in column 3, row 3 position (index 15)
- * @returns {mat4} A new mat4
+ * @returns {Mat4} A new mat4
  */
 export function fromValues(m00, m01, m02, m03, m10, m11, m12, m13, m20, m21, m22, m23, m30, m31, m32, m33) {
   let out = new glMatrix.ARRAY_TYPE(16);
@@ -160,7 +160,7 @@ export function fromValues(m00, m01, m02, m03, m10, m11, m12, m13, m20, m21, m22
 /**
  * Set the components of a mat4 to the given values
  *
- * @param {mat4} out the receiving matrix
+ * @param {Mat4} out the receiving matrix
  * @param {Number} m00 Component in column 0, row 0 position (index 0)
  * @param {Number} m01 Component in column 0, row 1 position (index 1)
  * @param {Number} m02 Component in column 0, row 2 position (index 2)
@@ -177,7 +177,7 @@ export function fromValues(m00, m01, m02, m03, m10, m11, m12, m13, m20, m21, m22
  * @param {Number} m31 Component in column 3, row 1 position (index 13)
  * @param {Number} m32 Component in column 3, row 2 position (index 14)
  * @param {Number} m33 Component in column 3, row 3 position (index 15)
- * @returns {mat4} out
+ * @returns {Mat4} out
  */
 export function set(out, m00, m01, m02, m03, m10, m11, m12, m13, m20, m21, m22, m23, m30, m31, m32, m33) {
   out[0] = m00;
@@ -203,8 +203,8 @@ export function set(out, m00, m01, m02, m03, m10, m11, m12, m13, m20, m21, m22, 
 /**
  * Set a mat4 to the identity matrix
  *
- * @param {mat4} out the receiving matrix
- * @returns {mat4} out
+ * @param {Mat4} out the receiving matrix
+ * @returns {Mat4} out
  */
 export function identity(out) {
   out[0] = 1;
@@ -229,9 +229,9 @@ export function identity(out) {
 /**
  * Transpose the values of a mat4
  *
- * @param {mat4} out the receiving matrix
- * @param {mat4} a the source matrix
- * @returns {mat4} out
+ * @param {Mat4} out the receiving matrix
+ * @param {Mat4} a the source matrix
+ * @returns {Mat4} out
  */
 export function transpose(out, a) {
   // If we are transposing ourselves we can skip a few steps but have to cache some values
@@ -277,9 +277,9 @@ export function transpose(out, a) {
 /**
  * Inverts a mat4
  *
- * @param {mat4} out the receiving matrix
- * @param {mat4} a the source matrix
- * @returns {mat4} out
+ * @param {Mat4} out the receiving matrix
+ * @param {Mat4} a the source matrix
+ * @returns {Mat4} out
  */
 export function invert(out, a) {
   let a00 = a[0], a01 = a[1], a02 = a[2], a03 = a[3];
@@ -331,9 +331,9 @@ export function invert(out, a) {
 /**
  * Calculates the adjugate of a mat4
  *
- * @param {mat4} out the receiving matrix
- * @param {mat4} a the source matrix
- * @returns {mat4} out
+ * @param {Mat4} out the receiving matrix
+ * @param {Mat4} a the source matrix
+ * @returns {Mat4} out
  */
 export function adjoint(out, a) {
   let a00 = a[0], a01 = a[1], a02 = a[2], a03 = a[3];
@@ -363,7 +363,7 @@ export function adjoint(out, a) {
 /**
  * Calculates the determinant of a mat4
  *
- * @param {mat4} a the source matrix
+ * @param {Mat4} a the source matrix
  * @returns {Number} determinant of a
  */
 export function determinant(a) {
@@ -392,10 +392,10 @@ export function determinant(a) {
 /**
  * Multiplies two mat4s
  *
- * @param {mat4} out the receiving matrix
- * @param {mat4} a the first operand
- * @param {mat4} b the second operand
- * @returns {mat4} out
+ * @param {Mat4} out the receiving matrix
+ * @param {Mat4} a the first operand
+ * @param {Mat4} b the second operand
+ * @returns {Mat4} out
  */
 export function multiply(out, a, b) {
   let a00 = a[0], a01 = a[1], a02 = a[2], a03 = a[3];
@@ -433,10 +433,10 @@ export function multiply(out, a, b) {
 /**
  * Translate a mat4 by the given vector
  *
- * @param {mat4} out the receiving matrix
- * @param {mat4} a the matrix to translate
- * @param {vec3} v vector to translate by
- * @returns {mat4} out
+ * @param {Mat4} out the receiving matrix
+ * @param {Mat4} a the matrix to translate
+ * @param {Vec3} v vector to translate by
+ * @returns {Mat4} out
  */
 export function translate(out, a, v) {
   let x = v[0], y = v[1], z = v[2];
@@ -470,10 +470,10 @@ export function translate(out, a, v) {
 /**
  * Scales the mat4 by the dimensions in the given vec3 not using vectorization
  *
- * @param {mat4} out the receiving matrix
- * @param {mat4} a the matrix to scale
- * @param {vec3} v the vec3 to scale the matrix by
- * @returns {mat4} out
+ * @param {Mat4} out the receiving matrix
+ * @param {Mat4} a the matrix to scale
+ * @param {Vec3} v the vec3 to scale the matrix by
+ * @returns {Mat4} out
  **/
 export function scale(out, a, v) {
   let x = v[0], y = v[1], z = v[2];
@@ -500,11 +500,11 @@ export function scale(out, a, v) {
 /**
  * Rotates a mat4 by the given angle around the given axis
  *
- * @param {mat4} out the receiving matrix
- * @param {mat4} a the matrix to rotate
+ * @param {Mat4} out the receiving matrix
+ * @param {Mat4} a the matrix to rotate
  * @param {Number} rad the angle to rotate the matrix by
- * @param {vec3} axis the axis to rotate around
- * @returns {mat4} out
+ * @param {Vec3} axis the axis to rotate around
+ * @returns {Mat4} out
  */
 export function rotate(out, a, rad, axis) {
   let x = axis[0], y = axis[1], z = axis[2];
@@ -563,10 +563,10 @@ export function rotate(out, a, rad, axis) {
 /**
  * Rotates a matrix by the given angle around the X axis
  *
- * @param {mat4} out the receiving matrix
- * @param {mat4} a the matrix to rotate
+ * @param {Mat4} out the receiving matrix
+ * @param {Mat4} a the matrix to rotate
  * @param {Number} rad the angle to rotate the matrix by
- * @returns {mat4} out
+ * @returns {Mat4} out
  */
 export function rotateX(out, a, rad) {
   let s = Math.sin(rad);
@@ -606,10 +606,10 @@ export function rotateX(out, a, rad) {
 /**
  * Rotates a matrix by the given angle around the Y axis
  *
- * @param {mat4} out the receiving matrix
- * @param {mat4} a the matrix to rotate
+ * @param {Mat4} out the receiving matrix
+ * @param {Mat4} a the matrix to rotate
  * @param {Number} rad the angle to rotate the matrix by
- * @returns {mat4} out
+ * @returns {Mat4} out
  */
 export function rotateY(out, a, rad) {
   let s = Math.sin(rad);
@@ -649,10 +649,10 @@ export function rotateY(out, a, rad) {
 /**
  * Rotates a matrix by the given angle around the Z axis
  *
- * @param {mat4} out the receiving matrix
- * @param {mat4} a the matrix to rotate
+ * @param {Mat4} out the receiving matrix
+ * @param {Mat4} a the matrix to rotate
  * @param {Number} rad the angle to rotate the matrix by
- * @returns {mat4} out
+ * @returns {Mat4} out
  */
 export function rotateZ(out, a, rad) {
   let s = Math.sin(rad);
@@ -696,9 +696,9 @@ export function rotateZ(out, a, rad) {
  *     mat4.identity(dest);
  *     mat4.translate(dest, dest, vec);
  *
- * @param {mat4} out mat4 receiving operation result
- * @param {vec3} v Translation vector
- * @returns {mat4} out
+ * @param {Mat4} out mat4 receiving operation result
+ * @param {Vec3} v Translation vector
+ * @returns {Mat4} out
  */
 export function fromTranslation(out, v) {
   out[0] = 1;
@@ -727,9 +727,9 @@ export function fromTranslation(out, v) {
  *     mat4.identity(dest);
  *     mat4.scale(dest, dest, vec);
  *
- * @param {mat4} out mat4 receiving operation result
- * @param {vec3} v Scaling vector
- * @returns {mat4} out
+ * @param {Mat4} out mat4 receiving operation result
+ * @param {Vec3} v Scaling vector
+ * @returns {Mat4} out
  */
 export function fromScaling(out, v) {
   out[0] = v[0];
@@ -758,10 +758,10 @@ export function fromScaling(out, v) {
  *     mat4.identity(dest);
  *     mat4.rotate(dest, dest, rad, axis);
  *
- * @param {mat4} out mat4 receiving operation result
+ * @param {Mat4} out mat4 receiving operation result
  * @param {Number} rad the angle to rotate the matrix by
- * @param {vec3} axis the axis to rotate around
- * @returns {mat4} out
+ * @param {Vec3} axis the axis to rotate around
+ * @returns {Mat4} out
  */
 export function fromRotation(out, rad, axis) {
   let x = axis[0], y = axis[1], z = axis[2];
@@ -806,9 +806,9 @@ export function fromRotation(out, rad, axis) {
  *     mat4.identity(dest);
  *     mat4.rotateX(dest, dest, rad);
  *
- * @param {mat4} out mat4 receiving operation result
+ * @param {Mat4} out mat4 receiving operation result
  * @param {Number} rad the angle to rotate the matrix by
- * @returns {mat4} out
+ * @returns {Mat4} out
  */
 export function fromXRotation(out, rad) {
   let s = Math.sin(rad);
@@ -841,9 +841,9 @@ export function fromXRotation(out, rad) {
  *     mat4.identity(dest);
  *     mat4.rotateY(dest, dest, rad);
  *
- * @param {mat4} out mat4 receiving operation result
+ * @param {Mat4} out mat4 receiving operation result
  * @param {Number} rad the angle to rotate the matrix by
- * @returns {mat4} out
+ * @returns {Mat4} out
  */
 export function fromYRotation(out, rad) {
   let s = Math.sin(rad);
@@ -876,9 +876,9 @@ export function fromYRotation(out, rad) {
  *     mat4.identity(dest);
  *     mat4.rotateZ(dest, dest, rad);
  *
- * @param {mat4} out mat4 receiving operation result
+ * @param {Mat4} out mat4 receiving operation result
  * @param {Number} rad the angle to rotate the matrix by
- * @returns {mat4} out
+ * @returns {Mat4} out
  */
 export function fromZRotation(out, rad) {
   let s = Math.sin(rad);
@@ -914,10 +914,10 @@ export function fromZRotation(out, rad) {
  *     quat4.toMat4(quat, quatMat);
  *     mat4.multiply(dest, quatMat);
  *
- * @param {mat4} out mat4 receiving operation result
+ * @param {Mat4} out mat4 receiving operation result
  * @param {quat4} q Rotation quaternion
- * @param {vec3} v Translation vector
- * @returns {mat4} out
+ * @param {Vec3} v Translation vector
+ * @returns {Mat4} out
  */
 export function fromRotationTranslation(out, q, v) {
   // Quaternion math
@@ -959,9 +959,9 @@ export function fromRotationTranslation(out, q, v) {
 /**
  * Creates a new mat4 from a dual quat.
  *
- * @param {mat4} out Matrix
- * @param {quat2} a Dual Quaternion
- * @returns {mat4} mat4 receiving operation result
+ * @param {Mat4} out Matrix
+ * @param {Quat2} a Dual Quaternion
+ * @returns {Mat4} mat4 receiving operation result
  */
 export function fromQuat2(out, a) {
   let translation = new glMatrix.ARRAY_TYPE(3);
@@ -988,9 +988,9 @@ export function fromQuat2(out, a) {
  *  matrix. If a matrix is built with fromRotationTranslation,
  *  the returned vector will be the same as the translation vector
  *  originally supplied.
- * @param  {vec3} out Vector to receive translation component
- * @param  {mat4} mat Matrix to be decomposed (input)
- * @return {vec3} out
+ * @param  {Vec3} out Vector to receive translation component
+ * @param  {Mat4} mat Matrix to be decomposed (input)
+ * @return {Vec3} out
  */
 export function getTranslation(out, mat) {
   out[0] = mat[12];
@@ -1006,9 +1006,9 @@ export function getTranslation(out, mat) {
  *  with a normalized Quaternion paramter, the returned vector will be
  *  the same as the scaling vector
  *  originally supplied.
- * @param  {vec3} out Vector to receive scaling factor component
- * @param  {mat4} mat Matrix to be decomposed (input)
- * @return {vec3} out
+ * @param  {Vec3} out Vector to receive scaling factor component
+ * @param  {Mat4} mat Matrix to be decomposed (input)
+ * @return {Vec3} out
  */
 export function getScaling(out, mat) {
   let m11 = mat[0];
@@ -1033,9 +1033,9 @@ export function getScaling(out, mat) {
  *  of a transformation matrix. If a matrix is built with
  *  fromRotationTranslation, the returned quaternion will be the
  *  same as the quaternion originally supplied.
- * @param {quat} out Quaternion to receive the rotation component
- * @param {mat4} mat Matrix to be decomposed (input)
- * @return {quat} out
+ * @param {Quat} out Quaternion to receive the rotation component
+ * @param {Mat4} mat Matrix to be decomposed (input)
+ * @return {Quat} out
  */
 export function getRotation(out, mat) {
   // Algorithm taken from http://www.euclideanspace.com/maths/geometry/rotations/conversions/matrixToQuaternion/index.htm
@@ -1082,11 +1082,11 @@ export function getRotation(out, mat) {
  *     mat4.multiply(dest, quatMat);
  *     mat4.scale(dest, scale)
  *
- * @param {mat4} out mat4 receiving operation result
+ * @param {Mat4} out mat4 receiving operation result
  * @param {quat4} q Rotation quaternion
- * @param {vec3} v Translation vector
- * @param {vec3} s Scaling vector
- * @returns {mat4} out
+ * @param {Vec3} v Translation vector
+ * @param {Vec3} s Scaling vector
+ * @returns {Mat4} out
  */
 export function fromRotationTranslationScale(out, q, v, s) {
   // Quaternion math
@@ -1141,12 +1141,12 @@ export function fromRotationTranslationScale(out, q, v, s) {
  *     mat4.scale(dest, scale)
  *     mat4.translate(dest, negativeOrigin);
  *
- * @param {mat4} out mat4 receiving operation result
+ * @param {Mat4} out mat4 receiving operation result
  * @param {quat4} q Rotation quaternion
- * @param {vec3} v Translation vector
- * @param {vec3} s Scaling vector
- * @param {vec3} o The origin vector around which to scale and rotate
- * @returns {mat4} out
+ * @param {Vec3} v Translation vector
+ * @param {Vec3} s Scaling vector
+ * @param {Vec3} o The origin vector around which to scale and rotate
+ * @returns {Mat4} out
  */
 export function fromRotationTranslationScaleOrigin(out, q, v, s, o) {
   // Quaternion math
@@ -1206,10 +1206,10 @@ export function fromRotationTranslationScaleOrigin(out, q, v, s, o) {
 /**
  * Calculates a 4x4 matrix from the given quaternion
  *
- * @param {mat4} out mat4 receiving operation result
- * @param {quat} q Quaternion to create matrix from
+ * @param {Mat4} out mat4 receiving operation result
+ * @param {Quat} q Quaternion to create matrix from
  *
- * @returns {mat4} out
+ * @returns {Mat4} out
  */
 export function fromQuat(out, q) {
   let x = q[0], y = q[1], z = q[2], w = q[3];
@@ -1253,14 +1253,14 @@ export function fromQuat(out, q) {
 /**
  * Generates a frustum matrix with the given bounds
  *
- * @param {mat4} out mat4 frustum matrix will be written into
+ * @param {Mat4} out mat4 frustum matrix will be written into
  * @param {Number} left Left bound of the frustum
  * @param {Number} right Right bound of the frustum
  * @param {Number} bottom Bottom bound of the frustum
  * @param {Number} top Top bound of the frustum
  * @param {Number} near Near bound of the frustum
  * @param {Number} far Far bound of the frustum
- * @returns {mat4} out
+ * @returns {Mat4} out
  */
 export function frustum(out, left, right, bottom, top, near, far) {
   let rl = 1 / (right - left);
@@ -1289,12 +1289,12 @@ export function frustum(out, left, right, bottom, top, near, far) {
  * Generates a perspective projection matrix with the given bounds.
  * Passing null/undefined/no value for far will generate infinite projection matrix.
  *
- * @param {mat4} out mat4 frustum matrix will be written into
+ * @param {Mat4} out mat4 frustum matrix will be written into
  * @param {number} fovy Vertical field of view in radians
  * @param {number} aspect Aspect ratio. typically viewport width/height
  * @param {number} near Near bound of the frustum
  * @param {number} far Far bound of the frustum, can be null or Infinity
- * @returns {mat4} out
+ * @returns {Mat4} out
  */
 export function perspective(out, fovy, aspect, near, far) {
   let f = 1.0 / Math.tan(fovy / 2), nf;
@@ -1328,11 +1328,11 @@ export function perspective(out, fovy, aspect, near, far) {
  * This is primarily useful for generating projection matrices to be used
  * with the still experiemental WebVR API.
  *
- * @param {mat4} out mat4 frustum matrix will be written into
+ * @param {Mat4} out mat4 frustum matrix will be written into
  * @param {Object} fov Object containing the following values: upDegrees, downDegrees, leftDegrees, rightDegrees
  * @param {number} near Near bound of the frustum
  * @param {number} far Far bound of the frustum
- * @returns {mat4} out
+ * @returns {Mat4} out
  */
 export function perspectiveFromFieldOfView(out, fov, near, far) {
   let upTan = Math.tan(fov.upDegrees * Math.PI/180.0);
@@ -1364,14 +1364,14 @@ export function perspectiveFromFieldOfView(out, fov, near, far) {
 /**
  * Generates a orthogonal projection matrix with the given bounds
  *
- * @param {mat4} out mat4 frustum matrix will be written into
+ * @param {Mat4} out mat4 frustum matrix will be written into
  * @param {number} left Left bound of the frustum
  * @param {number} right Right bound of the frustum
  * @param {number} bottom Bottom bound of the frustum
  * @param {number} top Top bound of the frustum
  * @param {number} near Near bound of the frustum
  * @param {number} far Far bound of the frustum
- * @returns {mat4} out
+ * @returns {Mat4} out
  */
 export function ortho(out, left, right, bottom, top, near, far) {
   let lr = 1 / (left - right);
@@ -1400,11 +1400,11 @@ export function ortho(out, left, right, bottom, top, near, far) {
  * Generates a look-at matrix with the given eye position, focal point, and up axis.
  * If you want a matrix that actually makes an object look at another object, you should use targetTo instead.
  *
- * @param {mat4} out mat4 frustum matrix will be written into
- * @param {vec3} eye Position of the viewer
- * @param {vec3} center Point the viewer is looking at
- * @param {vec3} up vec3 pointing up
- * @returns {mat4} out
+ * @param {Mat4} out mat4 frustum matrix will be written into
+ * @param {Vec3} eye Position of the viewer
+ * @param {Vec3} center Point the viewer is looking at
+ * @param {Vec3} up vec3 pointing up
+ * @returns {Mat4} out
  */
 export function lookAt(out, eye, center, up) {
   let x0, x1, x2, y0, y1, y2, z0, z1, z2, len;
@@ -1487,11 +1487,11 @@ export function lookAt(out, eye, center, up) {
 /**
  * Generates a matrix that makes something look at something else.
  *
- * @param {mat4} out mat4 frustum matrix will be written into
- * @param {vec3} eye Position of the viewer
- * @param {vec3} center Point the viewer is looking at
- * @param {vec3} up vec3 pointing up
- * @returns {mat4} out
+ * @param {Mat4} out mat4 frustum matrix will be written into
+ * @param {Vec3} eye Position of the viewer
+ * @param {Vec3} center Point the viewer is looking at
+ * @param {Vec3} up vec3 pointing up
+ * @returns {Mat4} out
  */
 export function targetTo(out, eye, target, up) {
   let eyex = eye[0],
@@ -1547,7 +1547,7 @@ export function targetTo(out, eye, target, up) {
 /**
  * Returns a string representation of a mat4
  *
- * @param {mat4} a matrix to represent as a string
+ * @param {Mat4} a matrix to represent as a string
  * @returns {String} string representation of the matrix
  */
 export function str(a) {
@@ -1560,7 +1560,7 @@ export function str(a) {
 /**
  * Returns Frobenius norm of a mat4
  *
- * @param {mat4} a the matrix to calculate Frobenius norm of
+ * @param {Mat4} a the matrix to calculate Frobenius norm of
  * @returns {Number} Frobenius norm
  */
 export function frob(a) {
@@ -1570,10 +1570,10 @@ export function frob(a) {
 /**
  * Adds two mat4's
  *
- * @param {mat4} out the receiving matrix
- * @param {mat4} a the first operand
- * @param {mat4} b the second operand
- * @returns {mat4} out
+ * @param {Mat4} out the receiving matrix
+ * @param {Mat4} a the first operand
+ * @param {Mat4} b the second operand
+ * @returns {Mat4} out
  */
 export function add(out, a, b) {
   out[0] = a[0] + b[0];
@@ -1598,10 +1598,10 @@ export function add(out, a, b) {
 /**
  * Subtracts matrix b from matrix a
  *
- * @param {mat4} out the receiving matrix
- * @param {mat4} a the first operand
- * @param {mat4} b the second operand
- * @returns {mat4} out
+ * @param {Mat4} out the receiving matrix
+ * @param {Mat4} a the first operand
+ * @param {Mat4} b the second operand
+ * @returns {Mat4} out
  */
 export function subtract(out, a, b) {
   out[0] = a[0] - b[0];
@@ -1626,10 +1626,10 @@ export function subtract(out, a, b) {
 /**
  * Multiply each element of the matrix by a scalar.
  *
- * @param {mat4} out the receiving matrix
- * @param {mat4} a the matrix to scale
+ * @param {Mat4} out the receiving matrix
+ * @param {Mat4} a the matrix to scale
  * @param {Number} b amount to scale the matrix's elements by
- * @returns {mat4} out
+ * @returns {Mat4} out
  */
 export function multiplyScalar(out, a, b) {
   out[0] = a[0] * b;
@@ -1654,11 +1654,11 @@ export function multiplyScalar(out, a, b) {
 /**
  * Adds two mat4's after multiplying each element of the second operand by a scalar value.
  *
- * @param {mat4} out the receiving vector
- * @param {mat4} a the first operand
- * @param {mat4} b the second operand
+ * @param {Mat4} out the receiving vector
+ * @param {Mat4} a the first operand
+ * @param {Mat4} b the second operand
  * @param {Number} scale the amount to scale b's elements by before adding
- * @returns {mat4} out
+ * @returns {Mat4} out
  */
 export function multiplyScalarAndAdd(out, a, b, scale) {
   out[0] = a[0] + (b[0] * scale);
@@ -1683,8 +1683,8 @@ export function multiplyScalarAndAdd(out, a, b, scale) {
 /**
  * Returns whether or not the matrices have exactly the same elements in the same position (when compared with ===)
  *
- * @param {mat4} a The first matrix.
- * @param {mat4} b The second matrix.
+ * @param {Mat4} a The first matrix.
+ * @param {Mat4} b The second matrix.
  * @returns {Boolean} True if the matrices are equal, false otherwise.
  */
 export function exactEquals(a, b) {
@@ -1697,8 +1697,8 @@ export function exactEquals(a, b) {
 /**
  * Returns whether or not the matrices have approximately the same elements in the same position.
  *
- * @param {mat4} a The first matrix.
- * @param {mat4} b The second matrix.
+ * @param {Mat4} a The first matrix.
+ * @param {Mat4} b The second matrix.
  * @returns {Boolean} True if the matrices are equal, false otherwise.
  */
 export function equals(a, b) {

--- a/docs/module-mat2.html
+++ b/docs/module-mat2.html
@@ -142,7 +142,7 @@
     
 
     
-    <h4 class="name" id=".add"><span class="type-signature">(static) </span>add<span class="signature">(out, a, b)</span><span class="type-signature"> &rarr; {mat2}</span></h4>
+    <h4 class="name" id=".add"><span class="type-signature">(static) </span>add<span class="signature">(out, a, b)</span><span class="type-signature"> &rarr; {Mat2}</span></h4>
     
 
     
@@ -345,7 +345,7 @@
     
 
     
-    <h4 class="name" id=".adjoint"><span class="type-signature">(static) </span>adjoint<span class="signature">(out, a)</span><span class="type-signature"> &rarr; {mat2}</span></h4>
+    <h4 class="name" id=".adjoint"><span class="type-signature">(static) </span>adjoint<span class="signature">(out, a)</span><span class="type-signature"> &rarr; {Mat2}</span></h4>
     
 
     
@@ -525,7 +525,7 @@
     
 
     
-    <h4 class="name" id=".clone"><span class="type-signature">(static) </span>clone<span class="signature">(a)</span><span class="type-signature"> &rarr; {mat2}</span></h4>
+    <h4 class="name" id=".clone"><span class="type-signature">(static) </span>clone<span class="signature">(a)</span><span class="type-signature"> &rarr; {Mat2}</span></h4>
     
 
     
@@ -682,7 +682,7 @@
     
 
     
-    <h4 class="name" id=".copy"><span class="type-signature">(static) </span>copy<span class="signature">(out, a)</span><span class="type-signature"> &rarr; {mat2}</span></h4>
+    <h4 class="name" id=".copy"><span class="type-signature">(static) </span>copy<span class="signature">(out, a)</span><span class="type-signature"> &rarr; {Mat2}</span></h4>
     
 
     
@@ -862,7 +862,7 @@
     
 
     
-    <h4 class="name" id=".create"><span class="type-signature">(static) </span>create<span class="signature">()</span><span class="type-signature"> &rarr; {mat2}</span></h4>
+    <h4 class="name" id=".create"><span class="type-signature">(static) </span>create<span class="signature">()</span><span class="type-signature"> &rarr; {Mat2}</span></h4>
     
 
     
@@ -1644,7 +1644,7 @@
     
 
     
-    <h4 class="name" id=".fromRotation"><span class="type-signature">(static) </span>fromRotation<span class="signature">(out, rad)</span><span class="type-signature"> &rarr; {mat2}</span></h4>
+    <h4 class="name" id=".fromRotation"><span class="type-signature">(static) </span>fromRotation<span class="signature">(out, rad)</span><span class="type-signature"> &rarr; {Mat2}</span></h4>
     
 
     
@@ -1652,7 +1652,11 @@
 
 
 <div class="description">
-    Creates a matrix from a given angleThis is equivalent to (but much faster than):    mat2.identity(dest);    mat2.rotate(dest, dest, rad);
+    Creates a matrix from a given angle
+This is equivalent to (but much faster than):
+
+    mat2.identity(dest);
+    mat2.rotate(dest, dest, rad);
 </div>
 
 
@@ -1820,7 +1824,7 @@
 
         
             
-
+{Mat2}
     
 
     
@@ -1832,7 +1836,11 @@
 
 
 <div class="description">
-    Creates a matrix from a vector scalingThis is equivalent to (but much faster than):    mat2.identity(dest);    mat2.scale(dest, dest, vec);
+    Creates a matrix from a vector scaling
+This is equivalent to (but much faster than):
+
+    mat2.identity(dest);
+    mat2.scale(dest, dest, vec);
 </div>
 
 
@@ -1996,7 +2004,7 @@
 
 
 
-
+{Mat2}
 
         
             
@@ -2222,7 +2230,7 @@
 
 
 
-
+{Mat2}
 
         
             
@@ -2379,7 +2387,7 @@
 
 
 
-
+{Mat2}
 
         
             
@@ -2849,7 +2857,7 @@
 
 
 
-
+{Mat2}
 
         
             
@@ -3052,7 +3060,7 @@
 
 
 
-
+{Mat2}
 
         
             
@@ -3255,7 +3263,7 @@
 
 
 
-
+{Mat2}
 
         
             
@@ -3481,7 +3489,7 @@
 
 
 
-
+{Mat2}
 
         
             
@@ -3684,7 +3692,7 @@
 
 
 
-
+{Mat2}
 
         
             
@@ -3887,7 +3895,7 @@
 
 
 
-
+{Mat2}
 
         
             
@@ -4379,7 +4387,7 @@
 
 
 
-
+{Mat2}
 
         
             
@@ -4582,7 +4590,7 @@
 
 
 
-
+{Mat2}
 
         
             

--- a/docs/module-mat2d.html
+++ b/docs/module-mat2d.html
@@ -38,7 +38,18 @@
     <div class="container-overview">
     
         
-            <div class="description">A mat2d contains six elements defined as:<pre>[a, c, tx, b, d, ty]</pre>This is a short form for the 3x3 matrix:<pre>[a, c, tx, b, d, ty, 0, 0, 1]</pre>The last row is ignored so the array is shorter and operations are faster.</div>
+            <div class="description">A mat2d contains six elements defined as:
+<pre>
+[a, c, tx,
+ b, d, ty]
+</pre>
+This is a short form for the 3x3 matrix:
+<pre>
+[a, c, tx,
+ b, d, ty,
+ 0, 0, 1]
+</pre>
+The last row is ignored so the array is shorter and operations are faster.</div>
         
 
         
@@ -131,7 +142,7 @@
 
     
 
-    
+    {Mat2d}
 
     
         <h3 class="subsection-title">Methods</h3>
@@ -334,7 +345,7 @@
 </dl>
 
     
-
+{Mat2d}
 
 
 
@@ -491,7 +502,7 @@
 </dl>
 
     
-
+{Mat2d}
 
 
 
@@ -671,7 +682,7 @@
 </dl>
 
     
-
+{Mat2d}
 
 
 
@@ -1453,7 +1464,7 @@
 </dl>
 
     
-
+{Mat2d}
 
 
 
@@ -1472,7 +1483,11 @@
 
 
 <div class="description">
-    Creates a matrix from a given angleThis is equivalent to (but much faster than):    mat2d.identity(dest);    mat2d.rotate(dest, dest, rad);
+    Creates a matrix from a given angle
+This is equivalent to (but much faster than):
+
+    mat2d.identity(dest);
+    mat2d.rotate(dest, dest, rad);
 </div>
 
 
@@ -1629,7 +1644,7 @@
 <span class="param-type">mat2d</span>
 
 
-    </dd>
+    </dd>{Mat2d}
 </dl>
 
     
@@ -1652,7 +1667,11 @@
 
 
 <div class="description">
-    Creates a matrix from a vector scalingThis is equivalent to (but much faster than):    mat2d.identity(dest);    mat2d.scale(dest, dest, vec);
+    Creates a matrix from a vector scaling
+This is equivalent to (but much faster than):
+
+    mat2d.identity(dest);
+    mat2d.scale(dest, dest, vec);
 </div>
 
 
@@ -1805,7 +1824,7 @@
         Type
     </dt>
     <dd>
-        
+        {Mat2d}
 <span class="param-type">mat2d</span>
 
 
@@ -1832,7 +1851,11 @@
 
 
 <div class="description">
-    Creates a matrix from a vector translationThis is equivalent to (but much faster than):    mat2d.identity(dest);    mat2d.translate(dest, dest, vec);
+    Creates a matrix from a vector translation
+This is equivalent to (but much faster than):
+
+    mat2d.identity(dest);
+    mat2d.translate(dest, dest, vec);
 </div>
 
 
@@ -1981,7 +2004,7 @@
 
 
 <dl>
-    <dt>
+    <dt>{Mat2d}
         Type
     </dt>
     <dd>
@@ -2253,7 +2276,7 @@
 
 
 <dl>
-    <dt>
+    <dt>{Mat2d}
         Type
     </dt>
     <dd>
@@ -2410,7 +2433,7 @@
 
 
 <dl>
-    <dt>
+    <dt>{Mat2d}
         Type
     </dt>
     <dd>
@@ -2676,7 +2699,7 @@
     
 </dl>
 
-
+{Mat2d}
 
 
 
@@ -2879,7 +2902,7 @@
 
 
 <dl>
-    <dt>
+    <dt>{Mat2d}
         Type
     </dt>
     <dd>
@@ -3082,7 +3105,7 @@
 
 
 <dl>
-    <dt>
+    <dt>{Mat2d}
         Type
     </dt>
     <dd>
@@ -3308,7 +3331,7 @@
 
 
 <dl>
-    <dt>
+    <dt>{Mat2d}
         Type
     </dt>
     <dd>
@@ -3511,7 +3534,7 @@
 
 
 <dl>
-    <dt>
+    <dt>{Mat2d}
         Type
     </dt>
     <dd>
@@ -3714,7 +3737,7 @@
 
 
 <dl>
-    <dt>
+    <dt>{Mat2d}
         Type
     </dt>
     <dd>
@@ -4252,7 +4275,7 @@
     
 </dl>
 
-
+{Mat2d}
 
 
 
@@ -4455,7 +4478,7 @@
 
 
 <dl>
-    <dt>
+    <dt>{Mat2d}
         Type
     </dt>
     <dd>

--- a/docs/module-mat3.html
+++ b/docs/module-mat3.html
@@ -142,7 +142,7 @@
     
 
     
-    <h4 class="name" id=".add"><span class="type-signature">(static) </span>add<span class="signature">(out, a, b)</span><span class="type-signature"> &rarr; {mat3}</span></h4>
+    <h4 class="name" id=".add"><span class="type-signature">(static) </span>add<span class="signature">(out, a, b)</span><span class="type-signature"> &rarr; {Mat3}</span></h4>
     
 
     
@@ -345,7 +345,7 @@
     
 
     
-    <h4 class="name" id=".adjoint"><span class="type-signature">(static) </span>adjoint<span class="signature">(out, a)</span><span class="type-signature"> &rarr; {mat3}</span></h4>
+    <h4 class="name" id=".adjoint"><span class="type-signature">(static) </span>adjoint<span class="signature">(out, a)</span><span class="type-signature"> &rarr; {Mat3}</span></h4>
     
 
     
@@ -525,7 +525,7 @@
     
 
     
-    <h4 class="name" id=".clone"><span class="type-signature">(static) </span>clone<span class="signature">(a)</span><span class="type-signature"> &rarr; {mat3}</span></h4>
+    <h4 class="name" id=".clone"><span class="type-signature">(static) </span>clone<span class="signature">(a)</span><span class="type-signature"> &rarr; {Mat3}</span></h4>
     
 
     
@@ -682,7 +682,7 @@
     
 
     
-    <h4 class="name" id=".copy"><span class="type-signature">(static) </span>copy<span class="signature">(out, a)</span><span class="type-signature"> &rarr; {mat3}</span></h4>
+    <h4 class="name" id=".copy"><span class="type-signature">(static) </span>copy<span class="signature">(out, a)</span><span class="type-signature"> &rarr; {Mat3}</span></h4>
     
 
     
@@ -862,7 +862,7 @@
     
 
     
-    <h4 class="name" id=".create"><span class="type-signature">(static) </span>create<span class="signature">()</span><span class="type-signature"> &rarr; {mat3}</span></h4>
+    <h4 class="name" id=".create"><span class="type-signature">(static) </span>create<span class="signature">()</span><span class="type-signature"> &rarr; {Mat3}</span></h4>
     
 
     
@@ -1644,7 +1644,7 @@
     
 
     
-    <h4 class="name" id=".fromMat2d"><span class="type-signature">(static) </span>fromMat2d<span class="signature">(out, a)</span><span class="type-signature"> &rarr; {mat3}</span></h4>
+    <h4 class="name" id=".fromMat2d"><span class="type-signature">(static) </span>fromMat2d<span class="signature">(out, a)</span><span class="type-signature"> &rarr; {Mat3}</span></h4>
     
 
     
@@ -1824,7 +1824,7 @@
     
 
     
-    <h4 class="name" id=".fromMat4"><span class="type-signature">(static) </span>fromMat4<span class="signature">(out, a)</span><span class="type-signature"> &rarr; {mat3}</span></h4>
+    <h4 class="name" id=".fromMat4"><span class="type-signature">(static) </span>fromMat4<span class="signature">(out, a)</span><span class="type-signature"> &rarr; {Mat3}</span></h4>
     
 
     
@@ -2004,7 +2004,7 @@
     
 
     
-    <h4 class="name" id=".fromQuat"><span class="type-signature">(static) </span>fromQuat<span class="signature">(out, q)</span><span class="type-signature"> &rarr; {mat3}</span></h4>
+    <h4 class="name" id=".fromQuat"><span class="type-signature">(static) </span>fromQuat<span class="signature">(out, q)</span><span class="type-signature"> &rarr; {Mat3}</span></h4>
     
 
     
@@ -2184,7 +2184,7 @@
     
 
     
-    <h4 class="name" id=".fromRotation"><span class="type-signature">(static) </span>fromRotation<span class="signature">(out, rad)</span><span class="type-signature"> &rarr; {mat3}</span></h4>
+    <h4 class="name" id=".fromRotation"><span class="type-signature">(static) </span>fromRotation<span class="signature">(out, rad)</span><span class="type-signature"> &rarr; {Mat3}</span></h4>
     
 
     
@@ -2192,7 +2192,11 @@
 
 
 <div class="description">
-    Creates a matrix from a given angleThis is equivalent to (but much faster than):    mat3.identity(dest);    mat3.rotate(dest, dest, rad);
+    Creates a matrix from a given angle
+This is equivalent to (but much faster than):
+
+    mat3.identity(dest);
+    mat3.rotate(dest, dest, rad);
 </div>
 
 
@@ -2360,7 +2364,7 @@
 
         
             
-
+{Mat3}
     
 
     
@@ -2372,7 +2376,11 @@
 
 
 <div class="description">
-    Creates a matrix from a vector scalingThis is equivalent to (but much faster than):    mat3.identity(dest);    mat3.scale(dest, dest, vec);
+    Creates a matrix from a vector scaling
+This is equivalent to (but much faster than):
+
+    mat3.identity(dest);
+    mat3.scale(dest, dest, vec);
 </div>
 
 
@@ -2536,7 +2544,7 @@
 
 
 
-
+{Mat3}
 
         
             
@@ -2552,7 +2560,11 @@
 
 
 <div class="description">
-    Creates a matrix from a vector translationThis is equivalent to (but much faster than):    mat3.identity(dest);    mat3.translate(dest, dest, vec);
+    Creates a matrix from a vector translation
+This is equivalent to (but much faster than):
+
+    mat3.identity(dest);
+    mat3.translate(dest, dest, vec);
 </div>
 
 
@@ -2712,7 +2724,7 @@
     </dd>
 </dl>
 
-    
+    {Mat3}
 
 
 
@@ -3053,7 +3065,7 @@
     </dd>
 </dl>
 
-    
+    {Mat3}
 
 
 
@@ -3210,7 +3222,7 @@
     </dd>
 </dl>
 
-    
+    {Mat3}
 
 
 
@@ -3476,7 +3488,7 @@
 
 
 
-
+{Mat3}
 
 
 
@@ -3679,7 +3691,7 @@
     </dd>
 </dl>
 
-    
+    {Mat3}
 
 
 
@@ -3882,7 +3894,7 @@
     </dd>
 </dl>
 
-    
+    {Mat3}
 
 
 
@@ -4108,7 +4120,7 @@
     </dd>
 </dl>
 
-    
+    {Mat3}
 
 
 
@@ -4288,7 +4300,7 @@
     </dd>
 </dl>
 
-    
+    {Mat3}
 
 
 
@@ -4491,7 +4503,7 @@
     </dd>
 </dl>
 
-    
+    {Mat3}
 
 
 
@@ -4694,7 +4706,7 @@
     </dd>
 </dl>
 
-    
+    {Mat3}
 
 
 
@@ -4897,7 +4909,7 @@
     </dd>
 </dl>
 
-    
+    {Mat3}
 
 
 
@@ -5504,7 +5516,7 @@
 
 
 
-
+{Mat3}
 
 
 
@@ -5707,7 +5719,7 @@
     </dd>
 </dl>
 
-    
+    {Mat3}
 
 
 
@@ -5910,7 +5922,7 @@
     </dd>
 </dl>
 
-    
+    {Mat3}
 
 
 

--- a/docs/module-mat4.html
+++ b/docs/module-mat4.html
@@ -142,7 +142,7 @@
     
 
     
-    <h4 class="name" id=".add"><span class="type-signature">(static) </span>add<span class="signature">(out, a, b)</span><span class="type-signature"> &rarr; {mat4}</span></h4>
+    <h4 class="name" id=".add"><span class="type-signature">(static) </span>add<span class="signature">(out, a, b)</span><span class="type-signature"> &rarr; {Mat4}</span></h4>
     
 
     
@@ -345,7 +345,7 @@
     
 
     
-    <h4 class="name" id=".adjoint"><span class="type-signature">(static) </span>adjoint<span class="signature">(out, a)</span><span class="type-signature"> &rarr; {mat4}</span></h4>
+    <h4 class="name" id=".adjoint"><span class="type-signature">(static) </span>adjoint<span class="signature">(out, a)</span><span class="type-signature"> &rarr; {Mat4}</span></h4>
     
 
     
@@ -525,7 +525,7 @@
     
 
     
-    <h4 class="name" id=".clone"><span class="type-signature">(static) </span>clone<span class="signature">(a)</span><span class="type-signature"> &rarr; {mat4}</span></h4>
+    <h4 class="name" id=".clone"><span class="type-signature">(static) </span>clone<span class="signature">(a)</span><span class="type-signature"> &rarr; {Mat4}</span></h4>
     
 
     
@@ -682,7 +682,7 @@
     
 
     
-    <h4 class="name" id=".copy"><span class="type-signature">(static) </span>copy<span class="signature">(out, a)</span><span class="type-signature"> &rarr; {mat4}</span></h4>
+    <h4 class="name" id=".copy"><span class="type-signature">(static) </span>copy<span class="signature">(out, a)</span><span class="type-signature"> &rarr; {Mat4}</span></h4>
     
 
     
@@ -862,7 +862,7 @@
     
 
     
-    <h4 class="name" id=".create"><span class="type-signature">(static) </span>create<span class="signature">()</span><span class="type-signature"> &rarr; {mat4}</span></h4>
+    <h4 class="name" id=".create"><span class="type-signature">(static) </span>create<span class="signature">()</span><span class="type-signature"> &rarr; {Mat4}</span></h4>
     
 
     
@@ -1644,7 +1644,7 @@
     
 
     
-    <h4 class="name" id=".fromQuat"><span class="type-signature">(static) </span>fromQuat<span class="signature">(out, q)</span><span class="type-signature"> &rarr; {mat4}</span></h4>
+    <h4 class="name" id=".fromQuat"><span class="type-signature">(static) </span>fromQuat<span class="signature">(out, q)</span><span class="type-signature"> &rarr; {Mat4}</span></h4>
     
 
     
@@ -1824,7 +1824,7 @@
     
 
     
-    <h4 class="name" id=".fromQuat2"><span class="type-signature">(static) </span>fromQuat2<span class="signature">(out, a)</span><span class="type-signature"> &rarr; {mat4}</span></h4>
+    <h4 class="name" id=".fromQuat2"><span class="type-signature">(static) </span>fromQuat2<span class="signature">(out, a)</span><span class="type-signature"> &rarr; {Mat4}</span></h4>
     
 
     
@@ -2004,7 +2004,7 @@
     
 
     
-    <h4 class="name" id=".fromRotation"><span class="type-signature">(static) </span>fromRotation<span class="signature">(out, rad, axis)</span><span class="type-signature"> &rarr; {mat4}</span></h4>
+    <h4 class="name" id=".fromRotation"><span class="type-signature">(static) </span>fromRotation<span class="signature">(out, rad, axis)</span><span class="type-signature"> &rarr; {Mat4}</span></h4>
     
 
     
@@ -2012,7 +2012,11 @@
 
 
 <div class="description">
-    Creates a matrix from a given angle around a given axisThis is equivalent to (but much faster than):    mat4.identity(dest);    mat4.rotate(dest, dest, rad, axis);
+    Creates a matrix from a given angle around a given axis
+This is equivalent to (but much faster than):
+
+    mat4.identity(dest);
+    mat4.rotate(dest, dest, rad, axis);
 </div>
 
 
@@ -2207,7 +2211,7 @@
     
 
     
-    <h4 class="name" id=".fromRotationTranslation"><span class="type-signature">(static) </span>fromRotationTranslation<span class="signature">(out, q, v)</span><span class="type-signature"> &rarr; {mat4}</span></h4>
+    <h4 class="name" id=".fromRotationTranslation"><span class="type-signature">(static) </span>fromRotationTranslation<span class="signature">(out, q, v)</span><span class="type-signature"> &rarr; {Mat4}</span></h4>
     
 
     
@@ -2215,7 +2219,14 @@
 
 
 <div class="description">
-    Creates a matrix from a quaternion rotation and vector translationThis is equivalent to (but much faster than):    mat4.identity(dest);    mat4.translate(dest, vec);    let quatMat = mat4.create();    quat4.toMat4(quat, quatMat);    mat4.multiply(dest, quatMat);
+    Creates a matrix from a quaternion rotation and vector translation
+This is equivalent to (but much faster than):
+
+    mat4.identity(dest);
+    mat4.translate(dest, vec);
+    let quatMat = mat4.create();
+    quat4.toMat4(quat, quatMat);
+    mat4.multiply(dest, quatMat);
 </div>
 
 
@@ -2410,7 +2421,7 @@
     
 
     
-    <h4 class="name" id=".fromRotationTranslationScale"><span class="type-signature">(static) </span>fromRotationTranslationScale<span class="signature">(out, q, v, s)</span><span class="type-signature"> &rarr; {mat4}</span></h4>
+    <h4 class="name" id=".fromRotationTranslationScale"><span class="type-signature">(static) </span>fromRotationTranslationScale<span class="signature">(out, q, v, s)</span><span class="type-signature"> &rarr; {Mat4}</span></h4>
     
 
     
@@ -2418,7 +2429,15 @@
 
 
 <div class="description">
-    Creates a matrix from a quaternion rotation, vector translation and vector scaleThis is equivalent to (but much faster than):    mat4.identity(dest);    mat4.translate(dest, vec);    let quatMat = mat4.create();    quat4.toMat4(quat, quatMat);    mat4.multiply(dest, quatMat);    mat4.scale(dest, scale)
+    Creates a matrix from a quaternion rotation, vector translation and vector scale
+This is equivalent to (but much faster than):
+
+    mat4.identity(dest);
+    mat4.translate(dest, vec);
+    let quatMat = mat4.create();
+    quat4.toMat4(quat, quatMat);
+    mat4.multiply(dest, quatMat);
+    mat4.scale(dest, scale)
 </div>
 
 
@@ -2636,7 +2655,7 @@
     
 
     
-    <h4 class="name" id=".fromRotationTranslationScaleOrigin"><span class="type-signature">(static) </span>fromRotationTranslationScaleOrigin<span class="signature">(out, q, v, s, o)</span><span class="type-signature"> &rarr; {mat4}</span></h4>
+    <h4 class="name" id=".fromRotationTranslationScaleOrigin"><span class="type-signature">(static) </span>fromRotationTranslationScaleOrigin<span class="signature">(out, q, v, s, o)</span><span class="type-signature"> &rarr; {Mat4}</span></h4>
     
 
     
@@ -2644,7 +2663,17 @@
 
 
 <div class="description">
-    Creates a matrix from a quaternion rotation, vector translation and vector scale, rotating and scaling around the given originThis is equivalent to (but much faster than):    mat4.identity(dest);    mat4.translate(dest, vec);    mat4.translate(dest, origin);    let quatMat = mat4.create();    quat4.toMat4(quat, quatMat);    mat4.multiply(dest, quatMat);    mat4.scale(dest, scale)    mat4.translate(dest, negativeOrigin);
+    Creates a matrix from a quaternion rotation, vector translation and vector scale, rotating and scaling around the given origin
+This is equivalent to (but much faster than):
+
+    mat4.identity(dest);
+    mat4.translate(dest, vec);
+    mat4.translate(dest, origin);
+    let quatMat = mat4.create();
+    quat4.toMat4(quat, quatMat);
+    mat4.multiply(dest, quatMat);
+    mat4.scale(dest, scale)
+    mat4.translate(dest, negativeOrigin);
 </div>
 
 
@@ -2885,7 +2914,7 @@
     
 
     
-    <h4 class="name" id=".fromScaling"><span class="type-signature">(static) </span>fromScaling<span class="signature">(out, v)</span><span class="type-signature"> &rarr; {mat4}</span></h4>
+    <h4 class="name" id=".fromScaling"><span class="type-signature">(static) </span>fromScaling<span class="signature">(out, v)</span><span class="type-signature"> &rarr; {Mat4}</span></h4>
     
 
     
@@ -2893,7 +2922,11 @@
 
 
 <div class="description">
-    Creates a matrix from a vector scalingThis is equivalent to (but much faster than):    mat4.identity(dest);    mat4.scale(dest, dest, vec);
+    Creates a matrix from a vector scaling
+This is equivalent to (but much faster than):
+
+    mat4.identity(dest);
+    mat4.scale(dest, dest, vec);
 </div>
 
 
@@ -3065,7 +3098,7 @@
     
 
     
-    <h4 class="name" id=".fromTranslation"><span class="type-signature">(static) </span>fromTranslation<span class="signature">(out, v)</span><span class="type-signature"> &rarr; {mat4}</span></h4>
+    <h4 class="name" id=".fromTranslation"><span class="type-signature">(static) </span>fromTranslation<span class="signature">(out, v)</span><span class="type-signature"> &rarr; {Mat4}</span></h4>
     
 
     
@@ -3073,7 +3106,11 @@
 
 
 <div class="description">
-    Creates a matrix from a vector translationThis is equivalent to (but much faster than):    mat4.identity(dest);    mat4.translate(dest, dest, vec);
+    Creates a matrix from a vector translation
+This is equivalent to (but much faster than):
+
+    mat4.identity(dest);
+    mat4.translate(dest, dest, vec);
 </div>
 
 
@@ -3245,7 +3282,7 @@
     
 
     
-    <h4 class="name" id=".fromValues"><span class="type-signature">(static) </span>fromValues<span class="signature">(m00, m01, m02, m03, m10, m11, m12, m13, m20, m21, m22, m23, m30, m31, m32, m33)</span><span class="type-signature"> &rarr; {mat4}</span></h4>
+    <h4 class="name" id=".fromValues"><span class="type-signature">(static) </span>fromValues<span class="signature">(m00, m01, m02, m03, m10, m11, m12, m13, m20, m21, m22, m23, m30, m31, m32, m33)</span><span class="type-signature"> &rarr; {Mat4}</span></h4>
     
 
     
@@ -3747,7 +3784,7 @@
     
 
     
-    <h4 class="name" id=".fromXRotation"><span class="type-signature">(static) </span>fromXRotation<span class="signature">(out, rad)</span><span class="type-signature"> &rarr; {mat4}</span></h4>
+    <h4 class="name" id=".fromXRotation"><span class="type-signature">(static) </span>fromXRotation<span class="signature">(out, rad)</span><span class="type-signature"> &rarr; {Mat4}</span></h4>
     
 
     
@@ -3755,7 +3792,11 @@
 
 
 <div class="description">
-    Creates a matrix from the given angle around the X axisThis is equivalent to (but much faster than):    mat4.identity(dest);    mat4.rotateX(dest, dest, rad);
+    Creates a matrix from the given angle around the X axis
+This is equivalent to (but much faster than):
+
+    mat4.identity(dest);
+    mat4.rotateX(dest, dest, rad);
 </div>
 
 
@@ -3927,7 +3968,7 @@
     
 
     
-    <h4 class="name" id=".fromYRotation"><span class="type-signature">(static) </span>fromYRotation<span class="signature">(out, rad)</span><span class="type-signature"> &rarr; {mat4}</span></h4>
+    <h4 class="name" id=".fromYRotation"><span class="type-signature">(static) </span>fromYRotation<span class="signature">(out, rad)</span><span class="type-signature"> &rarr; {Mat4}</span></h4>
     
 
     
@@ -3935,7 +3976,11 @@
 
 
 <div class="description">
-    Creates a matrix from the given angle around the Y axisThis is equivalent to (but much faster than):    mat4.identity(dest);    mat4.rotateY(dest, dest, rad);
+    Creates a matrix from the given angle around the Y axis
+This is equivalent to (but much faster than):
+
+    mat4.identity(dest);
+    mat4.rotateY(dest, dest, rad);
 </div>
 
 
@@ -4107,7 +4152,7 @@
     
 
     
-    <h4 class="name" id=".fromZRotation"><span class="type-signature">(static) </span>fromZRotation<span class="signature">(out, rad)</span><span class="type-signature"> &rarr; {mat4}</span></h4>
+    <h4 class="name" id=".fromZRotation"><span class="type-signature">(static) </span>fromZRotation<span class="signature">(out, rad)</span><span class="type-signature"> &rarr; {Mat4}</span></h4>
     
 
     
@@ -4115,7 +4160,11 @@
 
 
 <div class="description">
-    Creates a matrix from the given angle around the Z axisThis is equivalent to (but much faster than):    mat4.identity(dest);    mat4.rotateZ(dest, dest, rad);
+    Creates a matrix from the given angle around the Z axis
+This is equivalent to (but much faster than):
+
+    mat4.identity(dest);
+    mat4.rotateZ(dest, dest, rad);
 </div>
 
 
@@ -4287,7 +4336,7 @@
     
 
     
-    <h4 class="name" id=".frustum"><span class="type-signature">(static) </span>frustum<span class="signature">(out, left, right, bottom, top, near, far)</span><span class="type-signature"> &rarr; {mat4}</span></h4>
+    <h4 class="name" id=".frustum"><span class="type-signature">(static) </span>frustum<span class="signature">(out, left, right, bottom, top, near, far)</span><span class="type-signature"> &rarr; {Mat4}</span></h4>
     
 
     
@@ -4582,7 +4631,7 @@
     
 
     
-    <h4 class="name" id=".getRotation"><span class="type-signature">(static) </span>getRotation<span class="signature">(out, mat)</span><span class="type-signature"> &rarr; {quat}</span></h4>
+    <h4 class="name" id=".getRotation"><span class="type-signature">(static) </span>getRotation<span class="signature">(out, mat)</span><span class="type-signature"> &rarr; {Quat}</span></h4>
     
 
     
@@ -4590,7 +4639,10 @@
 
 
 <div class="description">
-    Returns a quaternion representing the rotational component of a transformation matrix. If a matrix is built with fromRotationTranslation, the returned quaternion will be the same as the quaternion originally supplied.
+    Returns a quaternion representing the rotational component
+ of a transformation matrix. If a matrix is built with
+ fromRotationTranslation, the returned quaternion will be the
+ same as the quaternion originally supplied.
 </div>
 
 
@@ -4710,7 +4762,7 @@
     </li></ul></dd>
     
 
-    
+    {Vec3}
 
     
 
@@ -4770,7 +4822,11 @@
 
 
 <div class="description">
-    Returns the scaling factor component of a transformation matrix. If a matrix is built with fromRotationTranslationScale with a normalized Quaternion paramter, the returned vector will be the same as the scaling vector originally supplied.
+    Returns the scaling factor component of a transformation
+ matrix. If a matrix is built with fromRotationTranslationScale
+ with a normalized Quaternion paramter, the returned vector will be
+ the same as the scaling vector
+ originally supplied.
 </div>
 
 
@@ -4886,7 +4942,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="mat4.js.html">mat4.js</a>, <a href="mat4.js.html#line985">line 985</a>
+        <a href="mat4.js.html">mat4.js</a>, <a href="mat4.js.html#line985">line 985</a>{Vec3}
     </li></ul></dd>
     
 
@@ -4950,7 +5006,10 @@
 
 
 <div class="description">
-    Returns the translation vector component of a transformation matrix. If a matrix is built with fromRotationTranslation, the returned vector will be the same as the translation vector originally supplied.
+    Returns the translation vector component of a transformation
+ matrix. If a matrix is built with fromRotationTranslation,
+ the returned vector will be the same as the translation vector
+ originally supplied.
 </div>
 
 
@@ -5122,7 +5181,7 @@
     
 
     
-    <h4 class="name" id=".identity"><span class="type-signature">(static) </span>identity<span class="signature">(out)</span><span class="type-signature"> &rarr; {mat4}</span></h4>
+    <h4 class="name" id=".identity"><span class="type-signature">(static) </span>identity<span class="signature">(out)</span><span class="type-signature"> &rarr; {Mat4}</span></h4>
     
 
     
@@ -5279,7 +5338,7 @@
     
 
     
-    <h4 class="name" id=".invert"><span class="type-signature">(static) </span>invert<span class="signature">(out, a)</span><span class="type-signature"> &rarr; {mat4}</span></h4>
+    <h4 class="name" id=".invert"><span class="type-signature">(static) </span>invert<span class="signature">(out, a)</span><span class="type-signature"> &rarr; {Mat4}</span></h4>
     
 
     
@@ -5459,7 +5518,7 @@
     
 
     
-    <h4 class="name" id=".lookAt"><span class="type-signature">(static) </span>lookAt<span class="signature">(out, eye, center, up)</span><span class="type-signature"> &rarr; {mat4}</span></h4>
+    <h4 class="name" id=".lookAt"><span class="type-signature">(static) </span>lookAt<span class="signature">(out, eye, center, up)</span><span class="type-signature"> &rarr; {Mat4}</span></h4>
     
 
     
@@ -5467,7 +5526,8 @@
 
 
 <div class="description">
-    Generates a look-at matrix with the given eye position, focal point, and up axis.If you want a matrix that actually makes an object look at another object, you should use targetTo instead.
+    Generates a look-at matrix with the given eye position, focal point, and up axis.
+If you want a matrix that actually makes an object look at another object, you should use targetTo instead.
 </div>
 
 
@@ -5771,7 +5831,7 @@
     
 
     
-    <h4 class="name" id=".multiply"><span class="type-signature">(static) </span>multiply<span class="signature">(out, a, b)</span><span class="type-signature"> &rarr; {mat4}</span></h4>
+    <h4 class="name" id=".multiply"><span class="type-signature">(static) </span>multiply<span class="signature">(out, a, b)</span><span class="type-signature"> &rarr; {Mat4}</span></h4>
     
 
     
@@ -5974,7 +6034,7 @@
     
 
     
-    <h4 class="name" id=".multiplyScalar"><span class="type-signature">(static) </span>multiplyScalar<span class="signature">(out, a, b)</span><span class="type-signature"> &rarr; {mat4}</span></h4>
+    <h4 class="name" id=".multiplyScalar"><span class="type-signature">(static) </span>multiplyScalar<span class="signature">(out, a, b)</span><span class="type-signature"> &rarr; {Mat4}</span></h4>
     
 
     
@@ -6177,7 +6237,7 @@
     
 
     
-    <h4 class="name" id=".multiplyScalarAndAdd"><span class="type-signature">(static) </span>multiplyScalarAndAdd<span class="signature">(out, a, b, scale)</span><span class="type-signature"> &rarr; {mat4}</span></h4>
+    <h4 class="name" id=".multiplyScalarAndAdd"><span class="type-signature">(static) </span>multiplyScalarAndAdd<span class="signature">(out, a, b, scale)</span><span class="type-signature"> &rarr; {Mat4}</span></h4>
     
 
     
@@ -6403,7 +6463,7 @@
     
 
     
-    <h4 class="name" id=".ortho"><span class="type-signature">(static) </span>ortho<span class="signature">(out, left, right, bottom, top, near, far)</span><span class="type-signature"> &rarr; {mat4}</span></h4>
+    <h4 class="name" id=".ortho"><span class="type-signature">(static) </span>ortho<span class="signature">(out, left, right, bottom, top, near, far)</span><span class="type-signature"> &rarr; {Mat4}</span></h4>
     
 
     
@@ -6698,7 +6758,7 @@
     
 
     
-    <h4 class="name" id=".perspective"><span class="type-signature">(static) </span>perspective<span class="signature">(out, fovy, aspect, near, far)</span><span class="type-signature"> &rarr; {mat4}</span></h4>
+    <h4 class="name" id=".perspective"><span class="type-signature">(static) </span>perspective<span class="signature">(out, fovy, aspect, near, far)</span><span class="type-signature"> &rarr; {Mat4}</span></h4>
     
 
     
@@ -6706,7 +6766,8 @@
 
 
 <div class="description">
-    Generates a perspective projection matrix with the given bounds.Passing null/undefined/no value for far will generate infinite projection matrix.
+    Generates a perspective projection matrix with the given bounds.
+Passing null/undefined/no value for far will generate infinite projection matrix.
 </div>
 
 
@@ -6947,7 +7008,7 @@
     
 
     
-    <h4 class="name" id=".perspectiveFromFieldOfView"><span class="type-signature">(static) </span>perspectiveFromFieldOfView<span class="signature">(out, fov, near, far)</span><span class="type-signature"> &rarr; {mat4}</span></h4>
+    <h4 class="name" id=".perspectiveFromFieldOfView"><span class="type-signature">(static) </span>perspectiveFromFieldOfView<span class="signature">(out, fov, near, far)</span><span class="type-signature"> &rarr; {Mat4}</span></h4>
     
 
     
@@ -6955,7 +7016,9 @@
 
 
 <div class="description">
-    Generates a perspective projection matrix with the given field of view.This is primarily useful for generating projection matrices to be usedwith the still experiemental WebVR API.
+    Generates a perspective projection matrix with the given field of view.
+This is primarily useful for generating projection matrices to be used
+with the still experiemental WebVR API.
 </div>
 
 
@@ -7173,7 +7236,7 @@
     
 
     
-    <h4 class="name" id=".rotate"><span class="type-signature">(static) </span>rotate<span class="signature">(out, a, rad, axis)</span><span class="type-signature"> &rarr; {mat4}</span></h4>
+    <h4 class="name" id=".rotate"><span class="type-signature">(static) </span>rotate<span class="signature">(out, a, rad, axis)</span><span class="type-signature"> &rarr; {Mat4}</span></h4>
     
 
     
@@ -7399,7 +7462,7 @@
     
 
     
-    <h4 class="name" id=".rotateX"><span class="type-signature">(static) </span>rotateX<span class="signature">(out, a, rad)</span><span class="type-signature"> &rarr; {mat4}</span></h4>
+    <h4 class="name" id=".rotateX"><span class="type-signature">(static) </span>rotateX<span class="signature">(out, a, rad)</span><span class="type-signature"> &rarr; {Mat4}</span></h4>
     
 
     
@@ -7602,7 +7665,7 @@
     
 
     
-    <h4 class="name" id=".rotateY"><span class="type-signature">(static) </span>rotateY<span class="signature">(out, a, rad)</span><span class="type-signature"> &rarr; {mat4}</span></h4>
+    <h4 class="name" id=".rotateY"><span class="type-signature">(static) </span>rotateY<span class="signature">(out, a, rad)</span><span class="type-signature"> &rarr; {Mat4}</span></h4>
     
 
     
@@ -7805,7 +7868,7 @@
     
 
     
-    <h4 class="name" id=".rotateZ"><span class="type-signature">(static) </span>rotateZ<span class="signature">(out, a, rad)</span><span class="type-signature"> &rarr; {mat4}</span></h4>
+    <h4 class="name" id=".rotateZ"><span class="type-signature">(static) </span>rotateZ<span class="signature">(out, a, rad)</span><span class="type-signature"> &rarr; {Mat4}</span></h4>
     
 
     
@@ -8008,7 +8071,7 @@
     
 
     
-    <h4 class="name" id=".scale"><span class="type-signature">(static) </span>scale<span class="signature">(out, a, v)</span><span class="type-signature"> &rarr; {mat4}</span></h4>
+    <h4 class="name" id=".scale"><span class="type-signature">(static) </span>scale<span class="signature">(out, a, v)</span><span class="type-signature"> &rarr; {Mat4}</span></h4>
     
 
     
@@ -8211,7 +8274,7 @@
     
 
     
-    <h4 class="name" id=".set"><span class="type-signature">(static) </span>set<span class="signature">(out, m00, m01, m02, m03, m10, m11, m12, m13, m20, m21, m22, m23, m30, m31, m32, m33)</span><span class="type-signature"> &rarr; {mat4}</span></h4>
+    <h4 class="name" id=".set"><span class="type-signature">(static) </span>set<span class="signature">(out, m00, m01, m02, m03, m10, m11, m12, m13, m20, m21, m22, m23, m30, m31, m32, m33)</span><span class="type-signature"> &rarr; {Mat4}</span></h4>
     
 
     
@@ -8979,7 +9042,7 @@
     
 
     
-    <h4 class="name" id=".subtract"><span class="type-signature">(static) </span>subtract<span class="signature">(out, a, b)</span><span class="type-signature"> &rarr; {mat4}</span></h4>
+    <h4 class="name" id=".subtract"><span class="type-signature">(static) </span>subtract<span class="signature">(out, a, b)</span><span class="type-signature"> &rarr; {Mat4}</span></h4>
     
 
     
@@ -9182,7 +9245,7 @@
     
 
     
-    <h4 class="name" id=".targetTo"><span class="type-signature">(static) </span>targetTo<span class="signature">(out, eye, center, up)</span><span class="type-signature"> &rarr; {mat4}</span></h4>
+    <h4 class="name" id=".targetTo"><span class="type-signature">(static) </span>targetTo<span class="signature">(out, eye, center, up)</span><span class="type-signature"> &rarr; {Mat4}</span></h4>
     
 
     
@@ -9408,7 +9471,7 @@
     
 
     
-    <h4 class="name" id=".translate"><span class="type-signature">(static) </span>translate<span class="signature">(out, a, v)</span><span class="type-signature"> &rarr; {mat4}</span></h4>
+    <h4 class="name" id=".translate"><span class="type-signature">(static) </span>translate<span class="signature">(out, a, v)</span><span class="type-signature"> &rarr; {Mat4}</span></h4>
     
 
     
@@ -9611,7 +9674,7 @@
     
 
     
-    <h4 class="name" id=".transpose"><span class="type-signature">(static) </span>transpose<span class="signature">(out, a)</span><span class="type-signature"> &rarr; {mat4}</span></h4>
+    <h4 class="name" id=".transpose"><span class="type-signature">(static) </span>transpose<span class="signature">(out, a)</span><span class="type-signature"> &rarr; {Mat4}</span></h4>
     
 
     

--- a/docs/module-quat.html
+++ b/docs/module-quat.html
@@ -328,7 +328,10 @@
 
 
 <div class="description">
-    Sets a quaternion to represent the shortest rotation from onevector to another.Both vectors are assumed to be unit length.
+    Sets a quaternion to represent the shortest rotation from one
+vector to another.
+
+Both vectors are assumed to be unit length.
 </div>
 
 
@@ -390,7 +393,9 @@
 
 
 <div class="description">
-    Sets the specified quaternion with values corresponding to the givenaxes. Each axis is a vec3 and is expected to be unit length andperpendicular to all other specified axes.
+    Sets the specified quaternion with values corresponding to the given
+axes. Each axis is a vec3 and is expected to be unit length and
+perpendicular to all other specified axes.
 </div>
 
 
@@ -513,7 +518,7 @@
         <h3 class="subsection-title">Methods</h3>
 
         
-            
+            {Quat}
 
     
 
@@ -716,7 +721,7 @@
 
 
         
-            
+            {Quat}
 
     
 
@@ -729,7 +734,9 @@
 
 
 <div class="description">
-    Calculates the W component of a quat from the X, Y, and Z components.Assumes that quaternion is 1 unit in length.Any existing W component will be ignored.
+    Calculates the W component of a quat from the X, Y, and Z components.
+Assumes that quaternion is 1 unit in length.
+Any existing W component will be ignored.
 </div>
 
 
@@ -894,7 +901,7 @@
 
 
 
-
+{Quat}
         
             
 
@@ -1051,7 +1058,7 @@
 
 
 
-
+{Quat}
         
             
 
@@ -1066,7 +1073,8 @@
 
 
 <div class="description">
-    Calculates the conjugate of a quatIf the quaternion is normalized, this function is faster than quat.inverse and produces the same result.
+    Calculates the conjugate of a quat
+If the quaternion is normalized, this function is faster than quat.inverse and produces the same result.
 </div>
 
 
@@ -1230,7 +1238,7 @@
 
 
 
-
+{Quat}
 
         
             
@@ -1410,7 +1418,7 @@
 
 
 
-
+{Quat}
 
         
             
@@ -1698,7 +1706,7 @@
 
 
 
-
+{Quat}
 
         
             
@@ -1924,7 +1932,7 @@
 
 
 
-
+{Quat}
 
         
             
@@ -1940,7 +1948,10 @@
 
 
 <div class="description">
-    Creates a quaternion from the given 3x3 rotation matrix.NOTE: The resultant quaternion is not normalized, so you should be sureto renormalize the quaternion yourself where necessary.
+    Creates a quaternion from the given 3x3 rotation matrix.
+
+NOTE: The resultant quaternion is not normalized, so you should be sure
+to renormalize the quaternion yourself where necessary.
 </div>
 
 
@@ -2101,7 +2112,7 @@
 </dl>
 
     
-
+{Quat}
 
 
 
@@ -2346,7 +2357,14 @@
 
 
 <div class="description">
-    Gets the rotation axis and angle for a given quaternion. If a quaternion is created with setAxisAngle, this method will return the same values as providied in the original parameter list OR functionally equivalent values.Example: The quaternion formed by axis [0, 0, 1] and angle -90 is the same as the quaternion formed by [0, 0, 1] and 270. This method favors the latter.
+    Gets the rotation axis and angle for a given
+ quaternion. If a quaternion is created with
+ setAxisAngle, this method will return the same
+ values as providied in the original parameter list
+ OR functionally equivalent values.
+Example: The quaternion formed by axis [0, 0, 1] and
+ angle -90 is the same as the quaternion formed by
+ [0, 0, 1] and 270. This method favors the latter.
 </div>
 
 
@@ -2500,7 +2518,7 @@
     </dt>
     <dd>
         
-<span class="param-type">Number</span>
+<span class="param-type">Number</span>{Quat}
 
 
     </dd>
@@ -2657,7 +2675,7 @@
     </dt>
     <dd>
         
-<span class="param-type">quat</span>
+<span class="param-type">quat</span>{Quat}
 
 
     </dd>
@@ -2923,7 +2941,7 @@
 
 
 
-
+{Quat}
 
 
 
@@ -3235,7 +3253,7 @@
 
 
 
-
+{Quat}
 
 
 
@@ -3438,7 +3456,7 @@
     </dt>
     <dd>
         
-<span class="param-type">quat</span>
+<span class="param-type">quat</span>{Quat}
 
 
     </dd>
@@ -3618,7 +3636,7 @@
     </dt>
     <dd>
         
-<span class="param-type">quat</span>
+<span class="param-type">quat</span>{Quat}
 
 
     </dd>
@@ -3775,7 +3793,7 @@
     </dt>
     <dd>
         
-<span class="param-type">quat</span>
+<span class="param-type">quat</span>{Quat}
 
 
     </dd>
@@ -3978,7 +3996,7 @@
     </dt>
     <dd>
         
-<span class="param-type">quat</span>
+<span class="param-type">quat</span>{Quat}
 
 
     </dd>
@@ -4181,7 +4199,7 @@
     </dt>
     <dd>
         
-<span class="param-type">quat</span>
+<span class="param-type">quat</span>{Quat}
 
 
     </dd>
@@ -4384,7 +4402,7 @@
     </dt>
     <dd>
         
-<span class="param-type">quat</span>
+<span class="param-type">quat</span>{Quat}
 
 
     </dd>
@@ -4587,7 +4605,7 @@
     </dt>
     <dd>
         
-<span class="param-type">quat</span>
+<span class="param-type">quat</span>{Quat}
 
 
     </dd>
@@ -4836,7 +4854,7 @@
     </dt>
     <dd>
         
-<span class="param-type">quat</span>
+<span class="param-type">quat</span>{Quat}
 
 
     </dd>
@@ -4862,7 +4880,8 @@
 
 
 <div class="description">
-    Sets a quat from the given angle and rotation axis,then returns it.
+    Sets a quat from the given angle and rotation axis,
+then returns it.
 </div>
 
 
@@ -5038,7 +5057,7 @@
         Type
     </dt>
     <dd>
-        
+        {Quat}
 <span class="param-type">quat</span>
 
 

--- a/docs/module-quat2.html
+++ b/docs/module-quat2.html
@@ -38,7 +38,10 @@
     <div class="container-overview">
     
         
-            <div class="description">Dual Quaternion<br>Format: [real, dual]<br>Quaternion format: XYZW<br>Make sure to have normalized dual quaternions, otherwise the functions may not work as intended.<br></div>
+            <div class="description">Dual Quaternion<br>
+Format: [real, dual]<br>
+Quaternion format: XYZW<br>
+Make sure to have normalized dual quaternions, otherwise the functions may not work as intended.<br></div>
         
 
         
@@ -208,7 +211,7 @@
     
 
     
-    <h4 class="name" id=".add"><span class="type-signature">(static) </span>add<span class="signature">(out, a, b)</span><span class="type-signature"> &rarr; {quat2}</span></h4>
+    <h4 class="name" id=".add"><span class="type-signature">(static) </span>add<span class="signature">(out, a, b)</span><span class="type-signature"> &rarr; {Quat2}</span></h4>
     
 
     
@@ -411,7 +414,7 @@
     
 
     
-    <h4 class="name" id=".clone"><span class="type-signature">(static) </span>clone<span class="signature">(a)</span><span class="type-signature"> &rarr; {quat2}</span></h4>
+    <h4 class="name" id=".clone"><span class="type-signature">(static) </span>clone<span class="signature">(a)</span><span class="type-signature"> &rarr; {Quat2}</span></h4>
     
 
     
@@ -568,7 +571,7 @@
     
 
     
-    <h4 class="name" id=".conjugate"><span class="type-signature">(static) </span>conjugate<span class="signature">(out, a)</span><span class="type-signature"> &rarr; {quat2}</span></h4>
+    <h4 class="name" id=".conjugate"><span class="type-signature">(static) </span>conjugate<span class="signature">(out, a)</span><span class="type-signature"> &rarr; {Quat2}</span></h4>
     
 
     
@@ -576,7 +579,8 @@
 
 
 <div class="description">
-    Calculates the conjugate of a dual quatIf the dual quaternion is normalized, this function is faster than quat2.inverse and produces the same result.
+    Calculates the conjugate of a dual quat
+If the dual quaternion is normalized, this function is faster than quat2.inverse and produces the same result.
 </div>
 
 
@@ -748,7 +752,7 @@
     
 
     
-    <h4 class="name" id=".copy"><span class="type-signature">(static) </span>copy<span class="signature">(out, a)</span><span class="type-signature"> &rarr; {quat2}</span></h4>
+    <h4 class="name" id=".copy"><span class="type-signature">(static) </span>copy<span class="signature">(out, a)</span><span class="type-signature"> &rarr; {Quat2}</span></h4>
     
 
     
@@ -928,7 +932,7 @@
     
 
     
-    <h4 class="name" id=".create"><span class="type-signature">(static) </span>create<span class="signature">()</span><span class="type-signature"> &rarr; {quat2}</span></h4>
+    <h4 class="name" id=".create"><span class="type-signature">(static) </span>create<span class="signature">()</span><span class="type-signature"> &rarr; {Quat2}</span></h4>
     
 
     
@@ -1576,7 +1580,7 @@
     
 
     
-    <h4 class="name" id=".fromMat4"><span class="type-signature">(static) </span>fromMat4<span class="signature">(out, a)</span><span class="type-signature"> &rarr; {quat2}</span></h4>
+    <h4 class="name" id=".fromMat4"><span class="type-signature">(static) </span>fromMat4<span class="signature">(out, a)</span><span class="type-signature"> &rarr; {Quat2}</span></h4>
     
 
     
@@ -1756,7 +1760,7 @@
     
 
     
-    <h4 class="name" id=".fromRotation"><span class="type-signature">(static) </span>fromRotation<span class="signature">(dual, q)</span><span class="type-signature"> &rarr; {quat2}</span></h4>
+    <h4 class="name" id=".fromRotation"><span class="type-signature">(static) </span>fromRotation<span class="signature">(dual, q)</span><span class="type-signature"> &rarr; {Quat2}</span></h4>
     
 
     
@@ -1936,7 +1940,7 @@
     
 
     
-    <h4 class="name" id=".fromRotationTranslation"><span class="type-signature">(static) </span>fromRotationTranslation<span class="signature">(dual, q, t)</span><span class="type-signature"> &rarr; {quat2}</span></h4>
+    <h4 class="name" id=".fromRotationTranslation"><span class="type-signature">(static) </span>fromRotationTranslation<span class="signature">(dual, q, t)</span><span class="type-signature"> &rarr; {Quat2}</span></h4>
     
 
     
@@ -2139,7 +2143,7 @@
     
 
     
-    <h4 class="name" id=".fromRotationTranslationValues"><span class="type-signature">(static) </span>fromRotationTranslationValues<span class="signature">(x1, y1, z1, w1, x2, y2, z2)</span><span class="type-signature"> &rarr; {quat2}</span></h4>
+    <h4 class="name" id=".fromRotationTranslationValues"><span class="type-signature">(static) </span>fromRotationTranslationValues<span class="signature">(x1, y1, z1, w1, x2, y2, z2)</span><span class="type-signature"> &rarr; {Quat2}</span></h4>
     
 
     
@@ -2434,7 +2438,7 @@
     
 
     
-    <h4 class="name" id=".fromTranslation"><span class="type-signature">(static) </span>fromTranslation<span class="signature">(dual, t)</span><span class="type-signature"> &rarr; {quat2}</span></h4>
+    <h4 class="name" id=".fromTranslation"><span class="type-signature">(static) </span>fromTranslation<span class="signature">(dual, t)</span><span class="type-signature"> &rarr; {Quat2}</span></h4>
     
 
     
@@ -2614,7 +2618,7 @@
     
 
     
-    <h4 class="name" id=".fromValues"><span class="type-signature">(static) </span>fromValues<span class="signature">(x1, y1, z1, w1, x2, y2, z2, w2)</span><span class="type-signature"> &rarr; {quat2}</span></h4>
+    <h4 class="name" id=".fromValues"><span class="type-signature">(static) </span>fromValues<span class="signature">(x1, y1, z1, w1, x2, y2, z2, w2)</span><span class="type-signature"> &rarr; {Quat2}</span></h4>
     
 
     
@@ -2932,7 +2936,7 @@
     
 
     
-    <h4 class="name" id=".getDual"><span class="type-signature">(static) </span>getDual<span class="signature">(out, a)</span><span class="type-signature"> &rarr; {quat}</span></h4>
+    <h4 class="name" id=".getDual"><span class="type-signature">(static) </span>getDual<span class="signature">(out, a)</span><span class="type-signature"> &rarr; {Quat}</span></h4>
     
 
     
@@ -3108,7 +3112,7 @@
 
         
             
-
+{Vec3}
     
 
     
@@ -3292,7 +3296,7 @@
     
 
     
-    <h4 class="name" id=".identity"><span class="type-signature">(static) </span>identity<span class="signature">(out)</span><span class="type-signature"> &rarr; {quat2}</span></h4>
+    <h4 class="name" id=".identity"><span class="type-signature">(static) </span>identity<span class="signature">(out)</span><span class="type-signature"> &rarr; {Quat2}</span></h4>
     
 
     
@@ -3449,7 +3453,7 @@
     
 
     
-    <h4 class="name" id=".invert"><span class="type-signature">(static) </span>invert<span class="signature">(out, a)</span><span class="type-signature"> &rarr; {quat2}</span></h4>
+    <h4 class="name" id=".invert"><span class="type-signature">(static) </span>invert<span class="signature">(out, a)</span><span class="type-signature"> &rarr; {Quat2}</span></h4>
     
 
     
@@ -3872,7 +3876,7 @@
     
 
     
-    <h4 class="name" id=".lerp"><span class="type-signature">(static) </span>lerp<span class="signature">(out, a, b, t)</span><span class="type-signature"> &rarr; {quat2}</span></h4>
+    <h4 class="name" id=".lerp"><span class="type-signature">(static) </span>lerp<span class="signature">(out, a, b, t)</span><span class="type-signature"> &rarr; {Quat2}</span></h4>
     
 
     
@@ -3880,7 +3884,8 @@
 
 
 <div class="description">
-    Performs a linear interpolation between two dual quats'sNOTE: The resulting dual quaternions won't always be normalized (The error is most noticeable when t = 0.5)
+    Performs a linear interpolation between two dual quats's
+NOTE: The resulting dual quaternions won't always be normalized (The error is most noticeable when t = 0.5)
 </div>
 
 
@@ -4184,7 +4189,7 @@
     
 
     
-    <h4 class="name" id=".multiply"><span class="type-signature">(static) </span>multiply<span class="signature">(out, a, b)</span><span class="type-signature"> &rarr; {quat2}</span></h4>
+    <h4 class="name" id=".multiply"><span class="type-signature">(static) </span>multiply<span class="signature">(out, a, b)</span><span class="type-signature"> &rarr; {Quat2}</span></h4>
     
 
     
@@ -4387,7 +4392,7 @@
     
 
     
-    <h4 class="name" id=".normalize"><span class="type-signature">(static) </span>normalize<span class="signature">(out, a)</span><span class="type-signature"> &rarr; {quat2}</span></h4>
+    <h4 class="name" id=".normalize"><span class="type-signature">(static) </span>normalize<span class="signature">(out, a)</span><span class="type-signature"> &rarr; {Quat2}</span></h4>
     
 
     
@@ -4567,7 +4572,7 @@
     
 
     
-    <h4 class="name" id=".rotateAroundAxis"><span class="type-signature">(static) </span>rotateAroundAxis<span class="signature">(out, a, axis, rad)</span><span class="type-signature"> &rarr; {quat2}</span></h4>
+    <h4 class="name" id=".rotateAroundAxis"><span class="type-signature">(static) </span>rotateAroundAxis<span class="signature">(out, a, axis, rad)</span><span class="type-signature"> &rarr; {Quat2}</span></h4>
     
 
     
@@ -4793,7 +4798,7 @@
     
 
     
-    <h4 class="name" id=".rotateByQuatAppend"><span class="type-signature">(static) </span>rotateByQuatAppend<span class="signature">(out, a, q)</span><span class="type-signature"> &rarr; {quat2}</span></h4>
+    <h4 class="name" id=".rotateByQuatAppend"><span class="type-signature">(static) </span>rotateByQuatAppend<span class="signature">(out, a, q)</span><span class="type-signature"> &rarr; {Quat2}</span></h4>
     
 
     
@@ -4996,7 +5001,7 @@
     
 
     
-    <h4 class="name" id=".rotateByQuatPrepend"><span class="type-signature">(static) </span>rotateByQuatPrepend<span class="signature">(out, q, a)</span><span class="type-signature"> &rarr; {quat2}</span></h4>
+    <h4 class="name" id=".rotateByQuatPrepend"><span class="type-signature">(static) </span>rotateByQuatPrepend<span class="signature">(out, q, a)</span><span class="type-signature"> &rarr; {Quat2}</span></h4>
     
 
     
@@ -5199,7 +5204,7 @@
     
 
     
-    <h4 class="name" id=".rotateX"><span class="type-signature">(static) </span>rotateX<span class="signature">(out, a, rad)</span><span class="type-signature"> &rarr; {quat2}</span></h4>
+    <h4 class="name" id=".rotateX"><span class="type-signature">(static) </span>rotateX<span class="signature">(out, a, rad)</span><span class="type-signature"> &rarr; {Quat2}</span></h4>
     
 
     
@@ -5402,7 +5407,7 @@
     
 
     
-    <h4 class="name" id=".rotateY"><span class="type-signature">(static) </span>rotateY<span class="signature">(out, a, rad)</span><span class="type-signature"> &rarr; {quat2}</span></h4>
+    <h4 class="name" id=".rotateY"><span class="type-signature">(static) </span>rotateY<span class="signature">(out, a, rad)</span><span class="type-signature"> &rarr; {Quat2}</span></h4>
     
 
     
@@ -5605,7 +5610,7 @@
     
 
     
-    <h4 class="name" id=".rotateZ"><span class="type-signature">(static) </span>rotateZ<span class="signature">(out, a, rad)</span><span class="type-signature"> &rarr; {quat2}</span></h4>
+    <h4 class="name" id=".rotateZ"><span class="type-signature">(static) </span>rotateZ<span class="signature">(out, a, rad)</span><span class="type-signature"> &rarr; {Quat2}</span></h4>
     
 
     
@@ -5808,7 +5813,7 @@
     
 
     
-    <h4 class="name" id=".scale"><span class="type-signature">(static) </span>scale<span class="signature">(out, a, b)</span><span class="type-signature"> &rarr; {quat2}</span></h4>
+    <h4 class="name" id=".scale"><span class="type-signature">(static) </span>scale<span class="signature">(out, a, b)</span><span class="type-signature"> &rarr; {Quat2}</span></h4>
     
 
     
@@ -6011,7 +6016,7 @@
     
 
     
-    <h4 class="name" id=".set"><span class="type-signature">(static) </span>set<span class="signature">(out, x1, y1, z1, w1, x2, y2, z2, w2)</span><span class="type-signature"> &rarr; {quat2}</span></h4>
+    <h4 class="name" id=".set"><span class="type-signature">(static) </span>set<span class="signature">(out, x1, y1, z1, w1, x2, y2, z2, w2)</span><span class="type-signature"> &rarr; {Quat2}</span></h4>
     
 
     
@@ -6352,7 +6357,7 @@
     
 
     
-    <h4 class="name" id=".setDual"><span class="type-signature">(static) </span>setDual<span class="signature">(out, q)</span><span class="type-signature"> &rarr; {quat2}</span></h4>
+    <h4 class="name" id=".setDual"><span class="type-signature">(static) </span>setDual<span class="signature">(out, q)</span><span class="type-signature"> &rarr; {Quat2}</span></h4>
     
 
     
@@ -6532,7 +6537,7 @@
     
 
     
-    <h4 class="name" id=".setReal"><span class="type-signature">(static) </span>setReal<span class="signature">(out, q)</span><span class="type-signature"> &rarr; {quat2}</span></h4>
+    <h4 class="name" id=".setReal"><span class="type-signature">(static) </span>setReal<span class="signature">(out, q)</span><span class="type-signature"> &rarr; {Quat2}</span></h4>
     
 
     
@@ -7112,7 +7117,7 @@
     
 
     
-    <h4 class="name" id=".translate"><span class="type-signature">(static) </span>translate<span class="signature">(out, a, v)</span><span class="type-signature"> &rarr; {quat2}</span></h4>
+    <h4 class="name" id=".translate"><span class="type-signature">(static) </span>translate<span class="signature">(out, a, v)</span><span class="type-signature"> &rarr; {Quat2}</span></h4>
     
 
     

--- a/docs/module-vec2.html
+++ b/docs/module-vec2.html
@@ -142,7 +142,7 @@
     
 
     
-    <h4 class="name" id=".add"><span class="type-signature">(static) </span>add<span class="signature">(out, a, b)</span><span class="type-signature"> &rarr; {vec2}</span></h4>
+    <h4 class="name" id=".add"><span class="type-signature">(static) </span>add<span class="signature">(out, a, b)</span><span class="type-signature"> &rarr; {Vec2}</span></h4>
     
 
     
@@ -525,7 +525,7 @@
     
 
     
-    <h4 class="name" id=".ceil"><span class="type-signature">(static) </span>ceil<span class="signature">(out, a)</span><span class="type-signature"> &rarr; {vec2}</span></h4>
+    <h4 class="name" id=".ceil"><span class="type-signature">(static) </span>ceil<span class="signature">(out, a)</span><span class="type-signature"> &rarr; {Vec2}</span></h4>
     
 
     
@@ -705,7 +705,7 @@
     
 
     
-    <h4 class="name" id=".clone"><span class="type-signature">(static) </span>clone<span class="signature">(a)</span><span class="type-signature"> &rarr; {vec2}</span></h4>
+    <h4 class="name" id=".clone"><span class="type-signature">(static) </span>clone<span class="signature">(a)</span><span class="type-signature"> &rarr; {Vec2}</span></h4>
     
 
     
@@ -862,7 +862,7 @@
     
 
     
-    <h4 class="name" id=".copy"><span class="type-signature">(static) </span>copy<span class="signature">(out, a)</span><span class="type-signature"> &rarr; {vec2}</span></h4>
+    <h4 class="name" id=".copy"><span class="type-signature">(static) </span>copy<span class="signature">(out, a)</span><span class="type-signature"> &rarr; {Vec2}</span></h4>
     
 
     
@@ -1042,7 +1042,7 @@
     
 
     
-    <h4 class="name" id=".create"><span class="type-signature">(static) </span>create<span class="signature">()</span><span class="type-signature"> &rarr; {vec2}</span></h4>
+    <h4 class="name" id=".create"><span class="type-signature">(static) </span>create<span class="signature">()</span><span class="type-signature"> &rarr; {Vec2}</span></h4>
     
 
     
@@ -1150,7 +1150,7 @@
     
 
     
-    <h4 class="name" id=".cross"><span class="type-signature">(static) </span>cross<span class="signature">(out, a, b)</span><span class="type-signature"> &rarr; {vec3}</span></h4>
+    <h4 class="name" id=".cross"><span class="type-signature">(static) </span>cross<span class="signature">(out, a, b)</span><span class="type-signature"> &rarr; {Vec3}</span></h4>
     
 
     
@@ -1158,7 +1158,8 @@
 
 
 <div class="description">
-    Computes the cross product of two vec2'sNote that the cross product must by definition produce a 3D vector
+    Computes the cross product of two vec2's
+Note that the cross product must by definition produce a 3D vector
 </div>
 
 
@@ -1704,7 +1705,7 @@
 
     
 
-    
+    {Vec2}
     <h4 class="name" id=".divide"><span class="type-signature">(static) </span>divide<span class="signature">(out, a, b)</span><span class="type-signature"> &rarr; {vec2}</span></h4>
     
 
@@ -2447,7 +2448,7 @@
 
     
 
-    
+    {Vec2}
     <h4 class="name" id=".floor"><span class="type-signature">(static) </span>floor<span class="signature">(out, a)</span><span class="type-signature"> &rarr; {vec2}</span></h4>
     
 
@@ -2951,7 +2952,7 @@
 
     
 
-    
+    {Vec2}
     <h4 class="name" id=".fromValues"><span class="type-signature">(static) </span>fromValues<span class="signature">(x, y)</span><span class="type-signature"> &rarr; {vec2}</span></h4>
     
 
@@ -3131,7 +3132,7 @@
 
     
 
-    
+    {Vec2}
     <h4 class="name" id=".inverse"><span class="type-signature">(static) </span>inverse<span class="signature">(out, a)</span><span class="type-signature"> &rarr; {vec2}</span></h4>
     
 
@@ -3554,7 +3555,7 @@
 
     
 
-    
+    {Vec2}
     <h4 class="name" id=".lerp"><span class="type-signature">(static) </span>lerp<span class="signature">(out, a, b, t)</span><span class="type-signature"> &rarr; {vec2}</span></h4>
     
 
@@ -3780,7 +3781,7 @@
 
     
 
-    
+    {Vec2}
     <h4 class="name" id=".max"><span class="type-signature">(static) </span>max<span class="signature">(out, a, b)</span><span class="type-signature"> &rarr; {vec2}</span></h4>
     
 
@@ -3983,7 +3984,7 @@
 
     
 
-    
+    {Vec2}
     <h4 class="name" id=".min"><span class="type-signature">(static) </span>min<span class="signature">(out, a, b)</span><span class="type-signature"> &rarr; {vec2}</span></h4>
     
 
@@ -4272,7 +4273,7 @@
 
     
 
-    
+    {Vec2}
     <h4 class="name" id=".multiply"><span class="type-signature">(static) </span>multiply<span class="signature">(out, a, b)</span><span class="type-signature"> &rarr; {vec2}</span></h4>
     
 
@@ -4475,7 +4476,7 @@
 
     
 
-    
+    {Vec2}
     <h4 class="name" id=".negate"><span class="type-signature">(static) </span>negate<span class="signature">(out, a)</span><span class="type-signature"> &rarr; {vec2}</span></h4>
     
 
@@ -4655,7 +4656,7 @@
 
     
 
-    
+    {Vec2}
     <h4 class="name" id=".normalize"><span class="type-signature">(static) </span>normalize<span class="signature">(out, a)</span><span class="type-signature"> &rarr; {vec2}</span></h4>
     
 
@@ -4835,7 +4836,7 @@
 
     
 
-    
+    {Vec2}
     <h4 class="name" id=".random"><span class="type-signature">(static) </span>random<span class="signature">(out, scale<span class="signature-attributes">opt</span>)</span><span class="type-signature"> &rarr; {vec2}</span></h4>
     
 
@@ -5035,7 +5036,7 @@
 
     
 
-    
+    {Vec2}
     <h4 class="name" id=".rotate"><span class="type-signature">(static) </span>rotate<span class="signature">(out, a, b, c)</span><span class="type-signature"> &rarr; {vec2}</span></h4>
     
 
@@ -5261,7 +5262,7 @@
 
     
 
-    
+    {Vec2}
     <h4 class="name" id=".round"><span class="type-signature">(static) </span>round<span class="signature">(out, a)</span><span class="type-signature"> &rarr; {vec2}</span></h4>
     
 
@@ -5441,7 +5442,7 @@
 
     
 
-    
+    {Vec2}
     <h4 class="name" id=".scale"><span class="type-signature">(static) </span>scale<span class="signature">(out, a, b)</span><span class="type-signature"> &rarr; {vec2}</span></h4>
     
 
@@ -5644,7 +5645,7 @@
 
     
 
-    
+    {Vec2}
     <h4 class="name" id=".scaleAndAdd"><span class="type-signature">(static) </span>scaleAndAdd<span class="signature">(out, a, b, scale)</span><span class="type-signature"> &rarr; {vec2}</span></h4>
     
 
@@ -5870,7 +5871,7 @@
 
     
 
-    
+    {Vec2}
     <h4 class="name" id=".set"><span class="type-signature">(static) </span>set<span class="signature">(out, x, y)</span><span class="type-signature"> &rarr; {vec2}</span></h4>
     
 
@@ -6825,7 +6826,7 @@
 
     
 
-    
+    {Vec2}
     <h4 class="name" id=".subtract"><span class="type-signature">(static) </span>subtract<span class="signature">(out, a, b)</span><span class="type-signature"> &rarr; {vec2}</span></h4>
     
 
@@ -7028,7 +7029,7 @@
 
     
 
-    
+    {Vec2}
     <h4 class="name" id=".transformMat2"><span class="type-signature">(static) </span>transformMat2<span class="signature">(out, a, m)</span><span class="type-signature"> &rarr; {vec2}</span></h4>
     
 
@@ -7231,7 +7232,7 @@
 
     
 
-    
+    {Vec2}
     <h4 class="name" id=".transformMat2d"><span class="type-signature">(static) </span>transformMat2d<span class="signature">(out, a, m)</span><span class="type-signature"> &rarr; {vec2}</span></h4>
     
 
@@ -7434,7 +7435,7 @@
 
     
 
-    
+    {Vec2}
     <h4 class="name" id=".transformMat3"><span class="type-signature">(static) </span>transformMat3<span class="signature">(out, a, m)</span><span class="type-signature"> &rarr; {vec2}</span></h4>
     
 
@@ -7443,7 +7444,8 @@
 
 
 <div class="description">
-    Transforms the vec2 with a mat33rd vector component is implicitly '1'
+    Transforms the vec2 with a mat3
+3rd vector component is implicitly '1'
 </div>
 
 
@@ -7636,7 +7638,7 @@
             
 
     
-
+{Vec2}
     
     <h4 class="name" id=".transformMat4"><span class="type-signature">(static) </span>transformMat4<span class="signature">(out, a, m)</span><span class="type-signature"> &rarr; {vec2}</span></h4>
     
@@ -7646,7 +7648,9 @@
 
 
 <div class="description">
-    Transforms the vec2 with a mat43rd vector component is implicitly '0'4th vector component is implicitly '1'
+    Transforms the vec2 with a mat4
+3rd vector component is implicitly '0'
+4th vector component is implicitly '1'
 </div>
 
 

--- a/docs/module-vec3.html
+++ b/docs/module-vec3.html
@@ -142,7 +142,7 @@
     
 
     
-    <h4 class="name" id=".add"><span class="type-signature">(static) </span>add<span class="signature">(out, a, b)</span><span class="type-signature"> &rarr; {vec3}</span></h4>
+    <h4 class="name" id=".add"><span class="type-signature">(static) </span>add<span class="signature">(out, a, b)</span><span class="type-signature"> &rarr; {Vec3}</span></h4>
     
 
     
@@ -525,7 +525,7 @@
     
 
     
-    <h4 class="name" id=".bezier"><span class="type-signature">(static) </span>bezier<span class="signature">(out, a, b, c, d, t)</span><span class="type-signature"> &rarr; {vec3}</span></h4>
+    <h4 class="name" id=".bezier"><span class="type-signature">(static) </span>bezier<span class="signature">(out, a, b, c, d, t)</span><span class="type-signature"> &rarr; {Vec3}</span></h4>
     
 
     
@@ -797,7 +797,7 @@
     
 
     
-    <h4 class="name" id=".ceil"><span class="type-signature">(static) </span>ceil<span class="signature">(out, a)</span><span class="type-signature"> &rarr; {vec3}</span></h4>
+    <h4 class="name" id=".ceil"><span class="type-signature">(static) </span>ceil<span class="signature">(out, a)</span><span class="type-signature"> &rarr; {Vec3}</span></h4>
     
 
     
@@ -977,7 +977,7 @@
     
 
     
-    <h4 class="name" id=".clone"><span class="type-signature">(static) </span>clone<span class="signature">(a)</span><span class="type-signature"> &rarr; {vec3}</span></h4>
+    <h4 class="name" id=".clone"><span class="type-signature">(static) </span>clone<span class="signature">(a)</span><span class="type-signature"> &rarr; {Vec3}</span></h4>
     
 
     
@@ -1134,7 +1134,7 @@
     
 
     
-    <h4 class="name" id=".copy"><span class="type-signature">(static) </span>copy<span class="signature">(out, a)</span><span class="type-signature"> &rarr; {vec3}</span></h4>
+    <h4 class="name" id=".copy"><span class="type-signature">(static) </span>copy<span class="signature">(out, a)</span><span class="type-signature"> &rarr; {Vec3}</span></h4>
     
 
     
@@ -1314,7 +1314,7 @@
     
 
     
-    <h4 class="name" id=".create"><span class="type-signature">(static) </span>create<span class="signature">()</span><span class="type-signature"> &rarr; {vec3}</span></h4>
+    <h4 class="name" id=".create"><span class="type-signature">(static) </span>create<span class="signature">()</span><span class="type-signature"> &rarr; {Vec3}</span></h4>
     
 
     
@@ -1422,7 +1422,7 @@
     
 
     
-    <h4 class="name" id=".cross"><span class="type-signature">(static) </span>cross<span class="signature">(out, a, b)</span><span class="type-signature"> &rarr; {vec3}</span></h4>
+    <h4 class="name" id=".cross"><span class="type-signature">(static) </span>cross<span class="signature">(out, a, b)</span><span class="type-signature"> &rarr; {Vec3}</span></h4>
     
 
     
@@ -1977,7 +1977,7 @@
     
 
     
-    <h4 class="name" id=".divide"><span class="type-signature">(static) </span>divide<span class="signature">(out, a, b)</span><span class="type-signature"> &rarr; {vec3}</span></h4>
+    <h4 class="name" id=".divide"><span class="type-signature">(static) </span>divide<span class="signature">(out, a, b)</span><span class="type-signature"> &rarr; {Vec3}</span></h4>
     
 
     
@@ -2720,7 +2720,7 @@
     
 
     
-    <h4 class="name" id=".floor"><span class="type-signature">(static) </span>floor<span class="signature">(out, a)</span><span class="type-signature"> &rarr; {vec3}</span></h4>
+    <h4 class="name" id=".floor"><span class="type-signature">(static) </span>floor<span class="signature">(out, a)</span><span class="type-signature"> &rarr; {Vec3}</span></h4>
     
 
     
@@ -3224,7 +3224,7 @@
     
 
     
-    <h4 class="name" id=".fromValues"><span class="type-signature">(static) </span>fromValues<span class="signature">(x, y, z)</span><span class="type-signature"> &rarr; {vec3}</span></h4>
+    <h4 class="name" id=".fromValues"><span class="type-signature">(static) </span>fromValues<span class="signature">(x, y, z)</span><span class="type-signature"> &rarr; {Vec3}</span></h4>
     
 
     
@@ -3427,7 +3427,7 @@
     
 
     
-    <h4 class="name" id=".hermite"><span class="type-signature">(static) </span>hermite<span class="signature">(out, a, b, c, d, t)</span><span class="type-signature"> &rarr; {vec3}</span></h4>
+    <h4 class="name" id=".hermite"><span class="type-signature">(static) </span>hermite<span class="signature">(out, a, b, c, d, t)</span><span class="type-signature"> &rarr; {Vec3}</span></h4>
     
 
     
@@ -3699,7 +3699,7 @@
     
 
     
-    <h4 class="name" id=".inverse"><span class="type-signature">(static) </span>inverse<span class="signature">(out, a)</span><span class="type-signature"> &rarr; {vec3}</span></h4>
+    <h4 class="name" id=".inverse"><span class="type-signature">(static) </span>inverse<span class="signature">(out, a)</span><span class="type-signature"> &rarr; {Vec3}</span></h4>
     
 
     
@@ -4122,7 +4122,7 @@
     
 
     
-    <h4 class="name" id=".lerp"><span class="type-signature">(static) </span>lerp<span class="signature">(out, a, b, t)</span><span class="type-signature"> &rarr; {vec3}</span></h4>
+    <h4 class="name" id=".lerp"><span class="type-signature">(static) </span>lerp<span class="signature">(out, a, b, t)</span><span class="type-signature"> &rarr; {Vec3}</span></h4>
     
 
     
@@ -4348,7 +4348,7 @@
     
 
     
-    <h4 class="name" id=".max"><span class="type-signature">(static) </span>max<span class="signature">(out, a, b)</span><span class="type-signature"> &rarr; {vec3}</span></h4>
+    <h4 class="name" id=".max"><span class="type-signature">(static) </span>max<span class="signature">(out, a, b)</span><span class="type-signature"> &rarr; {Vec3}</span></h4>
     
 
     
@@ -4551,7 +4551,7 @@
     
 
     
-    <h4 class="name" id=".min"><span class="type-signature">(static) </span>min<span class="signature">(out, a, b)</span><span class="type-signature"> &rarr; {vec3}</span></h4>
+    <h4 class="name" id=".min"><span class="type-signature">(static) </span>min<span class="signature">(out, a, b)</span><span class="type-signature"> &rarr; {Vec3}</span></h4>
     
 
     
@@ -4840,7 +4840,7 @@
     
 
     
-    <h4 class="name" id=".multiply"><span class="type-signature">(static) </span>multiply<span class="signature">(out, a, b)</span><span class="type-signature"> &rarr; {vec3}</span></h4>
+    <h4 class="name" id=".multiply"><span class="type-signature">(static) </span>multiply<span class="signature">(out, a, b)</span><span class="type-signature"> &rarr; {Vec3}</span></h4>
     
 
     
@@ -5043,7 +5043,7 @@
     
 
     
-    <h4 class="name" id=".negate"><span class="type-signature">(static) </span>negate<span class="signature">(out, a)</span><span class="type-signature"> &rarr; {vec3}</span></h4>
+    <h4 class="name" id=".negate"><span class="type-signature">(static) </span>negate<span class="signature">(out, a)</span><span class="type-signature"> &rarr; {Vec3}</span></h4>
     
 
     
@@ -5223,7 +5223,7 @@
     
 
     
-    <h4 class="name" id=".normalize"><span class="type-signature">(static) </span>normalize<span class="signature">(out, a)</span><span class="type-signature"> &rarr; {vec3}</span></h4>
+    <h4 class="name" id=".normalize"><span class="type-signature">(static) </span>normalize<span class="signature">(out, a)</span><span class="type-signature"> &rarr; {Vec3}</span></h4>
     
 
     
@@ -5403,7 +5403,7 @@
     
 
     
-    <h4 class="name" id=".random"><span class="type-signature">(static) </span>random<span class="signature">(out, scale<span class="signature-attributes">opt</span>)</span><span class="type-signature"> &rarr; {vec3}</span></h4>
+    <h4 class="name" id=".random"><span class="type-signature">(static) </span>random<span class="signature">(out, scale<span class="signature-attributes">opt</span>)</span><span class="type-signature"> &rarr; {Vec3}</span></h4>
     
 
     
@@ -5603,7 +5603,7 @@
     
 
     
-    <h4 class="name" id=".rotateX"><span class="type-signature">(static) </span>rotateX<span class="signature">(out, a, b, c)</span><span class="type-signature"> &rarr; {vec3}</span></h4>
+    <h4 class="name" id=".rotateX"><span class="type-signature">(static) </span>rotateX<span class="signature">(out, a, b, c)</span><span class="type-signature"> &rarr; {Vec3}</span></h4>
     
 
     
@@ -5829,7 +5829,7 @@
     
 
     
-    <h4 class="name" id=".rotateY"><span class="type-signature">(static) </span>rotateY<span class="signature">(out, a, b, c)</span><span class="type-signature"> &rarr; {vec3}</span></h4>
+    <h4 class="name" id=".rotateY"><span class="type-signature">(static) </span>rotateY<span class="signature">(out, a, b, c)</span><span class="type-signature"> &rarr; {Vec3}</span></h4>
     
 
     
@@ -6055,7 +6055,7 @@
     
 
     
-    <h4 class="name" id=".rotateZ"><span class="type-signature">(static) </span>rotateZ<span class="signature">(out, a, b, c)</span><span class="type-signature"> &rarr; {vec3}</span></h4>
+    <h4 class="name" id=".rotateZ"><span class="type-signature">(static) </span>rotateZ<span class="signature">(out, a, b, c)</span><span class="type-signature"> &rarr; {Vec3}</span></h4>
     
 
     
@@ -6281,7 +6281,7 @@
     
 
     
-    <h4 class="name" id=".round"><span class="type-signature">(static) </span>round<span class="signature">(out, a)</span><span class="type-signature"> &rarr; {vec3}</span></h4>
+    <h4 class="name" id=".round"><span class="type-signature">(static) </span>round<span class="signature">(out, a)</span><span class="type-signature"> &rarr; {Vec3}</span></h4>
     
 
     
@@ -6461,7 +6461,7 @@
     
 
     
-    <h4 class="name" id=".scale"><span class="type-signature">(static) </span>scale<span class="signature">(out, a, b)</span><span class="type-signature"> &rarr; {vec3}</span></h4>
+    <h4 class="name" id=".scale"><span class="type-signature">(static) </span>scale<span class="signature">(out, a, b)</span><span class="type-signature"> &rarr; {Vec3}</span></h4>
     
 
     
@@ -6664,7 +6664,7 @@
     
 
     
-    <h4 class="name" id=".scaleAndAdd"><span class="type-signature">(static) </span>scaleAndAdd<span class="signature">(out, a, b, scale)</span><span class="type-signature"> &rarr; {vec3}</span></h4>
+    <h4 class="name" id=".scaleAndAdd"><span class="type-signature">(static) </span>scaleAndAdd<span class="signature">(out, a, b, scale)</span><span class="type-signature"> &rarr; {Vec3}</span></h4>
     
 
     
@@ -6890,7 +6890,7 @@
     
 
     
-    <h4 class="name" id=".set"><span class="type-signature">(static) </span>set<span class="signature">(out, x, y, z)</span><span class="type-signature"> &rarr; {vec3}</span></h4>
+    <h4 class="name" id=".set"><span class="type-signature">(static) </span>set<span class="signature">(out, x, y, z)</span><span class="type-signature"> &rarr; {Vec3}</span></h4>
     
 
     
@@ -7868,7 +7868,7 @@
     
 
     
-    <h4 class="name" id=".subtract"><span class="type-signature">(static) </span>subtract<span class="signature">(out, a, b)</span><span class="type-signature"> &rarr; {vec3}</span></h4>
+    <h4 class="name" id=".subtract"><span class="type-signature">(static) </span>subtract<span class="signature">(out, a, b)</span><span class="type-signature"> &rarr; {Vec3}</span></h4>
     
 
     
@@ -8071,7 +8071,7 @@
     
 
     
-    <h4 class="name" id=".transformMat3"><span class="type-signature">(static) </span>transformMat3<span class="signature">(out, a, m)</span><span class="type-signature"> &rarr; {vec3}</span></h4>
+    <h4 class="name" id=".transformMat3"><span class="type-signature">(static) </span>transformMat3<span class="signature">(out, a, m)</span><span class="type-signature"> &rarr; {Vec3}</span></h4>
     
 
     
@@ -8274,7 +8274,7 @@
     
 
     
-    <h4 class="name" id=".transformMat4"><span class="type-signature">(static) </span>transformMat4<span class="signature">(out, a, m)</span><span class="type-signature"> &rarr; {vec3}</span></h4>
+    <h4 class="name" id=".transformMat4"><span class="type-signature">(static) </span>transformMat4<span class="signature">(out, a, m)</span><span class="type-signature"> &rarr; {Vec3}</span></h4>
     
 
     
@@ -8282,7 +8282,8 @@
 
 
 <div class="description">
-    Transforms the vec3 with a mat4.4th vector component is implicitly '1'
+    Transforms the vec3 with a mat4.
+4th vector component is implicitly '1'
 </div>
 
 
@@ -8476,7 +8477,7 @@
 
     
 
-    
+    {Vec3}
     <h4 class="name" id=".transformQuat"><span class="type-signature">(static) </span>transformQuat<span class="signature">(out, a, q)</span><span class="type-signature"> &rarr; {vec3}</span></h4>
     
 
@@ -8485,7 +8486,8 @@
 
 
 <div class="description">
-    Transforms the vec3 with a quatCan also be used for dual quaternions. (Multiply it with the real part)
+    Transforms the vec3 with a quat
+Can also be used for dual quaternions. (Multiply it with the real part)
 </div>
 
 

--- a/docs/module-vec4.html
+++ b/docs/module-vec4.html
@@ -142,7 +142,7 @@
     
 
     
-    <h4 class="name" id=".add"><span class="type-signature">(static) </span>add<span class="signature">(out, a, b)</span><span class="type-signature"> &rarr; {vec4}</span></h4>
+    <h4 class="name" id=".add"><span class="type-signature">(static) </span>add<span class="signature">(out, a, b)</span><span class="type-signature"> &rarr; {Vec4}</span></h4>
     
 
     
@@ -345,7 +345,7 @@
     
 
     
-    <h4 class="name" id=".ceil"><span class="type-signature">(static) </span>ceil<span class="signature">(out, a)</span><span class="type-signature"> &rarr; {vec4}</span></h4>
+    <h4 class="name" id=".ceil"><span class="type-signature">(static) </span>ceil<span class="signature">(out, a)</span><span class="type-signature"> &rarr; {Vec4}</span></h4>
     
 
     
@@ -525,7 +525,7 @@
     
 
     
-    <h4 class="name" id=".clone"><span class="type-signature">(static) </span>clone<span class="signature">(a)</span><span class="type-signature"> &rarr; {vec4}</span></h4>
+    <h4 class="name" id=".clone"><span class="type-signature">(static) </span>clone<span class="signature">(a)</span><span class="type-signature"> &rarr; {Vec4}</span></h4>
     
 
     
@@ -682,7 +682,7 @@
     
 
     
-    <h4 class="name" id=".copy"><span class="type-signature">(static) </span>copy<span class="signature">(out, a)</span><span class="type-signature"> &rarr; {vec4}</span></h4>
+    <h4 class="name" id=".copy"><span class="type-signature">(static) </span>copy<span class="signature">(out, a)</span><span class="type-signature"> &rarr; {Vec4}</span></h4>
     
 
     
@@ -862,7 +862,7 @@
     
 
     
-    <h4 class="name" id=".create"><span class="type-signature">(static) </span>create<span class="signature">()</span><span class="type-signature"> &rarr; {vec4}</span></h4>
+    <h4 class="name" id=".create"><span class="type-signature">(static) </span>create<span class="signature">()</span><span class="type-signature"> &rarr; {Vec4}</span></h4>
     
 
     
@@ -1322,7 +1322,7 @@
     
 
     
-    <h4 class="name" id=".divide"><span class="type-signature">(static) </span>divide<span class="signature">(out, a, b)</span><span class="type-signature"> &rarr; {vec4}</span></h4>
+    <h4 class="name" id=".divide"><span class="type-signature">(static) </span>divide<span class="signature">(out, a, b)</span><span class="type-signature"> &rarr; {Vec4}</span></h4>
     
 
     
@@ -2065,7 +2065,7 @@
     
 
     
-    <h4 class="name" id=".floor"><span class="type-signature">(static) </span>floor<span class="signature">(out, a)</span><span class="type-signature"> &rarr; {vec4}</span></h4>
+    <h4 class="name" id=".floor"><span class="type-signature">(static) </span>floor<span class="signature">(out, a)</span><span class="type-signature"> &rarr; {Vec4}</span></h4>
     
 
     
@@ -2569,7 +2569,7 @@
     
 
     
-    <h4 class="name" id=".fromValues"><span class="type-signature">(static) </span>fromValues<span class="signature">(x, y, z, w)</span><span class="type-signature"> &rarr; {vec4}</span></h4>
+    <h4 class="name" id=".fromValues"><span class="type-signature">(static) </span>fromValues<span class="signature">(x, y, z, w)</span><span class="type-signature"> &rarr; {Vec4}</span></h4>
     
 
     
@@ -2795,7 +2795,7 @@
     
 
     
-    <h4 class="name" id=".inverse"><span class="type-signature">(static) </span>inverse<span class="signature">(out, a)</span><span class="type-signature"> &rarr; {vec4}</span></h4>
+    <h4 class="name" id=".inverse"><span class="type-signature">(static) </span>inverse<span class="signature">(out, a)</span><span class="type-signature"> &rarr; {Vec4}</span></h4>
     
 
     
@@ -3218,7 +3218,7 @@
     
 
     
-    <h4 class="name" id=".lerp"><span class="type-signature">(static) </span>lerp<span class="signature">(out, a, b, t)</span><span class="type-signature"> &rarr; {vec4}</span></h4>
+    <h4 class="name" id=".lerp"><span class="type-signature">(static) </span>lerp<span class="signature">(out, a, b, t)</span><span class="type-signature"> &rarr; {Vec4}</span></h4>
     
 
     
@@ -3444,7 +3444,7 @@
     
 
     
-    <h4 class="name" id=".max"><span class="type-signature">(static) </span>max<span class="signature">(out, a, b)</span><span class="type-signature"> &rarr; {vec4}</span></h4>
+    <h4 class="name" id=".max"><span class="type-signature">(static) </span>max<span class="signature">(out, a, b)</span><span class="type-signature"> &rarr; {Vec4}</span></h4>
     
 
     
@@ -3647,7 +3647,7 @@
     
 
     
-    <h4 class="name" id=".min"><span class="type-signature">(static) </span>min<span class="signature">(out, a, b)</span><span class="type-signature"> &rarr; {vec4}</span></h4>
+    <h4 class="name" id=".min"><span class="type-signature">(static) </span>min<span class="signature">(out, a, b)</span><span class="type-signature"> &rarr; {Vec4}</span></h4>
     
 
     
@@ -3936,7 +3936,7 @@
     
 
     
-    <h4 class="name" id=".multiply"><span class="type-signature">(static) </span>multiply<span class="signature">(out, a, b)</span><span class="type-signature"> &rarr; {vec4}</span></h4>
+    <h4 class="name" id=".multiply"><span class="type-signature">(static) </span>multiply<span class="signature">(out, a, b)</span><span class="type-signature"> &rarr; {Vec4}</span></h4>
     
 
     
@@ -4139,7 +4139,7 @@
     
 
     
-    <h4 class="name" id=".negate"><span class="type-signature">(static) </span>negate<span class="signature">(out, a)</span><span class="type-signature"> &rarr; {vec4}</span></h4>
+    <h4 class="name" id=".negate"><span class="type-signature">(static) </span>negate<span class="signature">(out, a)</span><span class="type-signature"> &rarr; {Vec4}</span></h4>
     
 
     
@@ -4319,7 +4319,7 @@
     
 
     
-    <h4 class="name" id=".normalize"><span class="type-signature">(static) </span>normalize<span class="signature">(out, a)</span><span class="type-signature"> &rarr; {vec4}</span></h4>
+    <h4 class="name" id=".normalize"><span class="type-signature">(static) </span>normalize<span class="signature">(out, a)</span><span class="type-signature"> &rarr; {Vec4}</span></h4>
     
 
     
@@ -4499,7 +4499,7 @@
     
 
     
-    <h4 class="name" id=".random"><span class="type-signature">(static) </span>random<span class="signature">(out, scale<span class="signature-attributes">opt</span>)</span><span class="type-signature"> &rarr; {vec4}</span></h4>
+    <h4 class="name" id=".random"><span class="type-signature">(static) </span>random<span class="signature">(out, scale<span class="signature-attributes">opt</span>)</span><span class="type-signature"> &rarr; {Vec4}</span></h4>
     
 
     
@@ -4699,7 +4699,7 @@
     
 
     
-    <h4 class="name" id=".round"><span class="type-signature">(static) </span>round<span class="signature">(out, a)</span><span class="type-signature"> &rarr; {vec4}</span></h4>
+    <h4 class="name" id=".round"><span class="type-signature">(static) </span>round<span class="signature">(out, a)</span><span class="type-signature"> &rarr; {Vec4}</span></h4>
     
 
     
@@ -4879,7 +4879,7 @@
     
 
     
-    <h4 class="name" id=".scale"><span class="type-signature">(static) </span>scale<span class="signature">(out, a, b)</span><span class="type-signature"> &rarr; {vec4}</span></h4>
+    <h4 class="name" id=".scale"><span class="type-signature">(static) </span>scale<span class="signature">(out, a, b)</span><span class="type-signature"> &rarr; {Vec4}</span></h4>
     
 
     
@@ -5082,7 +5082,7 @@
     
 
     
-    <h4 class="name" id=".scaleAndAdd"><span class="type-signature">(static) </span>scaleAndAdd<span class="signature">(out, a, b, scale)</span><span class="type-signature"> &rarr; {vec4}</span></h4>
+    <h4 class="name" id=".scaleAndAdd"><span class="type-signature">(static) </span>scaleAndAdd<span class="signature">(out, a, b, scale)</span><span class="type-signature"> &rarr; {Vec4}</span></h4>
     
 
     
@@ -5308,7 +5308,7 @@
     
 
     
-    <h4 class="name" id=".set"><span class="type-signature">(static) </span>set<span class="signature">(out, x, y, z, w)</span><span class="type-signature"> &rarr; {vec4}</span></h4>
+    <h4 class="name" id=".set"><span class="type-signature">(static) </span>set<span class="signature">(out, x, y, z, w)</span><span class="type-signature"> &rarr; {Vec4}</span></h4>
     
 
     
@@ -6309,7 +6309,7 @@
     
 
     
-    <h4 class="name" id=".subtract"><span class="type-signature">(static) </span>subtract<span class="signature">(out, a, b)</span><span class="type-signature"> &rarr; {vec4}</span></h4>
+    <h4 class="name" id=".subtract"><span class="type-signature">(static) </span>subtract<span class="signature">(out, a, b)</span><span class="type-signature"> &rarr; {Vec4}</span></h4>
     
 
     
@@ -6512,7 +6512,7 @@
     
 
     
-    <h4 class="name" id=".transformMat4"><span class="type-signature">(static) </span>transformMat4<span class="signature">(out, a, m)</span><span class="type-signature"> &rarr; {vec4}</span></h4>
+    <h4 class="name" id=".transformMat4"><span class="type-signature">(static) </span>transformMat4<span class="signature">(out, a, m)</span><span class="type-signature"> &rarr; {Vec4}</span></h4>
     
 
     
@@ -6715,7 +6715,7 @@
     
 
     
-    <h4 class="name" id=".transformQuat"><span class="type-signature">(static) </span>transformQuat<span class="signature">(out, a, q)</span><span class="type-signature"> &rarr; {vec4}</span></h4>
+    <h4 class="name" id=".transformQuat"><span class="type-signature">(static) </span>transformQuat<span class="signature">(out, a, q)</span><span class="type-signature"> &rarr; {Vec4}</span></h4>
     
 
     

--- a/docs/quat.js.html
+++ b/docs/quat.js.html
@@ -39,7 +39,7 @@ import * as vec4 from "./vec4.js"
 /**
  * Creates a new identity quat
  *
- * @returns {quat} a new quaternion
+ * @returns {Quat} a new quaternion
  */
 export function create() {
   let out = new glMatrix.ARRAY_TYPE(4);
@@ -55,8 +55,8 @@ export function create() {
 /**
  * Set a quat to the identity quaternion
  *
- * @param {quat} out the receiving quaternion
- * @returns {quat} out
+ * @param {Quat} out the receiving quaternion
+ * @returns {Quat} out
  */
 export function identity(out) {
   out[0] = 0;
@@ -70,10 +70,10 @@ export function identity(out) {
  * Sets a quat from the given angle and rotation axis,
  * then returns it.
  *
- * @param {quat} out the receiving quaternion
- * @param {vec3} axis the axis around which to rotate
+ * @param {Quat} out the receiving quaternion
+ * @param {Vec3} axis the axis around which to rotate
  * @param {Number} rad the angle in radians
- * @returns {quat} out
+ * @returns {Quat} out
  **/
 export function setAxisAngle(out, axis, rad) {
   rad = rad * 0.5;
@@ -94,8 +94,8 @@ export function setAxisAngle(out, axis, rad) {
  * Example: The quaternion formed by axis [0, 0, 1] and
  *  angle -90 is the same as the quaternion formed by
  *  [0, 0, 1] and 270. This method favors the latter.
- * @param  {vec3} out_axis  Vector receiving the axis of rotation
- * @param  {quat} q     Quaternion to be decomposed
+ * @param  {Vec3} out_axis  Vector receiving the axis of rotation
+ * @param  {Quat} q     Quaternion to be decomposed
  * @return {Number}     Angle, in radians, of the rotation
  */
 export function getAxisAngle(out_axis, q) {
@@ -117,10 +117,10 @@ export function getAxisAngle(out_axis, q) {
 /**
  * Multiplies two quat's
  *
- * @param {quat} out the receiving quaternion
- * @param {quat} a the first operand
- * @param {quat} b the second operand
- * @returns {quat} out
+ * @param {Quat} out the receiving quaternion
+ * @param {Quat} a the first operand
+ * @param {Quat} b the second operand
+ * @returns {Quat} out
  */
 export function multiply(out, a, b) {
   let ax = a[0], ay = a[1], az = a[2], aw = a[3];
@@ -136,10 +136,10 @@ export function multiply(out, a, b) {
 /**
  * Rotates a quaternion by the given angle about the X axis
  *
- * @param {quat} out quat receiving operation result
- * @param {quat} a quat to rotate
+ * @param {Quat} out quat receiving operation result
+ * @param {Quat} a quat to rotate
  * @param {number} rad angle (in radians) to rotate
- * @returns {quat} out
+ * @returns {Quat} out
  */
 export function rotateX(out, a, rad) {
   rad *= 0.5;
@@ -157,10 +157,10 @@ export function rotateX(out, a, rad) {
 /**
  * Rotates a quaternion by the given angle about the Y axis
  *
- * @param {quat} out quat receiving operation result
- * @param {quat} a quat to rotate
+ * @param {Quat} out quat receiving operation result
+ * @param {Quat} a quat to rotate
  * @param {number} rad angle (in radians) to rotate
- * @returns {quat} out
+ * @returns {Quat} out
  */
 export function rotateY(out, a, rad) {
   rad *= 0.5;
@@ -178,10 +178,10 @@ export function rotateY(out, a, rad) {
 /**
  * Rotates a quaternion by the given angle about the Z axis
  *
- * @param {quat} out quat receiving operation result
- * @param {quat} a quat to rotate
+ * @param {Quat} out quat receiving operation result
+ * @param {Quat} a quat to rotate
  * @param {number} rad angle (in radians) to rotate
- * @returns {quat} out
+ * @returns {Quat} out
  */
 export function rotateZ(out, a, rad) {
   rad *= 0.5;
@@ -201,9 +201,9 @@ export function rotateZ(out, a, rad) {
  * Assumes that quaternion is 1 unit in length.
  * Any existing W component will be ignored.
  *
- * @param {quat} out the receiving quaternion
- * @param {quat} a quat to calculate W component of
- * @returns {quat} out
+ * @param {Quat} out the receiving quaternion
+ * @param {Quat} a quat to calculate W component of
+ * @returns {Quat} out
  */
 export function calculateW(out, a) {
   let x = a[0], y = a[1], z = a[2];
@@ -218,11 +218,11 @@ export function calculateW(out, a) {
 /**
  * Performs a spherical linear interpolation between two quat
  *
- * @param {quat} out the receiving quaternion
- * @param {quat} a the first operand
- * @param {quat} b the second operand
+ * @param {Quat} out the receiving quaternion
+ * @param {Quat} a the first operand
+ * @param {Quat} b the second operand
  * @param {Number} t interpolation amount, in the range [0-1], between the two inputs
- * @returns {quat} out
+ * @returns {Quat} out
  */
 export function slerp(out, a, b, t) {
   // benchmarks:
@@ -267,8 +267,8 @@ export function slerp(out, a, b, t) {
 /**
  * Generates a random quaternion
  *
- * @param {quat} out the receiving quaternion
- * @returns {quat} out
+ * @param {Quat} out the receiving quaternion
+ * @returns {Quat} out
  */
 export function random(out) {
   // Implementation of http://planning.cs.uiuc.edu/node198.html
@@ -290,9 +290,9 @@ export function random(out) {
 /**
  * Calculates the inverse of a quat
  *
- * @param {quat} out the receiving quaternion
- * @param {quat} a quat to calculate inverse of
- * @returns {quat} out
+ * @param {Quat} out the receiving quaternion
+ * @param {Quat} a quat to calculate inverse of
+ * @returns {Quat} out
  */
 export function invert(out, a) {
   let a0 = a[0], a1 = a[1], a2 = a[2], a3 = a[3];
@@ -312,9 +312,9 @@ export function invert(out, a) {
  * Calculates the conjugate of a quat
  * If the quaternion is normalized, this function is faster than quat.inverse and produces the same result.
  *
- * @param {quat} out the receiving quaternion
- * @param {quat} a quat to calculate conjugate of
- * @returns {quat} out
+ * @param {Quat} out the receiving quaternion
+ * @param {Quat} a quat to calculate conjugate of
+ * @returns {Quat} out
  */
 export function conjugate(out, a) {
   out[0] = -a[0];
@@ -330,9 +330,9 @@ export function conjugate(out, a) {
  * NOTE: The resultant quaternion is not normalized, so you should be sure
  * to renormalize the quaternion yourself where necessary.
  *
- * @param {quat} out the receiving quaternion
- * @param {mat3} m rotation matrix
- * @returns {quat} out
+ * @param {Quat} out the receiving quaternion
+ * @param {Mat3} m rotation matrix
+ * @returns {Quat} out
  * @function
  */
 export function fromMat3(out, m) {
@@ -373,11 +373,11 @@ export function fromMat3(out, m) {
 /**
  * Creates a quaternion from the given euler angle x, y, z.
  *
- * @param {quat} out the receiving quaternion
+ * @param {Quat} out the receiving quaternion
  * @param {x} Angle to rotate around X axis in degrees.
  * @param {y} Angle to rotate around Y axis in degrees.
  * @param {z} Angle to rotate around Z axis in degrees.
- * @returns {quat} out
+ * @returns {Quat} out
  * @function
  */
 export function fromEuler(out, x, y, z) {
@@ -404,7 +404,7 @@ export function fromEuler(out, x, y, z) {
 /**
  * Returns a string representation of a quatenion
  *
- * @param {quat} a vector to represent as a string
+ * @param {Quat} a vector to represent as a string
  * @returns {String} string representation of the vector
  */
 export function str(a) {
@@ -414,8 +414,8 @@ export function str(a) {
 /**
  * Creates a new quat initialized with values from an existing quaternion
  *
- * @param {quat} a quaternion to clone
- * @returns {quat} a new quaternion
+ * @param {Quat} a quaternion to clone
+ * @returns {Quat} a new quaternion
  * @function
  */
 export const clone = vec4.clone;
@@ -427,7 +427,7 @@ export const clone = vec4.clone;
  * @param {Number} y Y component
  * @param {Number} z Z component
  * @param {Number} w W component
- * @returns {quat} a new quaternion
+ * @returns {Quat} a new quaternion
  * @function
  */
 export const fromValues = vec4.fromValues;
@@ -435,9 +435,9 @@ export const fromValues = vec4.fromValues;
 /**
  * Copy the values from one quat to another
  *
- * @param {quat} out the receiving quaternion
- * @param {quat} a the source quaternion
- * @returns {quat} out
+ * @param {Quat} out the receiving quaternion
+ * @param {Quat} a the source quaternion
+ * @returns {Quat} out
  * @function
  */
 export const copy = vec4.copy;
@@ -445,12 +445,12 @@ export const copy = vec4.copy;
 /**
  * Set the components of a quat to the given values
  *
- * @param {quat} out the receiving quaternion
+ * @param {Quat} out the receiving quaternion
  * @param {Number} x X component
  * @param {Number} y Y component
  * @param {Number} z Z component
  * @param {Number} w W component
- * @returns {quat} out
+ * @returns {Quat} out
  * @function
  */
 export const set = vec4.set;
@@ -458,10 +458,10 @@ export const set = vec4.set;
 /**
  * Adds two quat's
  *
- * @param {quat} out the receiving quaternion
- * @param {quat} a the first operand
- * @param {quat} b the second operand
- * @returns {quat} out
+ * @param {Quat} out the receiving quaternion
+ * @param {Quat} a the first operand
+ * @param {Quat} b the second operand
+ * @returns {Quat} out
  * @function
  */
 export const add = vec4.add;
@@ -475,10 +475,10 @@ export const mul = multiply;
 /**
  * Scales a quat by a scalar number
  *
- * @param {quat} out the receiving vector
- * @param {quat} a the vector to scale
+ * @param {Quat} out the receiving vector
+ * @param {Quat} a the vector to scale
  * @param {Number} b amount to scale the vector by
- * @returns {quat} out
+ * @returns {Quat} out
  * @function
  */
 export const scale = vec4.scale;
@@ -486,8 +486,8 @@ export const scale = vec4.scale;
 /**
  * Calculates the dot product of two quat's
  *
- * @param {quat} a the first operand
- * @param {quat} b the second operand
+ * @param {Quat} a the first operand
+ * @param {Quat} b the second operand
  * @returns {Number} dot product of a and b
  * @function
  */
@@ -496,11 +496,11 @@ export const dot = vec4.dot;
 /**
  * Performs a linear interpolation between two quat's
  *
- * @param {quat} out the receiving quaternion
- * @param {quat} a the first operand
- * @param {quat} b the second operand
+ * @param {Quat} out the receiving quaternion
+ * @param {Quat} a the first operand
+ * @param {Quat} b the second operand
  * @param {Number} t interpolation amount, in the range [0-1], between the two inputs
- * @returns {quat} out
+ * @returns {Quat} out
  * @function
  */
 export const lerp = vec4.lerp;
@@ -508,7 +508,7 @@ export const lerp = vec4.lerp;
 /**
  * Calculates the length of a quat
  *
- * @param {quat} a vector to calculate length of
+ * @param {Quat} a vector to calculate length of
  * @returns {Number} length of a
  */
 export const length = vec4.length;
@@ -522,7 +522,7 @@ export const len = length;
 /**
  * Calculates the squared length of a quat
  *
- * @param {quat} a vector to calculate squared length of
+ * @param {Quat} a vector to calculate squared length of
  * @returns {Number} squared length of a
  * @function
  */
@@ -537,9 +537,9 @@ export const sqrLen = squaredLength;
 /**
  * Normalize a quat
  *
- * @param {quat} out the receiving quaternion
- * @param {quat} a quaternion to normalize
- * @returns {quat} out
+ * @param {Quat} out the receiving quaternion
+ * @param {Quat} a quaternion to normalize
+ * @returns {Quat} out
  * @function
  */
 export const normalize = vec4.normalize;
@@ -547,8 +547,8 @@ export const normalize = vec4.normalize;
 /**
  * Returns whether or not the quaternions have exactly the same elements in the same position (when compared with ===)
  *
- * @param {quat} a The first quaternion.
- * @param {quat} b The second quaternion.
+ * @param {Quat} a The first quaternion.
+ * @param {Quat} b The second quaternion.
  * @returns {Boolean} True if the vectors are equal, false otherwise.
  */
 export const exactEquals = vec4.exactEquals;
@@ -556,8 +556,8 @@ export const exactEquals = vec4.exactEquals;
 /**
  * Returns whether or not the quaternions have approximately the same elements in the same position.
  *
- * @param {quat} a The first vector.
- * @param {quat} b The second vector.
+ * @param {Quat} a The first vector.
+ * @param {Quat} b The second vector.
  * @returns {Boolean} True if the vectors are equal, false otherwise.
  */
 export const equals = vec4.equals;
@@ -568,10 +568,10 @@ export const equals = vec4.equals;
  *
  * Both vectors are assumed to be unit length.
  *
- * @param {quat} out the receiving quaternion.
- * @param {vec3} a the initial vector
- * @param {vec3} b the destination vector
- * @returns {quat} out
+ * @param {Quat} out the receiving quaternion.
+ * @param {Vec3} a the initial vector
+ * @param {Vec3} b the destination vector
+ * @returns {Quat} out
  */
 export const rotationTo = (function() {
   let tmpvec3 = vec3.create();
@@ -607,13 +607,13 @@ export const rotationTo = (function() {
 /**
  * Performs a spherical linear interpolation with two control points
  *
- * @param {quat} out the receiving quaternion
- * @param {quat} a the first operand
- * @param {quat} b the second operand
- * @param {quat} c the third operand
- * @param {quat} d the fourth operand
+ * @param {Quat} out the receiving quaternion
+ * @param {Quat} a the first operand
+ * @param {Quat} b the second operand
+ * @param {Quat} c the third operand
+ * @param {Quat} d the fourth operand
  * @param {Number} t interpolation amount, in the range [0-1], between the two inputs
- * @returns {quat} out
+ * @returns {Quat} out
  */
 export const sqlerp = (function () {
   let temp1 = create();
@@ -633,10 +633,10 @@ export const sqlerp = (function () {
  * axes. Each axis is a vec3 and is expected to be unit length and
  * perpendicular to all other specified axes.
  *
- * @param {vec3} view  the vector representing the viewing direction
- * @param {vec3} right the vector representing the local "right" direction
- * @param {vec3} up    the vector representing the local "up" direction
- * @returns {quat} out
+ * @param {Vec3} view  the vector representing the viewing direction
+ * @param {Vec3} right the vector representing the local "right" direction
+ * @param {Vec3} up    the vector representing the local "up" direction
+ * @returns {Quat} out
  */
 export const setAxes = (function() {
   let matr = mat3.create();

--- a/docs/quat2.js.html
+++ b/docs/quat2.js.html
@@ -42,7 +42,7 @@ import * as mat4 from "./mat4.js";
 /**
  * Creates a new identity dual quat
  *
- * @returns {quat2} a new dual quaternion [real -> rotation, dual -> translation]
+ * @returns {Quat2} a new dual quaternion [real -> rotation, dual -> translation]
  */
 export function create() {
   let dq = new glMatrix.ARRAY_TYPE(8);
@@ -62,8 +62,8 @@ export function create() {
 /**
  * Creates a new quat initialized with values from an existing quaternion
  *
- * @param {quat2} a dual quaternion to clone
- * @returns {quat2} new dual quaternion
+ * @param {Quat2} a dual quaternion to clone
+ * @returns {Quat2} new dual quaternion
  * @function
  */
 export function clone(a) {
@@ -90,7 +90,7 @@ export function clone(a) {
  * @param {Number} y2 Y component
  * @param {Number} z2 Z component
  * @param {Number} w2 W component
- * @returns {quat2} new dual quaternion
+ * @returns {Quat2} new dual quaternion
  * @function
  */
 export function fromValues(x1, y1, z1, w1, x2, y2, z2, w2) {
@@ -116,7 +116,7 @@ export function fromValues(x1, y1, z1, w1, x2, y2, z2, w2) {
  * @param {Number} x2 X component (translation)
  * @param {Number} y2 Y component (translation)
  * @param {Number} z2 Z component (translation)
- * @returns {quat2} new dual quaternion
+ * @returns {Quat2} new dual quaternion
  * @function
  */
 export function fromRotationTranslationValues(x1, y1, z1, w1, x2, y2, z2) {
@@ -138,10 +138,10 @@ export function fromRotationTranslationValues(x1, y1, z1, w1, x2, y2, z2) {
 /**
  * Creates a dual quat from a quaternion and a translation
  *
- * @param {quat2} dual quaternion receiving operation result
- * @param {quat} q quaternion
- * @param {vec3} t tranlation vector
- * @returns {quat2} dual quaternion receiving operation result
+ * @param {Quat2} dual quaternion receiving operation result
+ * @param {Quat} q quaternion
+ * @param {Vec3} t tranlation vector
+ * @returns {Quat2} dual quaternion receiving operation result
  * @function
  */
 export function fromRotationTranslation(out, q, t) {
@@ -166,9 +166,9 @@ export function fromRotationTranslation(out, q, t) {
 /**
  * Creates a dual quat from a translation
  *
- * @param {quat2} dual quaternion receiving operation result
- * @param {vec3} t translation vector
- * @returns {quat2} dual quaternion receiving operation result
+ * @param {Quat2} dual quaternion receiving operation result
+ * @param {Vec3} t translation vector
+ * @returns {Quat2} dual quaternion receiving operation result
  * @function
  */
 export function fromTranslation(out, t) {
@@ -186,9 +186,9 @@ export function fromTranslation(out, t) {
 /**
  * Creates a dual quat from a quaternion
  *
- * @param {quat2} dual quaternion receiving operation result
- * @param {quat} q the quaternion
- * @returns {quat2} dual quaternion receiving operation result
+ * @param {Quat2} dual quaternion receiving operation result
+ * @param {Quat} q the quaternion
+ * @returns {Quat2} dual quaternion receiving operation result
  * @function
  */
 export function fromRotation(out, q) {
@@ -206,9 +206,9 @@ export function fromRotation(out, q) {
 /**
  * Creates a new dual quat from a matrix (4x4)
  *
- * @param {quat2} out the dual quaternion
- * @param {mat4} a the matrix
- * @returns {quat2} dual quat receiving operation result
+ * @param {Quat2} out the dual quaternion
+ * @param {Mat4} a the matrix
+ * @returns {Quat2} dual quat receiving operation result
  * @function
  */
 export function fromMat4(out, a) {
@@ -224,9 +224,9 @@ export function fromMat4(out, a) {
 /**
  * Copy the values from one dual quat to another
  *
- * @param {quat2} out the receiving dual quaternion
- * @param {quat2} a the source dual quaternion
- * @returns {quat2} out
+ * @param {Quat2} out the receiving dual quaternion
+ * @param {Quat2} a the source dual quaternion
+ * @returns {Quat2} out
  * @function
  */
 export function copy(out, a) {
@@ -244,8 +244,8 @@ export function copy(out, a) {
 /**
  * Set a dual quat to the identity dual quaternion
  *
- * @param {quat2} out the receiving quaternion
- * @returns {quat2} out
+ * @param {Quat2} out the receiving quaternion
+ * @returns {Quat2} out
  */
 export function identity(out) {
   out[0] = 0;
@@ -262,7 +262,7 @@ export function identity(out) {
 /**
  * Set the components of a dual quat to the given values
  *
- * @param {quat2} out the receiving quaternion
+ * @param {Quat2} out the receiving quaternion
  * @param {Number} x1 X component
  * @param {Number} y1 Y component
  * @param {Number} z1 Z component
@@ -271,7 +271,7 @@ export function identity(out) {
  * @param {Number} y2 Y component
  * @param {Number} z2 Z component
  * @param {Number} w2 W component
- * @returns {quat2} out
+ * @returns {Quat2} out
  * @function
  */
 export function set(out, x1, y1, z1, w1, x2, y2, z2, w2) {
@@ -289,17 +289,17 @@ export function set(out, x1, y1, z1, w1, x2, y2, z2, w2) {
 
 /**
  * Gets the real part of a dual quat
- * @param  {quat} out real part
- * @param  {quat2} a Dual Quaternion
- * @return {quat} real part
+ * @param  {Quat} out real part
+ * @param  {Quat2} a Dual Quaternion
+ * @return {Quat} real part
  */
 export const getReal = quat.copy;
 
 /**
  * Gets the dual part of a dual quat
- * @param  {quat} out dual part
- * @param  {quat2} a Dual Quaternion
- * @return {quat} dual part
+ * @param  {Quat} out dual part
+ * @param  {Quat2} a Dual Quaternion
+ * @return {Quat} dual part
  */
 export function getDual(out, a) {
   out[0] = a[4];
@@ -312,9 +312,9 @@ export function getDual(out, a) {
 /**
  * Set the real component of a dual quat to the given quaternion
  *
- * @param {quat2} out the receiving quaternion
- * @param {quat} q a quaternion representing the real part
- * @returns {quat2} out
+ * @param {Quat2} out the receiving quaternion
+ * @param {Quat} q a quaternion representing the real part
+ * @returns {Quat2} out
  * @function
  */
 export const setReal = quat.copy;
@@ -322,9 +322,9 @@ export const setReal = quat.copy;
 /**
  * Set the dual component of a dual quat to the given quaternion
  *
- * @param {quat2} out the receiving quaternion
- * @param {quat} q a quaternion representing the dual part
- * @returns {quat2} out
+ * @param {Quat2} out the receiving quaternion
+ * @param {Quat} q a quaternion representing the dual part
+ * @returns {Quat2} out
  * @function
  */
 export function setDual(out, q) {
@@ -337,9 +337,9 @@ export function setDual(out, q) {
 
 /**
  * Gets the translation of a normalized dual quat
- * @param  {vec3} out translation
- * @param  {quat2} a Dual Quaternion to be decomposed
- * @return {vec3} translation
+ * @param  {Vec3} out translation
+ * @param  {Quat2} a Dual Quaternion to be decomposed
+ * @return {Vec3} translation
  */
 export function getTranslation(out, a) {
   let ax = a[4],
@@ -359,10 +359,10 @@ export function getTranslation(out, a) {
 /**
  * Translates a dual quat by the given vector
  *
- * @param {quat2} out the receiving dual quaternion
- * @param {quat2} a the dual quaternion to translate
- * @param {vec3} v vector to translate by
- * @returns {quat2} out
+ * @param {Quat2} out the receiving dual quaternion
+ * @param {Quat2} a the dual quaternion to translate
+ * @param {Vec3} v vector to translate by
+ * @returns {Quat2} out
  */
 export function translate(out, a, v) {
   let ax1 = a[0],
@@ -390,10 +390,10 @@ export function translate(out, a, v) {
 /**
  * Rotates a dual quat around the X axis
  *
- * @param {quat2} out the receiving dual quaternion
- * @param {quat2} a the dual quaternion to rotate
+ * @param {Quat2} out the receiving dual quaternion
+ * @param {Quat2} a the dual quaternion to rotate
  * @param {number} rad how far should the rotation be
- * @returns {quat2} out
+ * @returns {Quat2} out
  */
 export function rotateX(out, a, rad) {
   let bx = -a[0],
@@ -423,10 +423,10 @@ export function rotateX(out, a, rad) {
 /**
  * Rotates a dual quat around the Y axis
  *
- * @param {quat2} out the receiving dual quaternion
- * @param {quat2} a the dual quaternion to rotate
+ * @param {Quat2} out the receiving dual quaternion
+ * @param {Quat2} a the dual quaternion to rotate
  * @param {number} rad how far should the rotation be
- * @returns {quat2} out
+ * @returns {Quat2} out
  */
 export function rotateY(out, a, rad) {
   let bx = -a[0],
@@ -456,10 +456,10 @@ export function rotateY(out, a, rad) {
 /**
  * Rotates a dual quat around the Z axis
  *
- * @param {quat2} out the receiving dual quaternion
- * @param {quat2} a the dual quaternion to rotate
+ * @param {Quat2} out the receiving dual quaternion
+ * @param {Quat2} a the dual quaternion to rotate
  * @param {number} rad how far should the rotation be
- * @returns {quat2} out
+ * @returns {Quat2} out
  */
 export function rotateZ(out, a, rad) {
   let bx = -a[0],
@@ -489,10 +489,10 @@ export function rotateZ(out, a, rad) {
 /**
  * Rotates a dual quat by a given quaternion (a * q)
  *
- * @param {quat2} out the receiving dual quaternion
- * @param {quat2} a the dual quaternion to rotate
- * @param {quat} q quaternion to rotate by
- * @returns {quat2} out
+ * @param {Quat2} out the receiving dual quaternion
+ * @param {Quat2} a the dual quaternion to rotate
+ * @param {Quat} q quaternion to rotate by
+ * @returns {Quat2} out
  */
 export function rotateByQuatAppend(out, a, q) {
   let qx = q[0],
@@ -522,10 +522,10 @@ export function rotateByQuatAppend(out, a, q) {
 /**
  * Rotates a dual quat by a given quaternion (q * a)
  *
- * @param {quat2} out the receiving dual quaternion
- * @param {quat} q quaternion to rotate by
- * @param {quat2} a the dual quaternion to rotate
- * @returns {quat2} out
+ * @param {Quat2} out the receiving dual quaternion
+ * @param {Quat} q quaternion to rotate by
+ * @param {Quat2} a the dual quaternion to rotate
+ * @returns {Quat2} out
  */
 export function rotateByQuatPrepend(out, q, a) {
   let qx = q[0],
@@ -555,11 +555,11 @@ export function rotateByQuatPrepend(out, q, a) {
 /**
  * Rotates a dual quat around a given axis. Does the normalisation automatically
  *
- * @param {quat2} out the receiving dual quaternion
- * @param {quat2} a the dual quaternion to rotate
- * @param {vec3} axis the axis to rotate around
+ * @param {Quat2} out the receiving dual quaternion
+ * @param {Quat2} a the dual quaternion to rotate
+ * @param {Vec3} axis the axis to rotate around
  * @param {Number} rad how far the rotation should be
- * @returns {quat2} out
+ * @returns {Quat2} out
  */
 export function rotateAroundAxis(out, a, axis, rad) {
   //Special case for rad = 0
@@ -599,10 +599,10 @@ export function rotateAroundAxis(out, a, axis, rad) {
 /**
  * Adds two dual quat's
  *
- * @param {quat2} out the receiving dual quaternion
- * @param {quat2} a the first operand
- * @param {quat2} b the second operand
- * @returns {quat2} out
+ * @param {Quat2} out the receiving dual quaternion
+ * @param {Quat2} a the first operand
+ * @param {Quat2} b the second operand
+ * @returns {Quat2} out
  * @function
  */
 export function add(out, a, b) {
@@ -620,10 +620,10 @@ export function add(out, a, b) {
 /**
  * Multiplies two dual quat's
  *
- * @param {quat2} out the receiving dual quaternion
- * @param {quat2} a the first operand
- * @param {quat2} b the second operand
- * @returns {quat2} out
+ * @param {Quat2} out the receiving dual quaternion
+ * @param {Quat2} a the first operand
+ * @param {Quat2} b the second operand
+ * @returns {Quat2} out
  */
 export function multiply(out, a, b) {
   let ax0 = a[0],
@@ -662,10 +662,10 @@ export const mul = multiply;
 /**
  * Scales a dual quat by a scalar number
  *
- * @param {quat2} out the receiving dual quat
- * @param {quat2} a the dual quat to scale
+ * @param {Quat2} out the receiving dual quat
+ * @param {Quat2} a the dual quat to scale
  * @param {Number} b amount to scale the dual quat by
- * @returns {quat2} out
+ * @returns {Quat2} out
  * @function
  */
 export function scale(out, a, b) {
@@ -683,8 +683,8 @@ export function scale(out, a, b) {
 /**
  * Calculates the dot product of two dual quat's (The dot product of the real parts)
  *
- * @param {quat2} a the first operand
- * @param {quat2} b the second operand
+ * @param {Quat2} a the first operand
+ * @param {Quat2} b the second operand
  * @returns {Number} dot product of a and b
  * @function
  */
@@ -694,11 +694,11 @@ export const dot = quat.dot;
  * Performs a linear interpolation between two dual quats's
  * NOTE: The resulting dual quaternions won't always be normalized (The error is most noticeable when t = 0.5)
  *
- * @param {quat2} out the receiving dual quat
- * @param {quat2} a the first operand
- * @param {quat2} b the second operand
+ * @param {Quat2} out the receiving dual quat
+ * @param {Quat2} a the first operand
+ * @param {Quat2} b the second operand
  * @param {Number} t interpolation amount, in the range [0-1], between the two inputs
- * @returns {quat2} out
+ * @returns {Quat2} out
  */
 export function lerp(out, a, b, t) {
   let mt = 1 - t;
@@ -719,9 +719,9 @@ export function lerp(out, a, b, t) {
 /**
  * Calculates the inverse of a dual quat. If they are normalized, conjugate is cheaper
  *
- * @param {quat2} out the receiving dual quaternion
- * @param {quat2} a dual quat to calculate inverse of
- * @returns {quat2} out
+ * @param {Quat2} out the receiving dual quaternion
+ * @param {Quat2} a dual quat to calculate inverse of
+ * @returns {Quat2} out
  */
 export function invert(out, a) {
   let sqlen = squaredLength(a);
@@ -740,9 +740,9 @@ export function invert(out, a) {
  * Calculates the conjugate of a dual quat
  * If the dual quaternion is normalized, this function is faster than quat2.inverse and produces the same result.
  *
- * @param {quat2} out the receiving quaternion
- * @param {quat2} a quat to calculate conjugate of
- * @returns {quat2} out
+ * @param {Quat2} out the receiving quaternion
+ * @param {Quat2} a quat to calculate conjugate of
+ * @returns {Quat2} out
  */
 export function conjugate(out, a) {
   out[0] = -a[0];
@@ -759,7 +759,7 @@ export function conjugate(out, a) {
 /**
  * Calculates the length of a dual quat
  *
- * @param {quat2} a dual quat to calculate length of
+ * @param {Quat2} a dual quat to calculate length of
  * @returns {Number} length of a
  * @function
  */
@@ -774,7 +774,7 @@ export const len = length;
 /**
  * Calculates the squared length of a dual quat
  *
- * @param {quat2} a dual quat to calculate squared length of
+ * @param {Quat2} a dual quat to calculate squared length of
  * @returns {Number} squared length of a
  * @function
  */
@@ -789,9 +789,9 @@ export const sqrLen = squaredLength;
 /**
  * Normalize a dual quat
  *
- * @param {quat2} out the receiving dual quaternion
- * @param {quat2} a dual quaternion to normalize
- * @returns {quat2} out
+ * @param {Quat2} out the receiving dual quaternion
+ * @param {Quat2} a dual quaternion to normalize
+ * @returns {Quat2} out
  * @function
  */
 export function normalize(out, a) {
@@ -827,7 +827,7 @@ export function normalize(out, a) {
 /**
  * Returns a string representation of a dual quatenion
  *
- * @param {quat2} a dual quaternion to represent as a string
+ * @param {Quat2} a dual quaternion to represent as a string
  * @returns {String} string representation of the dual quat
  */
 export function str(a) {
@@ -838,8 +838,8 @@ export function str(a) {
 /**
  * Returns whether or not the dual quaternions have exactly the same elements in the same position (when compared with ===)
  *
- * @param {quat2} a the first dual quaternion.
- * @param {quat2} b the second dual quaternion.
+ * @param {Quat2} a the first dual quaternion.
+ * @param {Quat2} b the second dual quaternion.
  * @returns {Boolean} true if the dual quaternions are equal, false otherwise.
  */
 export function exactEquals(a, b) {
@@ -850,8 +850,8 @@ export function exactEquals(a, b) {
 /**
  * Returns whether or not the dual quaternions have approximately the same elements in the same position.
  *
- * @param {quat2} a the first dual quat.
- * @param {quat2} b the second dual quat.
+ * @param {Quat2} a the first dual quat.
+ * @param {Quat2} b the second dual quat.
  * @returns {Boolean} true if the dual quats are equal, false otherwise.
  */
 export function equals(a, b) {

--- a/docs/vec2.js.html
+++ b/docs/vec2.js.html
@@ -36,7 +36,7 @@
 /**
  * Creates a new, empty vec2
  *
- * @returns {vec2} a new 2D vector
+ * @returns {Vec2} a new 2D vector
  */
 export function create() {
   let out = new glMatrix.ARRAY_TYPE(2);
@@ -50,8 +50,8 @@ export function create() {
 /**
  * Creates a new vec2 initialized with values from an existing vector
  *
- * @param {vec2} a vector to clone
- * @returns {vec2} a new 2D vector
+ * @param {Vec2} a vector to clone
+ * @returns {Vec2} a new 2D vector
  */
 export function clone(a) {
   let out = new glMatrix.ARRAY_TYPE(2);
@@ -65,7 +65,7 @@ export function clone(a) {
  *
  * @param {Number} x X component
  * @param {Number} y Y component
- * @returns {vec2} a new 2D vector
+ * @returns {Vec2} a new 2D vector
  */
 export function fromValues(x, y) {
   let out = new glMatrix.ARRAY_TYPE(2);
@@ -77,9 +77,9 @@ export function fromValues(x, y) {
 /**
  * Copy the values from one vec2 to another
  *
- * @param {vec2} out the receiving vector
- * @param {vec2} a the source vector
- * @returns {vec2} out
+ * @param {Vec2} out the receiving vector
+ * @param {Vec2} a the source vector
+ * @returns {Vec2} out
  */
 export function copy(out, a) {
   out[0] = a[0];
@@ -90,10 +90,10 @@ export function copy(out, a) {
 /**
  * Set the components of a vec2 to the given values
  *
- * @param {vec2} out the receiving vector
+ * @param {Vec2} out the receiving vector
  * @param {Number} x X component
  * @param {Number} y Y component
- * @returns {vec2} out
+ * @returns {Vec2} out
  */
 export function set(out, x, y) {
   out[0] = x;
@@ -104,10 +104,10 @@ export function set(out, x, y) {
 /**
  * Adds two vec2's
  *
- * @param {vec2} out the receiving vector
- * @param {vec2} a the first operand
- * @param {vec2} b the second operand
- * @returns {vec2} out
+ * @param {Vec2} out the receiving vector
+ * @param {Vec2} a the first operand
+ * @param {Vec2} b the second operand
+ * @returns {Vec2} out
  */
 export function add(out, a, b) {
   out[0] = a[0] + b[0];
@@ -118,10 +118,10 @@ export function add(out, a, b) {
 /**
  * Subtracts vector b from vector a
  *
- * @param {vec2} out the receiving vector
- * @param {vec2} a the first operand
- * @param {vec2} b the second operand
- * @returns {vec2} out
+ * @param {Vec2} out the receiving vector
+ * @param {Vec2} a the first operand
+ * @param {Vec2} b the second operand
+ * @returns {Vec2} out
  */
 export function subtract(out, a, b) {
   out[0] = a[0] - b[0];
@@ -132,10 +132,10 @@ export function subtract(out, a, b) {
 /**
  * Multiplies two vec2's
  *
- * @param {vec2} out the receiving vector
- * @param {vec2} a the first operand
- * @param {vec2} b the second operand
- * @returns {vec2} out
+ * @param {Vec2} out the receiving vector
+ * @param {Vec2} a the first operand
+ * @param {Vec2} b the second operand
+ * @returns {Vec2} out
  */
 export function multiply(out, a, b) {
   out[0] = a[0] * b[0];
@@ -146,10 +146,10 @@ export function multiply(out, a, b) {
 /**
  * Divides two vec2's
  *
- * @param {vec2} out the receiving vector
- * @param {vec2} a the first operand
- * @param {vec2} b the second operand
- * @returns {vec2} out
+ * @param {Vec2} out the receiving vector
+ * @param {Vec2} a the first operand
+ * @param {Vec2} b the second operand
+ * @returns {Vec2} out
  */
 export function divide(out, a, b) {
   out[0] = a[0] / b[0];
@@ -160,9 +160,9 @@ export function divide(out, a, b) {
 /**
  * Math.ceil the components of a vec2
  *
- * @param {vec2} out the receiving vector
- * @param {vec2} a vector to ceil
- * @returns {vec2} out
+ * @param {Vec2} out the receiving vector
+ * @param {Vec2} a vector to ceil
+ * @returns {Vec2} out
  */
 export function ceil(out, a) {
   out[0] = Math.ceil(a[0]);
@@ -173,9 +173,9 @@ export function ceil(out, a) {
 /**
  * Math.floor the components of a vec2
  *
- * @param {vec2} out the receiving vector
- * @param {vec2} a vector to floor
- * @returns {vec2} out
+ * @param {Vec2} out the receiving vector
+ * @param {Vec2} a vector to floor
+ * @returns {Vec2} out
  */
 export function floor(out, a) {
   out[0] = Math.floor(a[0]);
@@ -186,10 +186,10 @@ export function floor(out, a) {
 /**
  * Returns the minimum of two vec2's
  *
- * @param {vec2} out the receiving vector
- * @param {vec2} a the first operand
- * @param {vec2} b the second operand
- * @returns {vec2} out
+ * @param {Vec2} out the receiving vector
+ * @param {Vec2} a the first operand
+ * @param {Vec2} b the second operand
+ * @returns {Vec2} out
  */
 export function min(out, a, b) {
   out[0] = Math.min(a[0], b[0]);
@@ -200,10 +200,10 @@ export function min(out, a, b) {
 /**
  * Returns the maximum of two vec2's
  *
- * @param {vec2} out the receiving vector
- * @param {vec2} a the first operand
- * @param {vec2} b the second operand
- * @returns {vec2} out
+ * @param {Vec2} out the receiving vector
+ * @param {Vec2} a the first operand
+ * @param {Vec2} b the second operand
+ * @returns {Vec2} out
  */
 export function max(out, a, b) {
   out[0] = Math.max(a[0], b[0]);
@@ -214,9 +214,9 @@ export function max(out, a, b) {
 /**
  * Math.round the components of a vec2
  *
- * @param {vec2} out the receiving vector
- * @param {vec2} a vector to round
- * @returns {vec2} out
+ * @param {Vec2} out the receiving vector
+ * @param {Vec2} a vector to round
+ * @returns {Vec2} out
  */
 export function round (out, a) {
   out[0] = Math.round(a[0]);
@@ -227,10 +227,10 @@ export function round (out, a) {
 /**
  * Scales a vec2 by a scalar number
  *
- * @param {vec2} out the receiving vector
- * @param {vec2} a the vector to scale
+ * @param {Vec2} out the receiving vector
+ * @param {Vec2} a the vector to scale
  * @param {Number} b amount to scale the vector by
- * @returns {vec2} out
+ * @returns {Vec2} out
  */
 export function scale(out, a, b) {
   out[0] = a[0] * b;
@@ -241,11 +241,11 @@ export function scale(out, a, b) {
 /**
  * Adds two vec2's after scaling the second operand by a scalar value
  *
- * @param {vec2} out the receiving vector
- * @param {vec2} a the first operand
- * @param {vec2} b the second operand
+ * @param {Vec2} out the receiving vector
+ * @param {Vec2} a the first operand
+ * @param {Vec2} b the second operand
  * @param {Number} scale the amount to scale b by before adding
- * @returns {vec2} out
+ * @returns {Vec2} out
  */
 export function scaleAndAdd(out, a, b, scale) {
   out[0] = a[0] + (b[0] * scale);
@@ -256,8 +256,8 @@ export function scaleAndAdd(out, a, b, scale) {
 /**
  * Calculates the euclidian distance between two vec2's
  *
- * @param {vec2} a the first operand
- * @param {vec2} b the second operand
+ * @param {Vec2} a the first operand
+ * @param {Vec2} b the second operand
  * @returns {Number} distance between a and b
  */
 export function distance(a, b) {
@@ -269,8 +269,8 @@ export function distance(a, b) {
 /**
  * Calculates the squared euclidian distance between two vec2's
  *
- * @param {vec2} a the first operand
- * @param {vec2} b the second operand
+ * @param {Vec2} a the first operand
+ * @param {Vec2} b the second operand
  * @returns {Number} squared distance between a and b
  */
 export function squaredDistance(a, b) {
@@ -282,7 +282,7 @@ export function squaredDistance(a, b) {
 /**
  * Calculates the length of a vec2
  *
- * @param {vec2} a vector to calculate length of
+ * @param {Vec2} a vector to calculate length of
  * @returns {Number} length of a
  */
 export function length(a) {
@@ -294,7 +294,7 @@ export function length(a) {
 /**
  * Calculates the squared length of a vec2
  *
- * @param {vec2} a vector to calculate squared length of
+ * @param {Vec2} a vector to calculate squared length of
  * @returns {Number} squared length of a
  */
 export function squaredLength (a) {
@@ -306,9 +306,9 @@ export function squaredLength (a) {
 /**
  * Negates the components of a vec2
  *
- * @param {vec2} out the receiving vector
- * @param {vec2} a vector to negate
- * @returns {vec2} out
+ * @param {Vec2} out the receiving vector
+ * @param {Vec2} a vector to negate
+ * @returns {Vec2} out
  */
 export function negate(out, a) {
   out[0] = -a[0];
@@ -319,9 +319,9 @@ export function negate(out, a) {
 /**
  * Returns the inverse of the components of a vec2
  *
- * @param {vec2} out the receiving vector
- * @param {vec2} a vector to invert
- * @returns {vec2} out
+ * @param {Vec2} out the receiving vector
+ * @param {Vec2} a vector to invert
+ * @returns {Vec2} out
  */
 export function inverse(out, a) {
   out[0] = 1.0 / a[0];
@@ -332,9 +332,9 @@ export function inverse(out, a) {
 /**
  * Normalize a vec2
  *
- * @param {vec2} out the receiving vector
- * @param {vec2} a vector to normalize
- * @returns {vec2} out
+ * @param {Vec2} out the receiving vector
+ * @param {Vec2} a vector to normalize
+ * @returns {Vec2} out
  */
 export function normalize(out, a) {
   var x = a[0],
@@ -352,8 +352,8 @@ export function normalize(out, a) {
 /**
  * Calculates the dot product of two vec2's
  *
- * @param {vec2} a the first operand
- * @param {vec2} b the second operand
+ * @param {Vec2} a the first operand
+ * @param {Vec2} b the second operand
  * @returns {Number} dot product of a and b
  */
 export function dot(a, b) {
@@ -364,10 +364,10 @@ export function dot(a, b) {
  * Computes the cross product of two vec2's
  * Note that the cross product must by definition produce a 3D vector
  *
- * @param {vec3} out the receiving vector
- * @param {vec2} a the first operand
- * @param {vec2} b the second operand
- * @returns {vec3} out
+ * @param {Vec3} out the receiving vector
+ * @param {Vec2} a the first operand
+ * @param {Vec2} b the second operand
+ * @returns {Vec3} out
  */
 export function cross(out, a, b) {
   var z = a[0] * b[1] - a[1] * b[0];
@@ -379,11 +379,11 @@ export function cross(out, a, b) {
 /**
  * Performs a linear interpolation between two vec2's
  *
- * @param {vec2} out the receiving vector
- * @param {vec2} a the first operand
- * @param {vec2} b the second operand
+ * @param {Vec2} out the receiving vector
+ * @param {Vec2} a the first operand
+ * @param {Vec2} b the second operand
  * @param {Number} t interpolation amount, in the range [0-1], between the two inputs
- * @returns {vec2} out
+ * @returns {Vec2} out
  */
 export function lerp(out, a, b, t) {
   var ax = a[0],
@@ -396,9 +396,9 @@ export function lerp(out, a, b, t) {
 /**
  * Generates a random vector with the given scale
  *
- * @param {vec2} out the receiving vector
+ * @param {Vec2} out the receiving vector
  * @param {Number} [scale] Length of the resulting vector. If ommitted, a unit vector will be returned
- * @returns {vec2} out
+ * @returns {Vec2} out
  */
 export function random(out, scale) {
   scale = scale || 1.0;
@@ -411,10 +411,10 @@ export function random(out, scale) {
 /**
  * Transforms the vec2 with a mat2
  *
- * @param {vec2} out the receiving vector
- * @param {vec2} a the vector to transform
- * @param {mat2} m matrix to transform with
- * @returns {vec2} out
+ * @param {Vec2} out the receiving vector
+ * @param {Vec2} a the vector to transform
+ * @param {Mat2} m matrix to transform with
+ * @returns {Vec2} out
  */
 export function transformMat2(out, a, m) {
   var x = a[0],
@@ -427,10 +427,10 @@ export function transformMat2(out, a, m) {
 /**
  * Transforms the vec2 with a mat2d
  *
- * @param {vec2} out the receiving vector
- * @param {vec2} a the vector to transform
- * @param {mat2d} m matrix to transform with
- * @returns {vec2} out
+ * @param {Vec2} out the receiving vector
+ * @param {Vec2} a the vector to transform
+ * @param {Mat2d} m matrix to transform with
+ * @returns {Vec2} out
  */
 export function transformMat2d(out, a, m) {
   var x = a[0],
@@ -444,10 +444,10 @@ export function transformMat2d(out, a, m) {
  * Transforms the vec2 with a mat3
  * 3rd vector component is implicitly '1'
  *
- * @param {vec2} out the receiving vector
- * @param {vec2} a the vector to transform
- * @param {mat3} m matrix to transform with
- * @returns {vec2} out
+ * @param {Vec2} out the receiving vector
+ * @param {Vec2} a the vector to transform
+ * @param {Mat3} m matrix to transform with
+ * @returns {Vec2} out
  */
 export function transformMat3(out, a, m) {
   var x = a[0],
@@ -462,10 +462,10 @@ export function transformMat3(out, a, m) {
  * 3rd vector component is implicitly '0'
  * 4th vector component is implicitly '1'
  *
- * @param {vec2} out the receiving vector
- * @param {vec2} a the vector to transform
- * @param {mat4} m matrix to transform with
- * @returns {vec2} out
+ * @param {Vec2} out the receiving vector
+ * @param {Vec2} a the vector to transform
+ * @param {Mat4} m matrix to transform with
+ * @returns {Vec2} out
  */
 export function transformMat4(out, a, m) {
   let x = a[0];
@@ -477,11 +477,11 @@ export function transformMat4(out, a, m) {
 
 /**
  * Rotate a 2D vector
- * @param {vec2} out The receiving vec2
- * @param {vec2} a The vec2 point to rotate
- * @param {vec2} b The origin of the rotation
+ * @param {Vec2} out The receiving vec2
+ * @param {Vec2} a The vec2 point to rotate
+ * @param {Vec2} b The origin of the rotation
  * @param {Number} c The angle of rotation
- * @returns {vec2} out
+ * @returns {Vec2} out
  */
 export function rotate(out, a, b, c) {
   //Translate point to the origin
@@ -499,8 +499,8 @@ export function rotate(out, a, b, c) {
 
 /**
  * Get the angle between two 2D vectors
- * @param {vec2} a The first operand
- * @param {vec2} b The second operand
+ * @param {Vec2} a The first operand
+ * @param {Vec2} b The second operand
  * @returns {Number} The angle in radians
  */
 export function angle(a, b) {
@@ -537,7 +537,7 @@ export function angle(a, b) {
 /**
  * Returns a string representation of a vector
  *
- * @param {vec2} a vector to represent as a string
+ * @param {Vec2} a vector to represent as a string
  * @returns {String} string representation of the vector
  */
 export function str(a) {
@@ -547,8 +547,8 @@ export function str(a) {
 /**
  * Returns whether or not the vectors exactly have the same elements in the same position (when compared with ===)
  *
- * @param {vec2} a The first vector.
- * @param {vec2} b The second vector.
+ * @param {Vec2} a The first vector.
+ * @param {Vec2} b The second vector.
  * @returns {Boolean} True if the vectors are equal, false otherwise.
  */
 export function exactEquals(a, b) {
@@ -558,8 +558,8 @@ export function exactEquals(a, b) {
 /**
  * Returns whether or not the vectors have approximately the same elements in the same position.
  *
- * @param {vec2} a The first vector.
- * @param {vec2} b The second vector.
+ * @param {Vec2} a The first vector.
+ * @param {Vec2} b The second vector.
  * @returns {Boolean} True if the vectors are equal, false otherwise.
  */
 export function equals(a, b) {

--- a/docs/vec3.js.html
+++ b/docs/vec3.js.html
@@ -36,7 +36,7 @@
 /**
  * Creates a new, empty vec3
  *
- * @returns {vec3} a new 3D vector
+ * @returns {Vec3} a new 3D vector
  */
 export function create() {
   let out = new glMatrix.ARRAY_TYPE(3);
@@ -51,8 +51,8 @@ export function create() {
 /**
  * Creates a new vec3 initialized with values from an existing vector
  *
- * @param {vec3} a vector to clone
- * @returns {vec3} a new 3D vector
+ * @param {Vec3} a vector to clone
+ * @returns {Vec3} a new 3D vector
  */
 export function clone(a) {
   var out = new glMatrix.ARRAY_TYPE(3);
@@ -65,7 +65,7 @@ export function clone(a) {
 /**
  * Calculates the length of a vec3
  *
- * @param {vec3} a vector to calculate length of
+ * @param {Vec3} a vector to calculate length of
  * @returns {Number} length of a
  */
 export function length(a) {
@@ -81,7 +81,7 @@ export function length(a) {
  * @param {Number} x X component
  * @param {Number} y Y component
  * @param {Number} z Z component
- * @returns {vec3} a new 3D vector
+ * @returns {Vec3} a new 3D vector
  */
 export function fromValues(x, y, z) {
   let out = new glMatrix.ARRAY_TYPE(3);
@@ -94,9 +94,9 @@ export function fromValues(x, y, z) {
 /**
  * Copy the values from one vec3 to another
  *
- * @param {vec3} out the receiving vector
- * @param {vec3} a the source vector
- * @returns {vec3} out
+ * @param {Vec3} out the receiving vector
+ * @param {Vec3} a the source vector
+ * @returns {Vec3} out
  */
 export function copy(out, a) {
   out[0] = a[0];
@@ -108,11 +108,11 @@ export function copy(out, a) {
 /**
  * Set the components of a vec3 to the given values
  *
- * @param {vec3} out the receiving vector
+ * @param {Vec3} out the receiving vector
  * @param {Number} x X component
  * @param {Number} y Y component
  * @param {Number} z Z component
- * @returns {vec3} out
+ * @returns {Vec3} out
  */
 export function set(out, x, y, z) {
   out[0] = x;
@@ -124,10 +124,10 @@ export function set(out, x, y, z) {
 /**
  * Adds two vec3's
  *
- * @param {vec3} out the receiving vector
- * @param {vec3} a the first operand
- * @param {vec3} b the second operand
- * @returns {vec3} out
+ * @param {Vec3} out the receiving vector
+ * @param {Vec3} a the first operand
+ * @param {Vec3} b the second operand
+ * @returns {Vec3} out
  */
 export function add(out, a, b) {
   out[0] = a[0] + b[0];
@@ -139,10 +139,10 @@ export function add(out, a, b) {
 /**
  * Subtracts vector b from vector a
  *
- * @param {vec3} out the receiving vector
- * @param {vec3} a the first operand
- * @param {vec3} b the second operand
- * @returns {vec3} out
+ * @param {Vec3} out the receiving vector
+ * @param {Vec3} a the first operand
+ * @param {Vec3} b the second operand
+ * @returns {Vec3} out
  */
 export function subtract(out, a, b) {
   out[0] = a[0] - b[0];
@@ -154,10 +154,10 @@ export function subtract(out, a, b) {
 /**
  * Multiplies two vec3's
  *
- * @param {vec3} out the receiving vector
- * @param {vec3} a the first operand
- * @param {vec3} b the second operand
- * @returns {vec3} out
+ * @param {Vec3} out the receiving vector
+ * @param {Vec3} a the first operand
+ * @param {Vec3} b the second operand
+ * @returns {Vec3} out
  */
 export function multiply(out, a, b) {
   out[0] = a[0] * b[0];
@@ -169,10 +169,10 @@ export function multiply(out, a, b) {
 /**
  * Divides two vec3's
  *
- * @param {vec3} out the receiving vector
- * @param {vec3} a the first operand
- * @param {vec3} b the second operand
- * @returns {vec3} out
+ * @param {Vec3} out the receiving vector
+ * @param {Vec3} a the first operand
+ * @param {Vec3} b the second operand
+ * @returns {Vec3} out
  */
 export function divide(out, a, b) {
   out[0] = a[0] / b[0];
@@ -184,9 +184,9 @@ export function divide(out, a, b) {
 /**
  * Math.ceil the components of a vec3
  *
- * @param {vec3} out the receiving vector
- * @param {vec3} a vector to ceil
- * @returns {vec3} out
+ * @param {Vec3} out the receiving vector
+ * @param {Vec3} a vector to ceil
+ * @returns {Vec3} out
  */
 export function ceil(out, a) {
   out[0] = Math.ceil(a[0]);
@@ -198,9 +198,9 @@ export function ceil(out, a) {
 /**
  * Math.floor the components of a vec3
  *
- * @param {vec3} out the receiving vector
- * @param {vec3} a vector to floor
- * @returns {vec3} out
+ * @param {Vec3} out the receiving vector
+ * @param {Vec3} a vector to floor
+ * @returns {Vec3} out
  */
 export function floor(out, a) {
   out[0] = Math.floor(a[0]);
@@ -212,10 +212,10 @@ export function floor(out, a) {
 /**
  * Returns the minimum of two vec3's
  *
- * @param {vec3} out the receiving vector
- * @param {vec3} a the first operand
- * @param {vec3} b the second operand
- * @returns {vec3} out
+ * @param {Vec3} out the receiving vector
+ * @param {Vec3} a the first operand
+ * @param {Vec3} b the second operand
+ * @returns {Vec3} out
  */
 export function min(out, a, b) {
   out[0] = Math.min(a[0], b[0]);
@@ -227,10 +227,10 @@ export function min(out, a, b) {
 /**
  * Returns the maximum of two vec3's
  *
- * @param {vec3} out the receiving vector
- * @param {vec3} a the first operand
- * @param {vec3} b the second operand
- * @returns {vec3} out
+ * @param {Vec3} out the receiving vector
+ * @param {Vec3} a the first operand
+ * @param {Vec3} b the second operand
+ * @returns {Vec3} out
  */
 export function max(out, a, b) {
   out[0] = Math.max(a[0], b[0]);
@@ -242,9 +242,9 @@ export function max(out, a, b) {
 /**
  * Math.round the components of a vec3
  *
- * @param {vec3} out the receiving vector
- * @param {vec3} a vector to round
- * @returns {vec3} out
+ * @param {Vec3} out the receiving vector
+ * @param {Vec3} a vector to round
+ * @returns {Vec3} out
  */
 export function round(out, a) {
   out[0] = Math.round(a[0]);
@@ -256,10 +256,10 @@ export function round(out, a) {
 /**
  * Scales a vec3 by a scalar number
  *
- * @param {vec3} out the receiving vector
- * @param {vec3} a the vector to scale
+ * @param {Vec3} out the receiving vector
+ * @param {Vec3} a the vector to scale
  * @param {Number} b amount to scale the vector by
- * @returns {vec3} out
+ * @returns {Vec3} out
  */
 export function scale(out, a, b) {
   out[0] = a[0] * b;
@@ -271,11 +271,11 @@ export function scale(out, a, b) {
 /**
  * Adds two vec3's after scaling the second operand by a scalar value
  *
- * @param {vec3} out the receiving vector
- * @param {vec3} a the first operand
- * @param {vec3} b the second operand
+ * @param {Vec3} out the receiving vector
+ * @param {Vec3} a the first operand
+ * @param {Vec3} b the second operand
  * @param {Number} scale the amount to scale b by before adding
- * @returns {vec3} out
+ * @returns {Vec3} out
  */
 export function scaleAndAdd(out, a, b, scale) {
   out[0] = a[0] + (b[0] * scale);
@@ -287,8 +287,8 @@ export function scaleAndAdd(out, a, b, scale) {
 /**
  * Calculates the euclidian distance between two vec3's
  *
- * @param {vec3} a the first operand
- * @param {vec3} b the second operand
+ * @param {Vec3} a the first operand
+ * @param {Vec3} b the second operand
  * @returns {Number} distance between a and b
  */
 export function distance(a, b) {
@@ -301,8 +301,8 @@ export function distance(a, b) {
 /**
  * Calculates the squared euclidian distance between two vec3's
  *
- * @param {vec3} a the first operand
- * @param {vec3} b the second operand
+ * @param {Vec3} a the first operand
+ * @param {Vec3} b the second operand
  * @returns {Number} squared distance between a and b
  */
 export function squaredDistance(a, b) {
@@ -315,7 +315,7 @@ export function squaredDistance(a, b) {
 /**
  * Calculates the squared length of a vec3
  *
- * @param {vec3} a vector to calculate squared length of
+ * @param {Vec3} a vector to calculate squared length of
  * @returns {Number} squared length of a
  */
 export function squaredLength(a) {
@@ -328,9 +328,9 @@ export function squaredLength(a) {
 /**
  * Negates the components of a vec3
  *
- * @param {vec3} out the receiving vector
- * @param {vec3} a vector to negate
- * @returns {vec3} out
+ * @param {Vec3} out the receiving vector
+ * @param {Vec3} a vector to negate
+ * @returns {Vec3} out
  */
 export function negate(out, a) {
   out[0] = -a[0];
@@ -342,9 +342,9 @@ export function negate(out, a) {
 /**
  * Returns the inverse of the components of a vec3
  *
- * @param {vec3} out the receiving vector
- * @param {vec3} a vector to invert
- * @returns {vec3} out
+ * @param {Vec3} out the receiving vector
+ * @param {Vec3} a vector to invert
+ * @returns {Vec3} out
  */
 export function inverse(out, a) {
   out[0] = 1.0 / a[0];
@@ -356,9 +356,9 @@ export function inverse(out, a) {
 /**
  * Normalize a vec3
  *
- * @param {vec3} out the receiving vector
- * @param {vec3} a vector to normalize
- * @returns {vec3} out
+ * @param {Vec3} out the receiving vector
+ * @param {Vec3} a vector to normalize
+ * @returns {Vec3} out
  */
 export function normalize(out, a) {
   let x = a[0];
@@ -378,8 +378,8 @@ export function normalize(out, a) {
 /**
  * Calculates the dot product of two vec3's
  *
- * @param {vec3} a the first operand
- * @param {vec3} b the second operand
+ * @param {Vec3} a the first operand
+ * @param {Vec3} b the second operand
  * @returns {Number} dot product of a and b
  */
 export function dot(a, b) {
@@ -389,10 +389,10 @@ export function dot(a, b) {
 /**
  * Computes the cross product of two vec3's
  *
- * @param {vec3} out the receiving vector
- * @param {vec3} a the first operand
- * @param {vec3} b the second operand
- * @returns {vec3} out
+ * @param {Vec3} out the receiving vector
+ * @param {Vec3} a the first operand
+ * @param {Vec3} b the second operand
+ * @returns {Vec3} out
  */
 export function cross(out, a, b) {
   let ax = a[0], ay = a[1], az = a[2];
@@ -407,11 +407,11 @@ export function cross(out, a, b) {
 /**
  * Performs a linear interpolation between two vec3's
  *
- * @param {vec3} out the receiving vector
- * @param {vec3} a the first operand
- * @param {vec3} b the second operand
+ * @param {Vec3} out the receiving vector
+ * @param {Vec3} a the first operand
+ * @param {Vec3} b the second operand
  * @param {Number} t interpolation amount, in the range [0-1], between the two inputs
- * @returns {vec3} out
+ * @returns {Vec3} out
  */
 export function lerp(out, a, b, t) {
   let ax = a[0];
@@ -426,13 +426,13 @@ export function lerp(out, a, b, t) {
 /**
  * Performs a hermite interpolation with two control points
  *
- * @param {vec3} out the receiving vector
- * @param {vec3} a the first operand
- * @param {vec3} b the second operand
- * @param {vec3} c the third operand
- * @param {vec3} d the fourth operand
+ * @param {Vec3} out the receiving vector
+ * @param {Vec3} a the first operand
+ * @param {Vec3} b the second operand
+ * @param {Vec3} c the third operand
+ * @param {Vec3} d the fourth operand
  * @param {Number} t interpolation amount, in the range [0-1], between the two inputs
- * @returns {vec3} out
+ * @returns {Vec3} out
  */
 export function hermite(out, a, b, c, d, t) {
   let factorTimes2 = t * t;
@@ -451,13 +451,13 @@ export function hermite(out, a, b, c, d, t) {
 /**
  * Performs a bezier interpolation with two control points
  *
- * @param {vec3} out the receiving vector
- * @param {vec3} a the first operand
- * @param {vec3} b the second operand
- * @param {vec3} c the third operand
- * @param {vec3} d the fourth operand
+ * @param {Vec3} out the receiving vector
+ * @param {Vec3} a the first operand
+ * @param {Vec3} b the second operand
+ * @param {Vec3} c the third operand
+ * @param {Vec3} d the fourth operand
  * @param {Number} t interpolation amount, in the range [0-1], between the two inputs
- * @returns {vec3} out
+ * @returns {Vec3} out
  */
 export function bezier(out, a, b, c, d, t) {
   let inverseFactor = 1 - t;
@@ -478,9 +478,9 @@ export function bezier(out, a, b, c, d, t) {
 /**
  * Generates a random vector with the given scale
  *
- * @param {vec3} out the receiving vector
+ * @param {Vec3} out the receiving vector
  * @param {Number} [scale] Length of the resulting vector. If ommitted, a unit vector will be returned
- * @returns {vec3} out
+ * @returns {Vec3} out
  */
 export function random(out, scale) {
   scale = scale || 1.0;
@@ -499,10 +499,10 @@ export function random(out, scale) {
  * Transforms the vec3 with a mat4.
  * 4th vector component is implicitly '1'
  *
- * @param {vec3} out the receiving vector
- * @param {vec3} a the vector to transform
- * @param {mat4} m matrix to transform with
- * @returns {vec3} out
+ * @param {Vec3} out the receiving vector
+ * @param {Vec3} a the vector to transform
+ * @param {Mat4} m matrix to transform with
+ * @returns {Vec3} out
  */
 export function transformMat4(out, a, m) {
   let x = a[0], y = a[1], z = a[2];
@@ -517,10 +517,10 @@ export function transformMat4(out, a, m) {
 /**
  * Transforms the vec3 with a mat3.
  *
- * @param {vec3} out the receiving vector
- * @param {vec3} a the vector to transform
- * @param {mat3} m the 3x3 matrix to transform with
- * @returns {vec3} out
+ * @param {Vec3} out the receiving vector
+ * @param {Vec3} a the vector to transform
+ * @param {Mat3} m the 3x3 matrix to transform with
+ * @returns {Vec3} out
  */
 export function transformMat3(out, a, m) {
   let x = a[0], y = a[1], z = a[2];
@@ -534,10 +534,10 @@ export function transformMat3(out, a, m) {
  * Transforms the vec3 with a quat
  * Can also be used for dual quaternions. (Multiply it with the real part)
  *
- * @param {vec3} out the receiving vector
- * @param {vec3} a the vector to transform
- * @param {quat} q quaternion to transform with
- * @returns {vec3} out
+ * @param {Vec3} out the receiving vector
+ * @param {Vec3} a the vector to transform
+ * @param {Quat} q quaternion to transform with
+ * @returns {Vec3} out
  */
 export function transformQuat(out, a, q) {
     // benchmarks: https://jsperf.com/quaternion-transform-vec3-implementations-fixed
@@ -570,11 +570,11 @@ export function transformQuat(out, a, q) {
 
 /**
  * Rotate a 3D vector around the x-axis
- * @param {vec3} out The receiving vec3
- * @param {vec3} a The vec3 point to rotate
- * @param {vec3} b The origin of the rotation
+ * @param {Vec3} out The receiving vec3
+ * @param {Vec3} a The vec3 point to rotate
+ * @param {Vec3} b The origin of the rotation
  * @param {Number} c The angle of rotation
- * @returns {vec3} out
+ * @returns {Vec3} out
  */
 export function rotateX(out, a, b, c){
   let p = [], r=[];
@@ -598,11 +598,11 @@ export function rotateX(out, a, b, c){
 
 /**
  * Rotate a 3D vector around the y-axis
- * @param {vec3} out The receiving vec3
- * @param {vec3} a The vec3 point to rotate
- * @param {vec3} b The origin of the rotation
+ * @param {Vec3} out The receiving vec3
+ * @param {Vec3} a The vec3 point to rotate
+ * @param {Vec3} b The origin of the rotation
  * @param {Number} c The angle of rotation
- * @returns {vec3} out
+ * @returns {Vec3} out
  */
 export function rotateY(out, a, b, c){
   let p = [], r=[];
@@ -626,11 +626,11 @@ export function rotateY(out, a, b, c){
 
 /**
  * Rotate a 3D vector around the z-axis
- * @param {vec3} out The receiving vec3
- * @param {vec3} a The vec3 point to rotate
- * @param {vec3} b The origin of the rotation
+ * @param {Vec3} out The receiving vec3
+ * @param {Vec3} a The vec3 point to rotate
+ * @param {Vec3} b The origin of the rotation
  * @param {Number} c The angle of rotation
- * @returns {vec3} out
+ * @returns {Vec3} out
  */
 export function rotateZ(out, a, b, c){
   let p = [], r=[];
@@ -654,8 +654,8 @@ export function rotateZ(out, a, b, c){
 
 /**
  * Get the angle between two 3D vectors
- * @param {vec3} a The first operand
- * @param {vec3} b The second operand
+ * @param {Vec3} a The first operand
+ * @param {Vec3} b The second operand
  * @returns {Number} The angle in radians
  */
 export function angle(a, b) {
@@ -680,7 +680,7 @@ export function angle(a, b) {
 /**
  * Returns a string representation of a vector
  *
- * @param {vec3} a vector to represent as a string
+ * @param {Vec3} a vector to represent as a string
  * @returns {String} string representation of the vector
  */
 export function str(a) {
@@ -690,8 +690,8 @@ export function str(a) {
 /**
  * Returns whether or not the vectors have exactly the same elements in the same position (when compared with ===)
  *
- * @param {vec3} a The first vector.
- * @param {vec3} b The second vector.
+ * @param {Vec3} a The first vector.
+ * @param {Vec3} b The second vector.
  * @returns {Boolean} True if the vectors are equal, false otherwise.
  */
 export function exactEquals(a, b) {
@@ -701,8 +701,8 @@ export function exactEquals(a, b) {
 /**
  * Returns whether or not the vectors have approximately the same elements in the same position.
  *
- * @param {vec3} a The first vector.
- * @param {vec3} b The second vector.
+ * @param {Vec3} a The first vector.
+ * @param {Vec3} b The second vector.
  * @returns {Boolean} True if the vectors are equal, false otherwise.
  */
 export function equals(a, b) {

--- a/docs/vec4.js.html
+++ b/docs/vec4.js.html
@@ -36,7 +36,7 @@
 /**
  * Creates a new, empty vec4
  *
- * @returns {vec4} a new 4D vector
+ * @returns {Vec4} a new 4D vector
  */
 export function create() {
   let out = new glMatrix.ARRAY_TYPE(4);
@@ -52,8 +52,8 @@ export function create() {
 /**
  * Creates a new vec4 initialized with values from an existing vector
  *
- * @param {vec4} a vector to clone
- * @returns {vec4} a new 4D vector
+ * @param {Vec4} a vector to clone
+ * @returns {Vec4} a new 4D vector
  */
 export function clone(a) {
   let out = new glMatrix.ARRAY_TYPE(4);
@@ -71,7 +71,7 @@ export function clone(a) {
  * @param {Number} y Y component
  * @param {Number} z Z component
  * @param {Number} w W component
- * @returns {vec4} a new 4D vector
+ * @returns {Vec4} a new 4D vector
  */
 export function fromValues(x, y, z, w) {
   let out = new glMatrix.ARRAY_TYPE(4);
@@ -85,9 +85,9 @@ export function fromValues(x, y, z, w) {
 /**
  * Copy the values from one vec4 to another
  *
- * @param {vec4} out the receiving vector
- * @param {vec4} a the source vector
- * @returns {vec4} out
+ * @param {Vec4} out the receiving vector
+ * @param {Vec4} a the source vector
+ * @returns {Vec4} out
  */
 export function copy(out, a) {
   out[0] = a[0];
@@ -100,12 +100,12 @@ export function copy(out, a) {
 /**
  * Set the components of a vec4 to the given values
  *
- * @param {vec4} out the receiving vector
+ * @param {Vec4} out the receiving vector
  * @param {Number} x X component
  * @param {Number} y Y component
  * @param {Number} z Z component
  * @param {Number} w W component
- * @returns {vec4} out
+ * @returns {Vec4} out
  */
 export function set(out, x, y, z, w) {
   out[0] = x;
@@ -118,10 +118,10 @@ export function set(out, x, y, z, w) {
 /**
  * Adds two vec4's
  *
- * @param {vec4} out the receiving vector
- * @param {vec4} a the first operand
- * @param {vec4} b the second operand
- * @returns {vec4} out
+ * @param {Vec4} out the receiving vector
+ * @param {Vec4} a the first operand
+ * @param {Vec4} b the second operand
+ * @returns {Vec4} out
  */
 export function add(out, a, b) {
   out[0] = a[0] + b[0];
@@ -134,10 +134,10 @@ export function add(out, a, b) {
 /**
  * Subtracts vector b from vector a
  *
- * @param {vec4} out the receiving vector
- * @param {vec4} a the first operand
- * @param {vec4} b the second operand
- * @returns {vec4} out
+ * @param {Vec4} out the receiving vector
+ * @param {Vec4} a the first operand
+ * @param {Vec4} b the second operand
+ * @returns {Vec4} out
  */
 export function subtract(out, a, b) {
   out[0] = a[0] - b[0];
@@ -150,10 +150,10 @@ export function subtract(out, a, b) {
 /**
  * Multiplies two vec4's
  *
- * @param {vec4} out the receiving vector
- * @param {vec4} a the first operand
- * @param {vec4} b the second operand
- * @returns {vec4} out
+ * @param {Vec4} out the receiving vector
+ * @param {Vec4} a the first operand
+ * @param {Vec4} b the second operand
+ * @returns {Vec4} out
  */
 export function multiply(out, a, b) {
   out[0] = a[0] * b[0];
@@ -166,10 +166,10 @@ export function multiply(out, a, b) {
 /**
  * Divides two vec4's
  *
- * @param {vec4} out the receiving vector
- * @param {vec4} a the first operand
- * @param {vec4} b the second operand
- * @returns {vec4} out
+ * @param {Vec4} out the receiving vector
+ * @param {Vec4} a the first operand
+ * @param {Vec4} b the second operand
+ * @returns {Vec4} out
  */
 export function divide(out, a, b) {
   out[0] = a[0] / b[0];
@@ -182,9 +182,9 @@ export function divide(out, a, b) {
 /**
  * Math.ceil the components of a vec4
  *
- * @param {vec4} out the receiving vector
- * @param {vec4} a vector to ceil
- * @returns {vec4} out
+ * @param {Vec4} out the receiving vector
+ * @param {Vec4} a vector to ceil
+ * @returns {Vec4} out
  */
 export function ceil(out, a) {
   out[0] = Math.ceil(a[0]);
@@ -197,9 +197,9 @@ export function ceil(out, a) {
 /**
  * Math.floor the components of a vec4
  *
- * @param {vec4} out the receiving vector
- * @param {vec4} a vector to floor
- * @returns {vec4} out
+ * @param {Vec4} out the receiving vector
+ * @param {Vec4} a vector to floor
+ * @returns {Vec4} out
  */
 export function floor(out, a) {
   out[0] = Math.floor(a[0]);
@@ -212,10 +212,10 @@ export function floor(out, a) {
 /**
  * Returns the minimum of two vec4's
  *
- * @param {vec4} out the receiving vector
- * @param {vec4} a the first operand
- * @param {vec4} b the second operand
- * @returns {vec4} out
+ * @param {Vec4} out the receiving vector
+ * @param {Vec4} a the first operand
+ * @param {Vec4} b the second operand
+ * @returns {Vec4} out
  */
 export function min(out, a, b) {
   out[0] = Math.min(a[0], b[0]);
@@ -228,10 +228,10 @@ export function min(out, a, b) {
 /**
  * Returns the maximum of two vec4's
  *
- * @param {vec4} out the receiving vector
- * @param {vec4} a the first operand
- * @param {vec4} b the second operand
- * @returns {vec4} out
+ * @param {Vec4} out the receiving vector
+ * @param {Vec4} a the first operand
+ * @param {Vec4} b the second operand
+ * @returns {Vec4} out
  */
 export function max(out, a, b) {
   out[0] = Math.max(a[0], b[0]);
@@ -244,9 +244,9 @@ export function max(out, a, b) {
 /**
  * Math.round the components of a vec4
  *
- * @param {vec4} out the receiving vector
- * @param {vec4} a vector to round
- * @returns {vec4} out
+ * @param {Vec4} out the receiving vector
+ * @param {Vec4} a vector to round
+ * @returns {Vec4} out
  */
 export function round(out, a) {
   out[0] = Math.round(a[0]);
@@ -259,10 +259,10 @@ export function round(out, a) {
 /**
  * Scales a vec4 by a scalar number
  *
- * @param {vec4} out the receiving vector
- * @param {vec4} a the vector to scale
+ * @param {Vec4} out the receiving vector
+ * @param {Vec4} a the vector to scale
  * @param {Number} b amount to scale the vector by
- * @returns {vec4} out
+ * @returns {Vec4} out
  */
 export function scale(out, a, b) {
   out[0] = a[0] * b;
@@ -275,11 +275,11 @@ export function scale(out, a, b) {
 /**
  * Adds two vec4's after scaling the second operand by a scalar value
  *
- * @param {vec4} out the receiving vector
- * @param {vec4} a the first operand
- * @param {vec4} b the second operand
+ * @param {Vec4} out the receiving vector
+ * @param {Vec4} a the first operand
+ * @param {Vec4} b the second operand
  * @param {Number} scale the amount to scale b by before adding
- * @returns {vec4} out
+ * @returns {Vec4} out
  */
 export function scaleAndAdd(out, a, b, scale) {
   out[0] = a[0] + (b[0] * scale);
@@ -292,8 +292,8 @@ export function scaleAndAdd(out, a, b, scale) {
 /**
  * Calculates the euclidian distance between two vec4's
  *
- * @param {vec4} a the first operand
- * @param {vec4} b the second operand
+ * @param {Vec4} a the first operand
+ * @param {Vec4} b the second operand
  * @returns {Number} distance between a and b
  */
 export function distance(a, b) {
@@ -307,8 +307,8 @@ export function distance(a, b) {
 /**
  * Calculates the squared euclidian distance between two vec4's
  *
- * @param {vec4} a the first operand
- * @param {vec4} b the second operand
+ * @param {Vec4} a the first operand
+ * @param {Vec4} b the second operand
  * @returns {Number} squared distance between a and b
  */
 export function squaredDistance(a, b) {
@@ -322,7 +322,7 @@ export function squaredDistance(a, b) {
 /**
  * Calculates the length of a vec4
  *
- * @param {vec4} a vector to calculate length of
+ * @param {Vec4} a vector to calculate length of
  * @returns {Number} length of a
  */
 export function length(a) {
@@ -336,7 +336,7 @@ export function length(a) {
 /**
  * Calculates the squared length of a vec4
  *
- * @param {vec4} a vector to calculate squared length of
+ * @param {Vec4} a vector to calculate squared length of
  * @returns {Number} squared length of a
  */
 export function squaredLength(a) {
@@ -350,9 +350,9 @@ export function squaredLength(a) {
 /**
  * Negates the components of a vec4
  *
- * @param {vec4} out the receiving vector
- * @param {vec4} a vector to negate
- * @returns {vec4} out
+ * @param {Vec4} out the receiving vector
+ * @param {Vec4} a vector to negate
+ * @returns {Vec4} out
  */
 export function negate(out, a) {
   out[0] = -a[0];
@@ -365,9 +365,9 @@ export function negate(out, a) {
 /**
  * Returns the inverse of the components of a vec4
  *
- * @param {vec4} out the receiving vector
- * @param {vec4} a vector to invert
- * @returns {vec4} out
+ * @param {Vec4} out the receiving vector
+ * @param {Vec4} a vector to invert
+ * @returns {Vec4} out
  */
 export function inverse(out, a) {
   out[0] = 1.0 / a[0];
@@ -380,9 +380,9 @@ export function inverse(out, a) {
 /**
  * Normalize a vec4
  *
- * @param {vec4} out the receiving vector
- * @param {vec4} a vector to normalize
- * @returns {vec4} out
+ * @param {Vec4} out the receiving vector
+ * @param {Vec4} a vector to normalize
+ * @returns {Vec4} out
  */
 export function normalize(out, a) {
   let x = a[0];
@@ -403,8 +403,8 @@ export function normalize(out, a) {
 /**
  * Calculates the dot product of two vec4's
  *
- * @param {vec4} a the first operand
- * @param {vec4} b the second operand
+ * @param {Vec4} a the first operand
+ * @param {Vec4} b the second operand
  * @returns {Number} dot product of a and b
  */
 export function dot(a, b) {
@@ -414,11 +414,11 @@ export function dot(a, b) {
 /**
  * Performs a linear interpolation between two vec4's
  *
- * @param {vec4} out the receiving vector
- * @param {vec4} a the first operand
- * @param {vec4} b the second operand
+ * @param {Vec4} out the receiving vector
+ * @param {Vec4} a the first operand
+ * @param {Vec4} b the second operand
  * @param {Number} t interpolation amount, in the range [0-1], between the two inputs
- * @returns {vec4} out
+ * @returns {Vec4} out
  */
 export function lerp(out, a, b, t) {
   let ax = a[0];
@@ -435,9 +435,9 @@ export function lerp(out, a, b, t) {
 /**
  * Generates a random vector with the given scale
  *
- * @param {vec4} out the receiving vector
+ * @param {Vec4} out the receiving vector
  * @param {Number} [scale] Length of the resulting vector. If ommitted, a unit vector will be returned
- * @returns {vec4} out
+ * @returns {Vec4} out
  */
 export function random(out, scale) {
   scale = scale || 1.0;
@@ -469,10 +469,10 @@ export function random(out, scale) {
 /**
  * Transforms the vec4 with a mat4.
  *
- * @param {vec4} out the receiving vector
- * @param {vec4} a the vector to transform
- * @param {mat4} m matrix to transform with
- * @returns {vec4} out
+ * @param {Vec4} out the receiving vector
+ * @param {Vec4} a the vector to transform
+ * @param {Mat4} m matrix to transform with
+ * @returns {Vec4} out
  */
 export function transformMat4(out, a, m) {
   let x = a[0], y = a[1], z = a[2], w = a[3];
@@ -486,10 +486,10 @@ export function transformMat4(out, a, m) {
 /**
  * Transforms the vec4 with a quat
  *
- * @param {vec4} out the receiving vector
- * @param {vec4} a the vector to transform
- * @param {quat} q quaternion to transform with
- * @returns {vec4} out
+ * @param {Vec4} out the receiving vector
+ * @param {Vec4} a the vector to transform
+ * @param {Quat} q quaternion to transform with
+ * @returns {Vec4} out
  */
 export function transformQuat(out, a, q) {
   let x = a[0], y = a[1], z = a[2];
@@ -512,7 +512,7 @@ export function transformQuat(out, a, q) {
 /**
  * Returns a string representation of a vector
  *
- * @param {vec4} a vector to represent as a string
+ * @param {Vec4} a vector to represent as a string
  * @returns {String} string representation of the vector
  */
 export function str(a) {
@@ -522,8 +522,8 @@ export function str(a) {
 /**
  * Returns whether or not the vectors have exactly the same elements in the same position (when compared with ===)
  *
- * @param {vec4} a The first vector.
- * @param {vec4} b The second vector.
+ * @param {Vec4} a The first vector.
+ * @param {Vec4} b The second vector.
  * @returns {Boolean} True if the vectors are equal, false otherwise.
  */
 export function exactEquals(a, b) {
@@ -533,8 +533,8 @@ export function exactEquals(a, b) {
 /**
  * Returns whether or not the vectors have approximately the same elements in the same position.
  *
- * @param {vec4} a The first vector.
- * @param {vec4} b The second vector.
+ * @param {Vec4} a The first vector.
+ * @param {Vec4} b The second vector.
  * @returns {Boolean} True if the vectors are equal, false otherwise.
  */
 export function equals(a, b) {

--- a/src/mat2.js
+++ b/src/mat2.js
@@ -8,7 +8,7 @@ import * as glMatrix from "./common.js"
 /**
  * Creates a new identity mat2
  *
- * @returns {mat2} a new 2x2 matrix
+ * @returns {Mat2} a new 2x2 matrix
  */
 export function create() {
   let out = new glMatrix.ARRAY_TYPE(4);
@@ -24,8 +24,8 @@ export function create() {
 /**
  * Creates a new mat2 initialized with values from an existing matrix
  *
- * @param {mat2} a matrix to clone
- * @returns {mat2} a new 2x2 matrix
+ * @param {Mat2} a matrix to clone
+ * @returns {Mat2} a new 2x2 matrix
  */
 export function clone(a) {
   let out = new glMatrix.ARRAY_TYPE(4);
@@ -39,9 +39,9 @@ export function clone(a) {
 /**
  * Copy the values from one mat2 to another
  *
- * @param {mat2} out the receiving matrix
- * @param {mat2} a the source matrix
- * @returns {mat2} out
+ * @param {Mat2} out the receiving matrix
+ * @param {Mat2} a the source matrix
+ * @returns {Mat2} out
  */
 export function copy(out, a) {
   out[0] = a[0];
@@ -54,8 +54,8 @@ export function copy(out, a) {
 /**
  * Set a mat2 to the identity matrix
  *
- * @param {mat2} out the receiving matrix
- * @returns {mat2} out
+ * @param {Mat2} out the receiving matrix
+ * @returns {Mat2} out
  */
 export function identity(out) {
   out[0] = 1;
@@ -72,7 +72,7 @@ export function identity(out) {
  * @param {Number} m01 Component in column 0, row 1 position (index 1)
  * @param {Number} m10 Component in column 1, row 0 position (index 2)
  * @param {Number} m11 Component in column 1, row 1 position (index 3)
- * @returns {mat2} out A new 2x2 matrix
+ * @returns {Mat2} out A new 2x2 matrix
  */
 export function fromValues(m00, m01, m10, m11) {
   let out = new glMatrix.ARRAY_TYPE(4);
@@ -86,12 +86,12 @@ export function fromValues(m00, m01, m10, m11) {
 /**
  * Set the components of a mat2 to the given values
  *
- * @param {mat2} out the receiving matrix
+ * @param {Mat2} out the receiving matrix
  * @param {Number} m00 Component in column 0, row 0 position (index 0)
  * @param {Number} m01 Component in column 0, row 1 position (index 1)
  * @param {Number} m10 Component in column 1, row 0 position (index 2)
  * @param {Number} m11 Component in column 1, row 1 position (index 3)
- * @returns {mat2} out
+ * @returns {Mat2} out
  */
 export function set(out, m00, m01, m10, m11) {
   out[0] = m00;
@@ -104,9 +104,9 @@ export function set(out, m00, m01, m10, m11) {
 /**
  * Transpose the values of a mat2
  *
- * @param {mat2} out the receiving matrix
- * @param {mat2} a the source matrix
- * @returns {mat2} out
+ * @param {Mat2} out the receiving matrix
+ * @param {Mat2} a the source matrix
+ * @returns {Mat2} out
  */
 export function transpose(out, a) {
   // If we are transposing ourselves we can skip a few steps but have to cache
@@ -128,9 +128,9 @@ export function transpose(out, a) {
 /**
  * Inverts a mat2
  *
- * @param {mat2} out the receiving matrix
- * @param {mat2} a the source matrix
- * @returns {mat2} out
+ * @param {Mat2} out the receiving matrix
+ * @param {Mat2} a the source matrix
+ * @returns {Mat2} out
  */
 export function invert(out, a) {
   let a0 = a[0], a1 = a[1], a2 = a[2], a3 = a[3];
@@ -154,9 +154,9 @@ export function invert(out, a) {
 /**
  * Calculates the adjugate of a mat2
  *
- * @param {mat2} out the receiving matrix
- * @param {mat2} a the source matrix
- * @returns {mat2} out
+ * @param {Mat2} out the receiving matrix
+ * @param {Mat2} a the source matrix
+ * @returns {Mat2} out
  */
 export function adjoint(out, a) {
   // Caching this value is nessecary if out == a
@@ -172,7 +172,7 @@ export function adjoint(out, a) {
 /**
  * Calculates the determinant of a mat2
  *
- * @param {mat2} a the source matrix
+ * @param {Mat2} a the source matrix
  * @returns {Number} determinant of a
  */
 export function determinant(a) {
@@ -182,10 +182,10 @@ export function determinant(a) {
 /**
  * Multiplies two mat2's
  *
- * @param {mat2} out the receiving matrix
- * @param {mat2} a the first operand
- * @param {mat2} b the second operand
- * @returns {mat2} out
+ * @param {Mat2} out the receiving matrix
+ * @param {Mat2} a the first operand
+ * @param {Mat2} b the second operand
+ * @returns {Mat2} out
  */
 export function multiply(out, a, b) {
   let a0 = a[0], a1 = a[1], a2 = a[2], a3 = a[3];
@@ -200,10 +200,10 @@ export function multiply(out, a, b) {
 /**
  * Rotates a mat2 by the given angle
  *
- * @param {mat2} out the receiving matrix
- * @param {mat2} a the matrix to rotate
+ * @param {Mat2} out the receiving matrix
+ * @param {Mat2} a the matrix to rotate
  * @param {Number} rad the angle to rotate the matrix by
- * @returns {mat2} out
+ * @returns {Mat2} out
  */
 export function rotate(out, a, rad) {
   let a0 = a[0], a1 = a[1], a2 = a[2], a3 = a[3];
@@ -219,10 +219,10 @@ export function rotate(out, a, rad) {
 /**
  * Scales the mat2 by the dimensions in the given vec2
  *
- * @param {mat2} out the receiving matrix
- * @param {mat2} a the matrix to rotate
- * @param {vec2} v the vec2 to scale the matrix by
- * @returns {mat2} out
+ * @param {Mat2} out the receiving matrix
+ * @param {Mat2} a the matrix to rotate
+ * @param {Vec2} v the vec2 to scale the matrix by
+ * @returns {Mat2} out
  **/
 export function scale(out, a, v) {
   let a0 = a[0], a1 = a[1], a2 = a[2], a3 = a[3];
@@ -241,9 +241,9 @@ export function scale(out, a, v) {
  *     mat2.identity(dest);
  *     mat2.rotate(dest, dest, rad);
  *
- * @param {mat2} out mat2 receiving operation result
+ * @param {Mat2} out mat2 receiving operation result
  * @param {Number} rad the angle to rotate the matrix by
- * @returns {mat2} out
+ * @returns {Mat2} out
  */
 export function fromRotation(out, rad) {
   let s = Math.sin(rad);
@@ -262,9 +262,9 @@ export function fromRotation(out, rad) {
  *     mat2.identity(dest);
  *     mat2.scale(dest, dest, vec);
  *
- * @param {mat2} out mat2 receiving operation result
- * @param {vec2} v Scaling vector
- * @returns {mat2} out
+ * @param {Mat2} out mat2 receiving operation result
+ * @param {Vec2} v Scaling vector
+ * @returns {Mat2} out
  */
 export function fromScaling(out, v) {
   out[0] = v[0];
@@ -277,7 +277,7 @@ export function fromScaling(out, v) {
 /**
  * Returns a string representation of a mat2
  *
- * @param {mat2} a matrix to represent as a string
+ * @param {Mat2} a matrix to represent as a string
  * @returns {String} string representation of the matrix
  */
 export function str(a) {
@@ -287,7 +287,7 @@ export function str(a) {
 /**
  * Returns Frobenius norm of a mat2
  *
- * @param {mat2} a the matrix to calculate Frobenius norm of
+ * @param {Mat2} a the matrix to calculate Frobenius norm of
  * @returns {Number} Frobenius norm
  */
 export function frob(a) {
@@ -296,10 +296,10 @@ export function frob(a) {
 
 /**
  * Returns L, D and U matrices (Lower triangular, Diagonal and Upper triangular) by factorizing the input matrix
- * @param {mat2} L the lower triangular matrix
- * @param {mat2} D the diagonal matrix
- * @param {mat2} U the upper triangular matrix
- * @param {mat2} a the input matrix to factorize
+ * @param {Mat2} L the lower triangular matrix
+ * @param {Mat2} D the diagonal matrix
+ * @param {Mat2} U the upper triangular matrix
+ * @param {Mat2} a the input matrix to factorize
  */
 
 export function LDU(L, D, U, a) {
@@ -313,10 +313,10 @@ export function LDU(L, D, U, a) {
 /**
  * Adds two mat2's
  *
- * @param {mat2} out the receiving matrix
- * @param {mat2} a the first operand
- * @param {mat2} b the second operand
- * @returns {mat2} out
+ * @param {Mat2} out the receiving matrix
+ * @param {Mat2} a the first operand
+ * @param {Mat2} b the second operand
+ * @returns {Mat2} out
  */
 export function add(out, a, b) {
   out[0] = a[0] + b[0];
@@ -329,10 +329,10 @@ export function add(out, a, b) {
 /**
  * Subtracts matrix b from matrix a
  *
- * @param {mat2} out the receiving matrix
- * @param {mat2} a the first operand
- * @param {mat2} b the second operand
- * @returns {mat2} out
+ * @param {Mat2} out the receiving matrix
+ * @param {Mat2} a the first operand
+ * @param {Mat2} b the second operand
+ * @returns {Mat2} out
  */
 export function subtract(out, a, b) {
   out[0] = a[0] - b[0];
@@ -345,8 +345,8 @@ export function subtract(out, a, b) {
 /**
  * Returns whether or not the matrices have exactly the same elements in the same position (when compared with ===)
  *
- * @param {mat2} a The first matrix.
- * @param {mat2} b The second matrix.
+ * @param {Mat2} a The first matrix.
+ * @param {Mat2} b The second matrix.
  * @returns {Boolean} True if the matrices are equal, false otherwise.
  */
 export function exactEquals(a, b) {
@@ -356,8 +356,8 @@ export function exactEquals(a, b) {
 /**
  * Returns whether or not the matrices have approximately the same elements in the same position.
  *
- * @param {mat2} a The first matrix.
- * @param {mat2} b The second matrix.
+ * @param {Mat2} a The first matrix.
+ * @param {Mat2} b The second matrix.
  * @returns {Boolean} True if the matrices are equal, false otherwise.
  */
 export function equals(a, b) {
@@ -372,10 +372,10 @@ export function equals(a, b) {
 /**
  * Multiply each element of the matrix by a scalar.
  *
- * @param {mat2} out the receiving matrix
- * @param {mat2} a the matrix to scale
+ * @param {Mat2} out the receiving matrix
+ * @param {Mat2} a the matrix to scale
  * @param {Number} b amount to scale the matrix's elements by
- * @returns {mat2} out
+ * @returns {Mat2} out
  */
 export function multiplyScalar(out, a, b) {
   out[0] = a[0] * b;
@@ -388,11 +388,11 @@ export function multiplyScalar(out, a, b) {
 /**
  * Adds two mat2's after multiplying each element of the second operand by a scalar value.
  *
- * @param {mat2} out the receiving vector
- * @param {mat2} a the first operand
- * @param {mat2} b the second operand
+ * @param {Mat2} out the receiving vector
+ * @param {Mat2} a the first operand
+ * @param {Mat2} b the second operand
  * @param {Number} scale the amount to scale b's elements by before adding
- * @returns {mat2} out
+ * @returns {Mat2} out
  */
 export function multiplyScalarAndAdd(out, a, b, scale) {
   out[0] = a[0] + (b[0] * scale);

--- a/src/mat2.js
+++ b/src/mat2.js
@@ -6,6 +6,12 @@ import * as glMatrix from "./common.js"
  */
 
 /**
+ * @typedef {[
+  number, number,
+  number, number] | Float32Array} Mat2
+ */
+
+/**
  * Creates a new identity mat2
  *
  * @returns {Mat2} a new 2x2 matrix

--- a/src/mat2d.js
+++ b/src/mat2d.js
@@ -20,6 +20,12 @@ import * as glMatrix from "./common.js";
  */
 
 /**
+ * @typedef {[
+  number, number, number,
+  number, number, number] | Float32Array} Mat2d
+ */
+
+/**
  * Creates a new identity mat2d
  *
  * @returns {Mat2d} a new 2x3 matrix

--- a/src/mat2d.js
+++ b/src/mat2d.js
@@ -22,7 +22,7 @@ import * as glMatrix from "./common.js";
 /**
  * Creates a new identity mat2d
  *
- * @returns {mat2d} a new 2x3 matrix
+ * @returns {Mat2d} a new 2x3 matrix
  */
 export function create() {
   let out = new glMatrix.ARRAY_TYPE(6);
@@ -40,8 +40,8 @@ export function create() {
 /**
  * Creates a new mat2d initialized with values from an existing matrix
  *
- * @param {mat2d} a matrix to clone
- * @returns {mat2d} a new 2x3 matrix
+ * @param {Mat2d} a matrix to clone
+ * @returns {Mat2d} a new 2x3 matrix
  */
 export function clone(a) {
   let out = new glMatrix.ARRAY_TYPE(6);
@@ -57,9 +57,9 @@ export function clone(a) {
 /**
  * Copy the values from one mat2d to another
  *
- * @param {mat2d} out the receiving matrix
- * @param {mat2d} a the source matrix
- * @returns {mat2d} out
+ * @param {Mat2d} out the receiving matrix
+ * @param {Mat2d} a the source matrix
+ * @returns {Mat2d} out
  */
 export function copy(out, a) {
   out[0] = a[0];
@@ -74,8 +74,8 @@ export function copy(out, a) {
 /**
  * Set a mat2d to the identity matrix
  *
- * @param {mat2d} out the receiving matrix
- * @returns {mat2d} out
+ * @param {Mat2d} out the receiving matrix
+ * @returns {Mat2d} out
  */
 export function identity(out) {
   out[0] = 1;
@@ -96,7 +96,7 @@ export function identity(out) {
  * @param {Number} d Component D (index 3)
  * @param {Number} tx Component TX (index 4)
  * @param {Number} ty Component TY (index 5)
- * @returns {mat2d} A new mat2d
+ * @returns {Mat2d} A new mat2d
  */
 export function fromValues(a, b, c, d, tx, ty) {
   let out = new glMatrix.ARRAY_TYPE(6);
@@ -112,14 +112,14 @@ export function fromValues(a, b, c, d, tx, ty) {
 /**
  * Set the components of a mat2d to the given values
  *
- * @param {mat2d} out the receiving matrix
+ * @param {Mat2d} out the receiving matrix
  * @param {Number} a Component A (index 0)
  * @param {Number} b Component B (index 1)
  * @param {Number} c Component C (index 2)
  * @param {Number} d Component D (index 3)
  * @param {Number} tx Component TX (index 4)
  * @param {Number} ty Component TY (index 5)
- * @returns {mat2d} out
+ * @returns {Mat2d} out
  */
 export function set(out, a, b, c, d, tx, ty) {
   out[0] = a;
@@ -134,9 +134,9 @@ export function set(out, a, b, c, d, tx, ty) {
 /**
  * Inverts a mat2d
  *
- * @param {mat2d} out the receiving matrix
- * @param {mat2d} a the source matrix
- * @returns {mat2d} out
+ * @param {Mat2d} out the receiving matrix
+ * @param {Mat2d} a the source matrix
+ * @returns {Mat2d} out
  */
 export function invert(out, a) {
   let aa = a[0], ab = a[1], ac = a[2], ad = a[3];
@@ -160,7 +160,7 @@ export function invert(out, a) {
 /**
  * Calculates the determinant of a mat2d
  *
- * @param {mat2d} a the source matrix
+ * @param {Mat2d} a the source matrix
  * @returns {Number} determinant of a
  */
 export function determinant(a) {
@@ -170,10 +170,10 @@ export function determinant(a) {
 /**
  * Multiplies two mat2d's
  *
- * @param {mat2d} out the receiving matrix
- * @param {mat2d} a the first operand
- * @param {mat2d} b the second operand
- * @returns {mat2d} out
+ * @param {Mat2d} out the receiving matrix
+ * @param {Mat2d} a the first operand
+ * @param {Mat2d} b the second operand
+ * @returns {Mat2d} out
  */
 export function multiply(out, a, b) {
   let a0 = a[0], a1 = a[1], a2 = a[2], a3 = a[3], a4 = a[4], a5 = a[5];
@@ -190,10 +190,10 @@ export function multiply(out, a, b) {
 /**
  * Rotates a mat2d by the given angle
  *
- * @param {mat2d} out the receiving matrix
- * @param {mat2d} a the matrix to rotate
+ * @param {Mat2d} out the receiving matrix
+ * @param {Mat2d} a the matrix to rotate
  * @param {Number} rad the angle to rotate the matrix by
- * @returns {mat2d} out
+ * @returns {Mat2d} out
  */
 export function rotate(out, a, rad) {
   let a0 = a[0], a1 = a[1], a2 = a[2], a3 = a[3], a4 = a[4], a5 = a[5];
@@ -211,10 +211,10 @@ export function rotate(out, a, rad) {
 /**
  * Scales the mat2d by the dimensions in the given vec2
  *
- * @param {mat2d} out the receiving matrix
- * @param {mat2d} a the matrix to translate
- * @param {vec2} v the vec2 to scale the matrix by
- * @returns {mat2d} out
+ * @param {Mat2d} out the receiving matrix
+ * @param {Mat2d} a the matrix to translate
+ * @param {Vec2} v the vec2 to scale the matrix by
+ * @returns {Mat2d} out
  **/
 export function scale(out, a, v) {
   let a0 = a[0], a1 = a[1], a2 = a[2], a3 = a[3], a4 = a[4], a5 = a[5];
@@ -231,10 +231,10 @@ export function scale(out, a, v) {
 /**
  * Translates the mat2d by the dimensions in the given vec2
  *
- * @param {mat2d} out the receiving matrix
- * @param {mat2d} a the matrix to translate
- * @param {vec2} v the vec2 to translate the matrix by
- * @returns {mat2d} out
+ * @param {Mat2d} out the receiving matrix
+ * @param {Mat2d} a the matrix to translate
+ * @param {Vec2} v the vec2 to translate the matrix by
+ * @returns {Mat2d} out
  **/
 export function translate(out, a, v) {
   let a0 = a[0], a1 = a[1], a2 = a[2], a3 = a[3], a4 = a[4], a5 = a[5];
@@ -255,9 +255,9 @@ export function translate(out, a, v) {
  *     mat2d.identity(dest);
  *     mat2d.rotate(dest, dest, rad);
  *
- * @param {mat2d} out mat2d receiving operation result
+ * @param {Mat2d} out mat2d receiving operation result
  * @param {Number} rad the angle to rotate the matrix by
- * @returns {mat2d} out
+ * @returns {Mat2d} out
  */
 export function fromRotation(out, rad) {
   let s = Math.sin(rad), c = Math.cos(rad);
@@ -277,9 +277,9 @@ export function fromRotation(out, rad) {
  *     mat2d.identity(dest);
  *     mat2d.scale(dest, dest, vec);
  *
- * @param {mat2d} out mat2d receiving operation result
- * @param {vec2} v Scaling vector
- * @returns {mat2d} out
+ * @param {Mat2d} out mat2d receiving operation result
+ * @param {Vec2} v Scaling vector
+ * @returns {Mat2d} out
  */
 export function fromScaling(out, v) {
   out[0] = v[0];
@@ -298,9 +298,9 @@ export function fromScaling(out, v) {
  *     mat2d.identity(dest);
  *     mat2d.translate(dest, dest, vec);
  *
- * @param {mat2d} out mat2d receiving operation result
- * @param {vec2} v Translation vector
- * @returns {mat2d} out
+ * @param {Mat2d} out mat2d receiving operation result
+ * @param {Vec2} v Translation vector
+ * @returns {Mat2d} out
  */
 export function fromTranslation(out, v) {
   out[0] = 1;
@@ -315,7 +315,7 @@ export function fromTranslation(out, v) {
 /**
  * Returns a string representation of a mat2d
  *
- * @param {mat2d} a matrix to represent as a string
+ * @param {Mat2d} a matrix to represent as a string
  * @returns {String} string representation of the matrix
  */
 export function str(a) {
@@ -326,7 +326,7 @@ export function str(a) {
 /**
  * Returns Frobenius norm of a mat2d
  *
- * @param {mat2d} a the matrix to calculate Frobenius norm of
+ * @param {Mat2d} a the matrix to calculate Frobenius norm of
  * @returns {Number} Frobenius norm
  */
 export function frob(a) {
@@ -336,10 +336,10 @@ export function frob(a) {
 /**
  * Adds two mat2d's
  *
- * @param {mat2d} out the receiving matrix
- * @param {mat2d} a the first operand
- * @param {mat2d} b the second operand
- * @returns {mat2d} out
+ * @param {Mat2d} out the receiving matrix
+ * @param {Mat2d} a the first operand
+ * @param {Mat2d} b the second operand
+ * @returns {Mat2d} out
  */
 export function add(out, a, b) {
   out[0] = a[0] + b[0];
@@ -354,10 +354,10 @@ export function add(out, a, b) {
 /**
  * Subtracts matrix b from matrix a
  *
- * @param {mat2d} out the receiving matrix
- * @param {mat2d} a the first operand
- * @param {mat2d} b the second operand
- * @returns {mat2d} out
+ * @param {Mat2d} out the receiving matrix
+ * @param {Mat2d} a the first operand
+ * @param {Mat2d} b the second operand
+ * @returns {Mat2d} out
  */
 export function subtract(out, a, b) {
   out[0] = a[0] - b[0];
@@ -372,10 +372,10 @@ export function subtract(out, a, b) {
 /**
  * Multiply each element of the matrix by a scalar.
  *
- * @param {mat2d} out the receiving matrix
- * @param {mat2d} a the matrix to scale
+ * @param {Mat2d} out the receiving matrix
+ * @param {Mat2d} a the matrix to scale
  * @param {Number} b amount to scale the matrix's elements by
- * @returns {mat2d} out
+ * @returns {Mat2d} out
  */
 export function multiplyScalar(out, a, b) {
   out[0] = a[0] * b;
@@ -390,11 +390,11 @@ export function multiplyScalar(out, a, b) {
 /**
  * Adds two mat2d's after multiplying each element of the second operand by a scalar value.
  *
- * @param {mat2d} out the receiving vector
- * @param {mat2d} a the first operand
- * @param {mat2d} b the second operand
+ * @param {Mat2d} out the receiving vector
+ * @param {Mat2d} a the first operand
+ * @param {Mat2d} b the second operand
  * @param {Number} scale the amount to scale b's elements by before adding
- * @returns {mat2d} out
+ * @returns {Mat2d} out
  */
 export function multiplyScalarAndAdd(out, a, b, scale) {
   out[0] = a[0] + (b[0] * scale);
@@ -409,8 +409,8 @@ export function multiplyScalarAndAdd(out, a, b, scale) {
 /**
  * Returns whether or not the matrices have exactly the same elements in the same position (when compared with ===)
  *
- * @param {mat2d} a The first matrix.
- * @param {mat2d} b The second matrix.
+ * @param {Mat2d} a The first matrix.
+ * @param {Mat2d} b The second matrix.
  * @returns {Boolean} True if the matrices are equal, false otherwise.
  */
 export function exactEquals(a, b) {
@@ -420,8 +420,8 @@ export function exactEquals(a, b) {
 /**
  * Returns whether or not the matrices have approximately the same elements in the same position.
  *
- * @param {mat2d} a The first matrix.
- * @param {mat2d} b The second matrix.
+ * @param {Mat2d} a The first matrix.
+ * @param {Mat2d} b The second matrix.
  * @returns {Boolean} True if the matrices are equal, false otherwise.
  */
 export function equals(a, b) {

--- a/src/mat3.js
+++ b/src/mat3.js
@@ -6,6 +6,13 @@ import * as glMatrix from "./common.js";
  */
 
 /**
+ * @typedef {[
+  number, number, number,
+  number, number, number,
+  number, number, number] | Float32Array} Mat3
+ */
+
+/**
  * Creates a new identity mat3
  *
  * @returns {Mat3} a new 3x3 matrix

--- a/src/mat3.js
+++ b/src/mat3.js
@@ -8,7 +8,7 @@ import * as glMatrix from "./common.js";
 /**
  * Creates a new identity mat3
  *
- * @returns {mat3} a new 3x3 matrix
+ * @returns {Mat3} a new 3x3 matrix
  */
 export function create() {
   let out = new glMatrix.ARRAY_TYPE(9);
@@ -29,9 +29,9 @@ export function create() {
 /**
  * Copies the upper-left 3x3 values into the given mat3.
  *
- * @param {mat3} out the receiving 3x3 matrix
- * @param {mat4} a   the source 4x4 matrix
- * @returns {mat3} out
+ * @param {Mat3} out the receiving 3x3 matrix
+ * @param {Mat4} a   the source 4x4 matrix
+ * @returns {Mat3} out
  */
 export function fromMat4(out, a) {
   out[0] = a[0];
@@ -49,8 +49,8 @@ export function fromMat4(out, a) {
 /**
  * Creates a new mat3 initialized with values from an existing matrix
  *
- * @param {mat3} a matrix to clone
- * @returns {mat3} a new 3x3 matrix
+ * @param {Mat3} a matrix to clone
+ * @returns {Mat3} a new 3x3 matrix
  */
 export function clone(a) {
   let out = new glMatrix.ARRAY_TYPE(9);
@@ -69,9 +69,9 @@ export function clone(a) {
 /**
  * Copy the values from one mat3 to another
  *
- * @param {mat3} out the receiving matrix
- * @param {mat3} a the source matrix
- * @returns {mat3} out
+ * @param {Mat3} out the receiving matrix
+ * @param {Mat3} a the source matrix
+ * @returns {Mat3} out
  */
 export function copy(out, a) {
   out[0] = a[0];
@@ -98,7 +98,7 @@ export function copy(out, a) {
  * @param {Number} m20 Component in column 2, row 0 position (index 6)
  * @param {Number} m21 Component in column 2, row 1 position (index 7)
  * @param {Number} m22 Component in column 2, row 2 position (index 8)
- * @returns {mat3} A new mat3
+ * @returns {Mat3} A new mat3
  */
 export function fromValues(m00, m01, m02, m10, m11, m12, m20, m21, m22) {
   let out = new glMatrix.ARRAY_TYPE(9);
@@ -117,7 +117,7 @@ export function fromValues(m00, m01, m02, m10, m11, m12, m20, m21, m22) {
 /**
  * Set the components of a mat3 to the given values
  *
- * @param {mat3} out the receiving matrix
+ * @param {Mat3} out the receiving matrix
  * @param {Number} m00 Component in column 0, row 0 position (index 0)
  * @param {Number} m01 Component in column 0, row 1 position (index 1)
  * @param {Number} m02 Component in column 0, row 2 position (index 2)
@@ -127,7 +127,7 @@ export function fromValues(m00, m01, m02, m10, m11, m12, m20, m21, m22) {
  * @param {Number} m20 Component in column 2, row 0 position (index 6)
  * @param {Number} m21 Component in column 2, row 1 position (index 7)
  * @param {Number} m22 Component in column 2, row 2 position (index 8)
- * @returns {mat3} out
+ * @returns {Mat3} out
  */
 export function set(out, m00, m01, m02, m10, m11, m12, m20, m21, m22) {
   out[0] = m00;
@@ -145,8 +145,8 @@ export function set(out, m00, m01, m02, m10, m11, m12, m20, m21, m22) {
 /**
  * Set a mat3 to the identity matrix
  *
- * @param {mat3} out the receiving matrix
- * @returns {mat3} out
+ * @param {Mat3} out the receiving matrix
+ * @returns {Mat3} out
  */
 export function identity(out) {
   out[0] = 1;
@@ -164,9 +164,9 @@ export function identity(out) {
 /**
  * Transpose the values of a mat3
  *
- * @param {mat3} out the receiving matrix
- * @param {mat3} a the source matrix
- * @returns {mat3} out
+ * @param {Mat3} out the receiving matrix
+ * @param {Mat3} a the source matrix
+ * @returns {Mat3} out
  */
 export function transpose(out, a) {
   // If we are transposing ourselves we can skip a few steps but have to cache some values
@@ -196,9 +196,9 @@ export function transpose(out, a) {
 /**
  * Inverts a mat3
  *
- * @param {mat3} out the receiving matrix
- * @param {mat3} a the source matrix
- * @returns {mat3} out
+ * @param {Mat3} out the receiving matrix
+ * @param {Mat3} a the source matrix
+ * @returns {Mat3} out
  */
 export function invert(out, a) {
   let a00 = a[0], a01 = a[1], a02 = a[2];
@@ -232,9 +232,9 @@ export function invert(out, a) {
 /**
  * Calculates the adjugate of a mat3
  *
- * @param {mat3} out the receiving matrix
- * @param {mat3} a the source matrix
- * @returns {mat3} out
+ * @param {Mat3} out the receiving matrix
+ * @param {Mat3} a the source matrix
+ * @returns {Mat3} out
  */
 export function adjoint(out, a) {
   let a00 = a[0], a01 = a[1], a02 = a[2];
@@ -256,7 +256,7 @@ export function adjoint(out, a) {
 /**
  * Calculates the determinant of a mat3
  *
- * @param {mat3} a the source matrix
+ * @param {Mat3} a the source matrix
  * @returns {Number} determinant of a
  */
 export function determinant(a) {
@@ -270,10 +270,10 @@ export function determinant(a) {
 /**
  * Multiplies two mat3's
  *
- * @param {mat3} out the receiving matrix
- * @param {mat3} a the first operand
- * @param {mat3} b the second operand
- * @returns {mat3} out
+ * @param {Mat3} out the receiving matrix
+ * @param {Mat3} a the first operand
+ * @param {Mat3} b the second operand
+ * @returns {Mat3} out
  */
 export function multiply(out, a, b) {
   let a00 = a[0], a01 = a[1], a02 = a[2];
@@ -301,10 +301,10 @@ export function multiply(out, a, b) {
 /**
  * Translate a mat3 by the given vector
  *
- * @param {mat3} out the receiving matrix
- * @param {mat3} a the matrix to translate
- * @param {vec2} v vector to translate by
- * @returns {mat3} out
+ * @param {Mat3} out the receiving matrix
+ * @param {Mat3} a the matrix to translate
+ * @param {Vec2} v vector to translate by
+ * @returns {Mat3} out
  */
 export function translate(out, a, v) {
   let a00 = a[0], a01 = a[1], a02 = a[2],
@@ -329,10 +329,10 @@ export function translate(out, a, v) {
 /**
  * Rotates a mat3 by the given angle
  *
- * @param {mat3} out the receiving matrix
- * @param {mat3} a the matrix to rotate
+ * @param {Mat3} out the receiving matrix
+ * @param {Mat3} a the matrix to rotate
  * @param {Number} rad the angle to rotate the matrix by
- * @returns {mat3} out
+ * @returns {Mat3} out
  */
 export function rotate(out, a, rad) {
   let a00 = a[0], a01 = a[1], a02 = a[2],
@@ -359,10 +359,10 @@ export function rotate(out, a, rad) {
 /**
  * Scales the mat3 by the dimensions in the given vec2
  *
- * @param {mat3} out the receiving matrix
- * @param {mat3} a the matrix to rotate
- * @param {vec2} v the vec2 to scale the matrix by
- * @returns {mat3} out
+ * @param {Mat3} out the receiving matrix
+ * @param {Mat3} a the matrix to rotate
+ * @param {Vec2} v the vec2 to scale the matrix by
+ * @returns {Mat3} out
  **/
 export function scale(out, a, v) {
   let x = v[0], y = v[1];
@@ -388,9 +388,9 @@ export function scale(out, a, v) {
  *     mat3.identity(dest);
  *     mat3.translate(dest, dest, vec);
  *
- * @param {mat3} out mat3 receiving operation result
- * @param {vec2} v Translation vector
- * @returns {mat3} out
+ * @param {Mat3} out mat3 receiving operation result
+ * @param {Vec2} v Translation vector
+ * @returns {Mat3} out
  */
 export function fromTranslation(out, v) {
   out[0] = 1;
@@ -412,9 +412,9 @@ export function fromTranslation(out, v) {
  *     mat3.identity(dest);
  *     mat3.rotate(dest, dest, rad);
  *
- * @param {mat3} out mat3 receiving operation result
+ * @param {Mat3} out mat3 receiving operation result
  * @param {Number} rad the angle to rotate the matrix by
- * @returns {mat3} out
+ * @returns {Mat3} out
  */
 export function fromRotation(out, rad) {
   let s = Math.sin(rad), c = Math.cos(rad);
@@ -440,9 +440,9 @@ export function fromRotation(out, rad) {
  *     mat3.identity(dest);
  *     mat3.scale(dest, dest, vec);
  *
- * @param {mat3} out mat3 receiving operation result
- * @param {vec2} v Scaling vector
- * @returns {mat3} out
+ * @param {Mat3} out mat3 receiving operation result
+ * @param {Vec2} v Scaling vector
+ * @returns {Mat3} out
  */
 export function fromScaling(out, v) {
   out[0] = v[0];
@@ -462,9 +462,9 @@ export function fromScaling(out, v) {
 /**
  * Copies the values from a mat2d into a mat3
  *
- * @param {mat3} out the receiving matrix
- * @param {mat2d} a the matrix to copy
- * @returns {mat3} out
+ * @param {Mat3} out the receiving matrix
+ * @param {Mat2d} a the matrix to copy
+ * @returns {Mat3} out
  **/
 export function fromMat2d(out, a) {
   out[0] = a[0];
@@ -484,10 +484,10 @@ export function fromMat2d(out, a) {
 /**
 * Calculates a 3x3 matrix from the given quaternion
 *
-* @param {mat3} out mat3 receiving operation result
-* @param {quat} q Quaternion to create matrix from
+* @param {Mat3} out mat3 receiving operation result
+* @param {Quat} q Quaternion to create matrix from
 *
-* @returns {mat3} out
+* @returns {Mat3} out
 */
 export function fromQuat(out, q) {
   let x = q[0], y = q[1], z = q[2], w = q[3];
@@ -523,10 +523,10 @@ export function fromQuat(out, q) {
 /**
 * Calculates a 3x3 normal matrix (transpose inverse) from the 4x4 matrix
 *
-* @param {mat3} out mat3 receiving operation result
-* @param {mat4} a Mat4 to derive the normal matrix from
+* @param {Mat3} out mat3 receiving operation result
+* @param {Mat4} a Mat4 to derive the normal matrix from
 *
-* @returns {mat3} out
+* @returns {Mat3} out
 */
 export function normalFromMat4(out, a) {
   let a00 = a[0], a01 = a[1], a02 = a[2], a03 = a[3];
@@ -573,10 +573,10 @@ export function normalFromMat4(out, a) {
 /**
  * Generates a 2D projection matrix with the given bounds
  *
- * @param {mat3} out mat3 frustum matrix will be written into
+ * @param {Mat3} out mat3 frustum matrix will be written into
  * @param {number} width Width of your gl context
  * @param {number} height Height of gl context
- * @returns {mat3} out
+ * @returns {Mat3} out
  */
 export function projection(out, width, height) {
     out[0] = 2 / width;
@@ -594,7 +594,7 @@ export function projection(out, width, height) {
 /**
  * Returns a string representation of a mat3
  *
- * @param {mat3} a matrix to represent as a string
+ * @param {Mat3} a matrix to represent as a string
  * @returns {String} string representation of the matrix
  */
 export function str(a) {
@@ -606,7 +606,7 @@ export function str(a) {
 /**
  * Returns Frobenius norm of a mat3
  *
- * @param {mat3} a the matrix to calculate Frobenius norm of
+ * @param {Mat3} a the matrix to calculate Frobenius norm of
  * @returns {Number} Frobenius norm
  */
 export function frob(a) {
@@ -616,10 +616,10 @@ export function frob(a) {
 /**
  * Adds two mat3's
  *
- * @param {mat3} out the receiving matrix
- * @param {mat3} a the first operand
- * @param {mat3} b the second operand
- * @returns {mat3} out
+ * @param {Mat3} out the receiving matrix
+ * @param {Mat3} a the first operand
+ * @param {Mat3} b the second operand
+ * @returns {Mat3} out
  */
 export function add(out, a, b) {
   out[0] = a[0] + b[0];
@@ -637,10 +637,10 @@ export function add(out, a, b) {
 /**
  * Subtracts matrix b from matrix a
  *
- * @param {mat3} out the receiving matrix
- * @param {mat3} a the first operand
- * @param {mat3} b the second operand
- * @returns {mat3} out
+ * @param {Mat3} out the receiving matrix
+ * @param {Mat3} a the first operand
+ * @param {Mat3} b the second operand
+ * @returns {Mat3} out
  */
 export function subtract(out, a, b) {
   out[0] = a[0] - b[0];
@@ -660,10 +660,10 @@ export function subtract(out, a, b) {
 /**
  * Multiply each element of the matrix by a scalar.
  *
- * @param {mat3} out the receiving matrix
- * @param {mat3} a the matrix to scale
+ * @param {Mat3} out the receiving matrix
+ * @param {Mat3} a the matrix to scale
  * @param {Number} b amount to scale the matrix's elements by
- * @returns {mat3} out
+ * @returns {Mat3} out
  */
 export function multiplyScalar(out, a, b) {
   out[0] = a[0] * b;
@@ -681,11 +681,11 @@ export function multiplyScalar(out, a, b) {
 /**
  * Adds two mat3's after multiplying each element of the second operand by a scalar value.
  *
- * @param {mat3} out the receiving vector
- * @param {mat3} a the first operand
- * @param {mat3} b the second operand
+ * @param {Mat3} out the receiving vector
+ * @param {Mat3} a the first operand
+ * @param {Mat3} b the second operand
  * @param {Number} scale the amount to scale b's elements by before adding
- * @returns {mat3} out
+ * @returns {Mat3} out
  */
 export function multiplyScalarAndAdd(out, a, b, scale) {
   out[0] = a[0] + (b[0] * scale);
@@ -703,8 +703,8 @@ export function multiplyScalarAndAdd(out, a, b, scale) {
 /**
  * Returns whether or not the matrices have exactly the same elements in the same position (when compared with ===)
  *
- * @param {mat3} a The first matrix.
- * @param {mat3} b The second matrix.
+ * @param {Mat3} a The first matrix.
+ * @param {Mat3} b The second matrix.
  * @returns {Boolean} True if the matrices are equal, false otherwise.
  */
 export function exactEquals(a, b) {
@@ -716,8 +716,8 @@ export function exactEquals(a, b) {
 /**
  * Returns whether or not the matrices have approximately the same elements in the same position.
  *
- * @param {mat3} a The first matrix.
- * @param {mat3} b The second matrix.
+ * @param {Mat3} a The first matrix.
+ * @param {Mat3} b The second matrix.
  * @returns {Boolean} True if the matrices are equal, false otherwise.
  */
 export function equals(a, b) {

--- a/src/mat4.js
+++ b/src/mat4.js
@@ -6,6 +6,14 @@ import * as glMatrix from "./common.js";
  */
 
 /**
+ * @typedef {[
+  number, number, number, number,
+  number, number, number, number,
+  number, number, number, number,
+  number, number, number, number] | Float32Array} Mat4
+ */
+
+/**
  * Creates a new identity mat4
  *
  * @returns {Mat4} a new 4x4 matrix

--- a/src/mat4.js
+++ b/src/mat4.js
@@ -8,7 +8,7 @@ import * as glMatrix from "./common.js";
 /**
  * Creates a new identity mat4
  *
- * @returns {mat4} a new 4x4 matrix
+ * @returns {Mat4} a new 4x4 matrix
  */
 export function create() {
   let out = new glMatrix.ARRAY_TYPE(16);
@@ -36,8 +36,8 @@ export function create() {
 /**
  * Creates a new mat4 initialized with values from an existing matrix
  *
- * @param {mat4} a matrix to clone
- * @returns {mat4} a new 4x4 matrix
+ * @param {Mat4} a matrix to clone
+ * @returns {Mat4} a new 4x4 matrix
  */
 export function clone(a) {
   let out = new glMatrix.ARRAY_TYPE(16);
@@ -63,9 +63,9 @@ export function clone(a) {
 /**
  * Copy the values from one mat4 to another
  *
- * @param {mat4} out the receiving matrix
- * @param {mat4} a the source matrix
- * @returns {mat4} out
+ * @param {Mat4} out the receiving matrix
+ * @param {Mat4} a the source matrix
+ * @returns {Mat4} out
  */
 export function copy(out, a) {
   out[0] = a[0];
@@ -106,7 +106,7 @@ export function copy(out, a) {
  * @param {Number} m31 Component in column 3, row 1 position (index 13)
  * @param {Number} m32 Component in column 3, row 2 position (index 14)
  * @param {Number} m33 Component in column 3, row 3 position (index 15)
- * @returns {mat4} A new mat4
+ * @returns {Mat4} A new mat4
  */
 export function fromValues(m00, m01, m02, m03, m10, m11, m12, m13, m20, m21, m22, m23, m30, m31, m32, m33) {
   let out = new glMatrix.ARRAY_TYPE(16);
@@ -132,7 +132,7 @@ export function fromValues(m00, m01, m02, m03, m10, m11, m12, m13, m20, m21, m22
 /**
  * Set the components of a mat4 to the given values
  *
- * @param {mat4} out the receiving matrix
+ * @param {Mat4} out the receiving matrix
  * @param {Number} m00 Component in column 0, row 0 position (index 0)
  * @param {Number} m01 Component in column 0, row 1 position (index 1)
  * @param {Number} m02 Component in column 0, row 2 position (index 2)
@@ -149,7 +149,7 @@ export function fromValues(m00, m01, m02, m03, m10, m11, m12, m13, m20, m21, m22
  * @param {Number} m31 Component in column 3, row 1 position (index 13)
  * @param {Number} m32 Component in column 3, row 2 position (index 14)
  * @param {Number} m33 Component in column 3, row 3 position (index 15)
- * @returns {mat4} out
+ * @returns {Mat4} out
  */
 export function set(out, m00, m01, m02, m03, m10, m11, m12, m13, m20, m21, m22, m23, m30, m31, m32, m33) {
   out[0] = m00;
@@ -175,8 +175,8 @@ export function set(out, m00, m01, m02, m03, m10, m11, m12, m13, m20, m21, m22, 
 /**
  * Set a mat4 to the identity matrix
  *
- * @param {mat4} out the receiving matrix
- * @returns {mat4} out
+ * @param {Mat4} out the receiving matrix
+ * @returns {Mat4} out
  */
 export function identity(out) {
   out[0] = 1;
@@ -201,9 +201,9 @@ export function identity(out) {
 /**
  * Transpose the values of a mat4
  *
- * @param {mat4} out the receiving matrix
- * @param {mat4} a the source matrix
- * @returns {mat4} out
+ * @param {Mat4} out the receiving matrix
+ * @param {Mat4} a the source matrix
+ * @returns {Mat4} out
  */
 export function transpose(out, a) {
   // If we are transposing ourselves we can skip a few steps but have to cache some values
@@ -249,9 +249,9 @@ export function transpose(out, a) {
 /**
  * Inverts a mat4
  *
- * @param {mat4} out the receiving matrix
- * @param {mat4} a the source matrix
- * @returns {mat4} out
+ * @param {Mat4} out the receiving matrix
+ * @param {Mat4} a the source matrix
+ * @returns {Mat4} out
  */
 export function invert(out, a) {
   let a00 = a[0], a01 = a[1], a02 = a[2], a03 = a[3];
@@ -303,9 +303,9 @@ export function invert(out, a) {
 /**
  * Calculates the adjugate of a mat4
  *
- * @param {mat4} out the receiving matrix
- * @param {mat4} a the source matrix
- * @returns {mat4} out
+ * @param {Mat4} out the receiving matrix
+ * @param {Mat4} a the source matrix
+ * @returns {Mat4} out
  */
 export function adjoint(out, a) {
   let a00 = a[0], a01 = a[1], a02 = a[2], a03 = a[3];
@@ -335,7 +335,7 @@ export function adjoint(out, a) {
 /**
  * Calculates the determinant of a mat4
  *
- * @param {mat4} a the source matrix
+ * @param {Mat4} a the source matrix
  * @returns {Number} determinant of a
  */
 export function determinant(a) {
@@ -364,10 +364,10 @@ export function determinant(a) {
 /**
  * Multiplies two mat4s
  *
- * @param {mat4} out the receiving matrix
- * @param {mat4} a the first operand
- * @param {mat4} b the second operand
- * @returns {mat4} out
+ * @param {Mat4} out the receiving matrix
+ * @param {Mat4} a the first operand
+ * @param {Mat4} b the second operand
+ * @returns {Mat4} out
  */
 export function multiply(out, a, b) {
   let a00 = a[0], a01 = a[1], a02 = a[2], a03 = a[3];
@@ -405,10 +405,10 @@ export function multiply(out, a, b) {
 /**
  * Translate a mat4 by the given vector
  *
- * @param {mat4} out the receiving matrix
- * @param {mat4} a the matrix to translate
- * @param {vec3} v vector to translate by
- * @returns {mat4} out
+ * @param {Mat4} out the receiving matrix
+ * @param {Mat4} a the matrix to translate
+ * @param {Vec3} v vector to translate by
+ * @returns {Mat4} out
  */
 export function translate(out, a, v) {
   let x = v[0], y = v[1], z = v[2];
@@ -442,10 +442,10 @@ export function translate(out, a, v) {
 /**
  * Scales the mat4 by the dimensions in the given vec3 not using vectorization
  *
- * @param {mat4} out the receiving matrix
- * @param {mat4} a the matrix to scale
- * @param {vec3} v the vec3 to scale the matrix by
- * @returns {mat4} out
+ * @param {Mat4} out the receiving matrix
+ * @param {Mat4} a the matrix to scale
+ * @param {Vec3} v the vec3 to scale the matrix by
+ * @returns {Mat4} out
  **/
 export function scale(out, a, v) {
   let x = v[0], y = v[1], z = v[2];
@@ -472,11 +472,11 @@ export function scale(out, a, v) {
 /**
  * Rotates a mat4 by the given angle around the given axis
  *
- * @param {mat4} out the receiving matrix
- * @param {mat4} a the matrix to rotate
+ * @param {Mat4} out the receiving matrix
+ * @param {Mat4} a the matrix to rotate
  * @param {Number} rad the angle to rotate the matrix by
- * @param {vec3} axis the axis to rotate around
- * @returns {mat4} out
+ * @param {Vec3} axis the axis to rotate around
+ * @returns {Mat4} out
  */
 export function rotate(out, a, rad, axis) {
   let x = axis[0], y = axis[1], z = axis[2];
@@ -535,10 +535,10 @@ export function rotate(out, a, rad, axis) {
 /**
  * Rotates a matrix by the given angle around the X axis
  *
- * @param {mat4} out the receiving matrix
- * @param {mat4} a the matrix to rotate
+ * @param {Mat4} out the receiving matrix
+ * @param {Mat4} a the matrix to rotate
  * @param {Number} rad the angle to rotate the matrix by
- * @returns {mat4} out
+ * @returns {Mat4} out
  */
 export function rotateX(out, a, rad) {
   let s = Math.sin(rad);
@@ -578,10 +578,10 @@ export function rotateX(out, a, rad) {
 /**
  * Rotates a matrix by the given angle around the Y axis
  *
- * @param {mat4} out the receiving matrix
- * @param {mat4} a the matrix to rotate
+ * @param {Mat4} out the receiving matrix
+ * @param {Mat4} a the matrix to rotate
  * @param {Number} rad the angle to rotate the matrix by
- * @returns {mat4} out
+ * @returns {Mat4} out
  */
 export function rotateY(out, a, rad) {
   let s = Math.sin(rad);
@@ -621,10 +621,10 @@ export function rotateY(out, a, rad) {
 /**
  * Rotates a matrix by the given angle around the Z axis
  *
- * @param {mat4} out the receiving matrix
- * @param {mat4} a the matrix to rotate
+ * @param {Mat4} out the receiving matrix
+ * @param {Mat4} a the matrix to rotate
  * @param {Number} rad the angle to rotate the matrix by
- * @returns {mat4} out
+ * @returns {Mat4} out
  */
 export function rotateZ(out, a, rad) {
   let s = Math.sin(rad);
@@ -668,9 +668,9 @@ export function rotateZ(out, a, rad) {
  *     mat4.identity(dest);
  *     mat4.translate(dest, dest, vec);
  *
- * @param {mat4} out mat4 receiving operation result
- * @param {vec3} v Translation vector
- * @returns {mat4} out
+ * @param {Mat4} out mat4 receiving operation result
+ * @param {Vec3} v Translation vector
+ * @returns {Mat4} out
  */
 export function fromTranslation(out, v) {
   out[0] = 1;
@@ -699,9 +699,9 @@ export function fromTranslation(out, v) {
  *     mat4.identity(dest);
  *     mat4.scale(dest, dest, vec);
  *
- * @param {mat4} out mat4 receiving operation result
- * @param {vec3} v Scaling vector
- * @returns {mat4} out
+ * @param {Mat4} out mat4 receiving operation result
+ * @param {Vec3} v Scaling vector
+ * @returns {Mat4} out
  */
 export function fromScaling(out, v) {
   out[0] = v[0];
@@ -730,10 +730,10 @@ export function fromScaling(out, v) {
  *     mat4.identity(dest);
  *     mat4.rotate(dest, dest, rad, axis);
  *
- * @param {mat4} out mat4 receiving operation result
+ * @param {Mat4} out mat4 receiving operation result
  * @param {Number} rad the angle to rotate the matrix by
- * @param {vec3} axis the axis to rotate around
- * @returns {mat4} out
+ * @param {Vec3} axis the axis to rotate around
+ * @returns {Mat4} out
  */
 export function fromRotation(out, rad, axis) {
   let x = axis[0], y = axis[1], z = axis[2];
@@ -778,9 +778,9 @@ export function fromRotation(out, rad, axis) {
  *     mat4.identity(dest);
  *     mat4.rotateX(dest, dest, rad);
  *
- * @param {mat4} out mat4 receiving operation result
+ * @param {Mat4} out mat4 receiving operation result
  * @param {Number} rad the angle to rotate the matrix by
- * @returns {mat4} out
+ * @returns {Mat4} out
  */
 export function fromXRotation(out, rad) {
   let s = Math.sin(rad);
@@ -813,9 +813,9 @@ export function fromXRotation(out, rad) {
  *     mat4.identity(dest);
  *     mat4.rotateY(dest, dest, rad);
  *
- * @param {mat4} out mat4 receiving operation result
+ * @param {Mat4} out mat4 receiving operation result
  * @param {Number} rad the angle to rotate the matrix by
- * @returns {mat4} out
+ * @returns {Mat4} out
  */
 export function fromYRotation(out, rad) {
   let s = Math.sin(rad);
@@ -848,9 +848,9 @@ export function fromYRotation(out, rad) {
  *     mat4.identity(dest);
  *     mat4.rotateZ(dest, dest, rad);
  *
- * @param {mat4} out mat4 receiving operation result
+ * @param {Mat4} out mat4 receiving operation result
  * @param {Number} rad the angle to rotate the matrix by
- * @returns {mat4} out
+ * @returns {Mat4} out
  */
 export function fromZRotation(out, rad) {
   let s = Math.sin(rad);
@@ -886,10 +886,10 @@ export function fromZRotation(out, rad) {
  *     quat4.toMat4(quat, quatMat);
  *     mat4.multiply(dest, quatMat);
  *
- * @param {mat4} out mat4 receiving operation result
+ * @param {Mat4} out mat4 receiving operation result
  * @param {quat4} q Rotation quaternion
- * @param {vec3} v Translation vector
- * @returns {mat4} out
+ * @param {Vec3} v Translation vector
+ * @returns {Mat4} out
  */
 export function fromRotationTranslation(out, q, v) {
   // Quaternion math
@@ -931,9 +931,9 @@ export function fromRotationTranslation(out, q, v) {
 /**
  * Creates a new mat4 from a dual quat.
  *
- * @param {mat4} out Matrix
- * @param {quat2} a Dual Quaternion
- * @returns {mat4} mat4 receiving operation result
+ * @param {Mat4} out Matrix
+ * @param {Quat2} a Dual Quaternion
+ * @returns {Mat4} mat4 receiving operation result
  */
 export function fromQuat2(out, a) {
   let translation = new glMatrix.ARRAY_TYPE(3);
@@ -960,9 +960,9 @@ export function fromQuat2(out, a) {
  *  matrix. If a matrix is built with fromRotationTranslation,
  *  the returned vector will be the same as the translation vector
  *  originally supplied.
- * @param  {vec3} out Vector to receive translation component
- * @param  {mat4} mat Matrix to be decomposed (input)
- * @return {vec3} out
+ * @param  {Vec3} out Vector to receive translation component
+ * @param  {Mat4} mat Matrix to be decomposed (input)
+ * @return {Vec3} out
  */
 export function getTranslation(out, mat) {
   out[0] = mat[12];
@@ -978,9 +978,9 @@ export function getTranslation(out, mat) {
  *  with a normalized Quaternion paramter, the returned vector will be
  *  the same as the scaling vector
  *  originally supplied.
- * @param  {vec3} out Vector to receive scaling factor component
- * @param  {mat4} mat Matrix to be decomposed (input)
- * @return {vec3} out
+ * @param  {Vec3} out Vector to receive scaling factor component
+ * @param  {Mat4} mat Matrix to be decomposed (input)
+ * @return {Vec3} out
  */
 export function getScaling(out, mat) {
   let m11 = mat[0];
@@ -1005,9 +1005,9 @@ export function getScaling(out, mat) {
  *  of a transformation matrix. If a matrix is built with
  *  fromRotationTranslation, the returned quaternion will be the
  *  same as the quaternion originally supplied.
- * @param {quat} out Quaternion to receive the rotation component
- * @param {mat4} mat Matrix to be decomposed (input)
- * @return {quat} out
+ * @param {Quat} out Quaternion to receive the rotation component
+ * @param {Mat4} mat Matrix to be decomposed (input)
+ * @return {Quat} out
  */
 export function getRotation(out, mat) {
   // Algorithm taken from http://www.euclideanspace.com/maths/geometry/rotations/conversions/matrixToQuaternion/index.htm
@@ -1054,11 +1054,11 @@ export function getRotation(out, mat) {
  *     mat4.multiply(dest, quatMat);
  *     mat4.scale(dest, scale)
  *
- * @param {mat4} out mat4 receiving operation result
+ * @param {Mat4} out mat4 receiving operation result
  * @param {quat4} q Rotation quaternion
- * @param {vec3} v Translation vector
- * @param {vec3} s Scaling vector
- * @returns {mat4} out
+ * @param {Vec3} v Translation vector
+ * @param {Vec3} s Scaling vector
+ * @returns {Mat4} out
  */
 export function fromRotationTranslationScale(out, q, v, s) {
   // Quaternion math
@@ -1113,12 +1113,12 @@ export function fromRotationTranslationScale(out, q, v, s) {
  *     mat4.scale(dest, scale)
  *     mat4.translate(dest, negativeOrigin);
  *
- * @param {mat4} out mat4 receiving operation result
+ * @param {Mat4} out mat4 receiving operation result
  * @param {quat4} q Rotation quaternion
- * @param {vec3} v Translation vector
- * @param {vec3} s Scaling vector
- * @param {vec3} o The origin vector around which to scale and rotate
- * @returns {mat4} out
+ * @param {Vec3} v Translation vector
+ * @param {Vec3} s Scaling vector
+ * @param {Vec3} o The origin vector around which to scale and rotate
+ * @returns {Mat4} out
  */
 export function fromRotationTranslationScaleOrigin(out, q, v, s, o) {
   // Quaternion math
@@ -1178,10 +1178,10 @@ export function fromRotationTranslationScaleOrigin(out, q, v, s, o) {
 /**
  * Calculates a 4x4 matrix from the given quaternion
  *
- * @param {mat4} out mat4 receiving operation result
- * @param {quat} q Quaternion to create matrix from
+ * @param {Mat4} out mat4 receiving operation result
+ * @param {Quat} q Quaternion to create matrix from
  *
- * @returns {mat4} out
+ * @returns {Mat4} out
  */
 export function fromQuat(out, q) {
   let x = q[0], y = q[1], z = q[2], w = q[3];
@@ -1225,14 +1225,14 @@ export function fromQuat(out, q) {
 /**
  * Generates a frustum matrix with the given bounds
  *
- * @param {mat4} out mat4 frustum matrix will be written into
+ * @param {Mat4} out mat4 frustum matrix will be written into
  * @param {Number} left Left bound of the frustum
  * @param {Number} right Right bound of the frustum
  * @param {Number} bottom Bottom bound of the frustum
  * @param {Number} top Top bound of the frustum
  * @param {Number} near Near bound of the frustum
  * @param {Number} far Far bound of the frustum
- * @returns {mat4} out
+ * @returns {Mat4} out
  */
 export function frustum(out, left, right, bottom, top, near, far) {
   let rl = 1 / (right - left);
@@ -1261,12 +1261,12 @@ export function frustum(out, left, right, bottom, top, near, far) {
  * Generates a perspective projection matrix with the given bounds.
  * Passing null/undefined/no value for far will generate infinite projection matrix.
  *
- * @param {mat4} out mat4 frustum matrix will be written into
+ * @param {Mat4} out mat4 frustum matrix will be written into
  * @param {number} fovy Vertical field of view in radians
  * @param {number} aspect Aspect ratio. typically viewport width/height
  * @param {number} near Near bound of the frustum
  * @param {number} far Far bound of the frustum, can be null or Infinity
- * @returns {mat4} out
+ * @returns {Mat4} out
  */
 export function perspective(out, fovy, aspect, near, far) {
   let f = 1.0 / Math.tan(fovy / 2), nf;
@@ -1300,11 +1300,11 @@ export function perspective(out, fovy, aspect, near, far) {
  * This is primarily useful for generating projection matrices to be used
  * with the still experiemental WebVR API.
  *
- * @param {mat4} out mat4 frustum matrix will be written into
+ * @param {Mat4} out mat4 frustum matrix will be written into
  * @param {Object} fov Object containing the following values: upDegrees, downDegrees, leftDegrees, rightDegrees
  * @param {number} near Near bound of the frustum
  * @param {number} far Far bound of the frustum
- * @returns {mat4} out
+ * @returns {Mat4} out
  */
 export function perspectiveFromFieldOfView(out, fov, near, far) {
   let upTan = Math.tan(fov.upDegrees * Math.PI/180.0);
@@ -1336,14 +1336,14 @@ export function perspectiveFromFieldOfView(out, fov, near, far) {
 /**
  * Generates a orthogonal projection matrix with the given bounds
  *
- * @param {mat4} out mat4 frustum matrix will be written into
+ * @param {Mat4} out mat4 frustum matrix will be written into
  * @param {number} left Left bound of the frustum
  * @param {number} right Right bound of the frustum
  * @param {number} bottom Bottom bound of the frustum
  * @param {number} top Top bound of the frustum
  * @param {number} near Near bound of the frustum
  * @param {number} far Far bound of the frustum
- * @returns {mat4} out
+ * @returns {Mat4} out
  */
 export function ortho(out, left, right, bottom, top, near, far) {
   let lr = 1 / (left - right);
@@ -1372,11 +1372,11 @@ export function ortho(out, left, right, bottom, top, near, far) {
  * Generates a look-at matrix with the given eye position, focal point, and up axis.
  * If you want a matrix that actually makes an object look at another object, you should use targetTo instead.
  *
- * @param {mat4} out mat4 frustum matrix will be written into
- * @param {vec3} eye Position of the viewer
- * @param {vec3} center Point the viewer is looking at
- * @param {vec3} up vec3 pointing up
- * @returns {mat4} out
+ * @param {Mat4} out mat4 frustum matrix will be written into
+ * @param {Vec3} eye Position of the viewer
+ * @param {Vec3} center Point the viewer is looking at
+ * @param {Vec3} up vec3 pointing up
+ * @returns {Mat4} out
  */
 export function lookAt(out, eye, center, up) {
   let x0, x1, x2, y0, y1, y2, z0, z1, z2, len;
@@ -1459,11 +1459,11 @@ export function lookAt(out, eye, center, up) {
 /**
  * Generates a matrix that makes something look at something else.
  *
- * @param {mat4} out mat4 frustum matrix will be written into
- * @param {vec3} eye Position of the viewer
- * @param {vec3} center Point the viewer is looking at
- * @param {vec3} up vec3 pointing up
- * @returns {mat4} out
+ * @param {Mat4} out mat4 frustum matrix will be written into
+ * @param {Vec3} eye Position of the viewer
+ * @param {Vec3} center Point the viewer is looking at
+ * @param {Vec3} up vec3 pointing up
+ * @returns {Mat4} out
  */
 export function targetTo(out, eye, target, up) {
   let eyex = eye[0],
@@ -1519,7 +1519,7 @@ export function targetTo(out, eye, target, up) {
 /**
  * Returns a string representation of a mat4
  *
- * @param {mat4} a matrix to represent as a string
+ * @param {Mat4} a matrix to represent as a string
  * @returns {String} string representation of the matrix
  */
 export function str(a) {
@@ -1532,7 +1532,7 @@ export function str(a) {
 /**
  * Returns Frobenius norm of a mat4
  *
- * @param {mat4} a the matrix to calculate Frobenius norm of
+ * @param {Mat4} a the matrix to calculate Frobenius norm of
  * @returns {Number} Frobenius norm
  */
 export function frob(a) {
@@ -1542,10 +1542,10 @@ export function frob(a) {
 /**
  * Adds two mat4's
  *
- * @param {mat4} out the receiving matrix
- * @param {mat4} a the first operand
- * @param {mat4} b the second operand
- * @returns {mat4} out
+ * @param {Mat4} out the receiving matrix
+ * @param {Mat4} a the first operand
+ * @param {Mat4} b the second operand
+ * @returns {Mat4} out
  */
 export function add(out, a, b) {
   out[0] = a[0] + b[0];
@@ -1570,10 +1570,10 @@ export function add(out, a, b) {
 /**
  * Subtracts matrix b from matrix a
  *
- * @param {mat4} out the receiving matrix
- * @param {mat4} a the first operand
- * @param {mat4} b the second operand
- * @returns {mat4} out
+ * @param {Mat4} out the receiving matrix
+ * @param {Mat4} a the first operand
+ * @param {Mat4} b the second operand
+ * @returns {Mat4} out
  */
 export function subtract(out, a, b) {
   out[0] = a[0] - b[0];
@@ -1598,10 +1598,10 @@ export function subtract(out, a, b) {
 /**
  * Multiply each element of the matrix by a scalar.
  *
- * @param {mat4} out the receiving matrix
- * @param {mat4} a the matrix to scale
+ * @param {Mat4} out the receiving matrix
+ * @param {Mat4} a the matrix to scale
  * @param {Number} b amount to scale the matrix's elements by
- * @returns {mat4} out
+ * @returns {Mat4} out
  */
 export function multiplyScalar(out, a, b) {
   out[0] = a[0] * b;
@@ -1626,11 +1626,11 @@ export function multiplyScalar(out, a, b) {
 /**
  * Adds two mat4's after multiplying each element of the second operand by a scalar value.
  *
- * @param {mat4} out the receiving vector
- * @param {mat4} a the first operand
- * @param {mat4} b the second operand
+ * @param {Mat4} out the receiving vector
+ * @param {Mat4} a the first operand
+ * @param {Mat4} b the second operand
  * @param {Number} scale the amount to scale b's elements by before adding
- * @returns {mat4} out
+ * @returns {Mat4} out
  */
 export function multiplyScalarAndAdd(out, a, b, scale) {
   out[0] = a[0] + (b[0] * scale);
@@ -1655,8 +1655,8 @@ export function multiplyScalarAndAdd(out, a, b, scale) {
 /**
  * Returns whether or not the matrices have exactly the same elements in the same position (when compared with ===)
  *
- * @param {mat4} a The first matrix.
- * @param {mat4} b The second matrix.
+ * @param {Mat4} a The first matrix.
+ * @param {Mat4} b The second matrix.
  * @returns {Boolean} True if the matrices are equal, false otherwise.
  */
 export function exactEquals(a, b) {
@@ -1669,8 +1669,8 @@ export function exactEquals(a, b) {
 /**
  * Returns whether or not the matrices have approximately the same elements in the same position.
  *
- * @param {mat4} a The first matrix.
- * @param {mat4} b The second matrix.
+ * @param {Mat4} a The first matrix.
+ * @param {Mat4} b The second matrix.
  * @returns {Boolean} True if the matrices are equal, false otherwise.
  */
 export function equals(a, b) {

--- a/src/quat.js
+++ b/src/quat.js
@@ -11,7 +11,7 @@ import * as vec4 from "./vec4.js"
 /**
  * Creates a new identity quat
  *
- * @returns {quat} a new quaternion
+ * @returns {Quat} a new quaternion
  */
 export function create() {
   let out = new glMatrix.ARRAY_TYPE(4);
@@ -27,8 +27,8 @@ export function create() {
 /**
  * Set a quat to the identity quaternion
  *
- * @param {quat} out the receiving quaternion
- * @returns {quat} out
+ * @param {Quat} out the receiving quaternion
+ * @returns {Quat} out
  */
 export function identity(out) {
   out[0] = 0;
@@ -42,10 +42,10 @@ export function identity(out) {
  * Sets a quat from the given angle and rotation axis,
  * then returns it.
  *
- * @param {quat} out the receiving quaternion
- * @param {vec3} axis the axis around which to rotate
+ * @param {Quat} out the receiving quaternion
+ * @param {Vec3} axis the axis around which to rotate
  * @param {Number} rad the angle in radians
- * @returns {quat} out
+ * @returns {Quat} out
  **/
 export function setAxisAngle(out, axis, rad) {
   rad = rad * 0.5;
@@ -66,8 +66,8 @@ export function setAxisAngle(out, axis, rad) {
  * Example: The quaternion formed by axis [0, 0, 1] and
  *  angle -90 is the same as the quaternion formed by
  *  [0, 0, 1] and 270. This method favors the latter.
- * @param  {vec3} out_axis  Vector receiving the axis of rotation
- * @param  {quat} q     Quaternion to be decomposed
+ * @param  {Vec3} out_axis  Vector receiving the axis of rotation
+ * @param  {Quat} q     Quaternion to be decomposed
  * @return {Number}     Angle, in radians, of the rotation
  */
 export function getAxisAngle(out_axis, q) {
@@ -89,10 +89,10 @@ export function getAxisAngle(out_axis, q) {
 /**
  * Multiplies two quat's
  *
- * @param {quat} out the receiving quaternion
- * @param {quat} a the first operand
- * @param {quat} b the second operand
- * @returns {quat} out
+ * @param {Quat} out the receiving quaternion
+ * @param {Quat} a the first operand
+ * @param {Quat} b the second operand
+ * @returns {Quat} out
  */
 export function multiply(out, a, b) {
   let ax = a[0], ay = a[1], az = a[2], aw = a[3];
@@ -108,10 +108,10 @@ export function multiply(out, a, b) {
 /**
  * Rotates a quaternion by the given angle about the X axis
  *
- * @param {quat} out quat receiving operation result
- * @param {quat} a quat to rotate
+ * @param {Quat} out quat receiving operation result
+ * @param {Quat} a quat to rotate
  * @param {number} rad angle (in radians) to rotate
- * @returns {quat} out
+ * @returns {Quat} out
  */
 export function rotateX(out, a, rad) {
   rad *= 0.5;
@@ -129,10 +129,10 @@ export function rotateX(out, a, rad) {
 /**
  * Rotates a quaternion by the given angle about the Y axis
  *
- * @param {quat} out quat receiving operation result
- * @param {quat} a quat to rotate
+ * @param {Quat} out quat receiving operation result
+ * @param {Quat} a quat to rotate
  * @param {number} rad angle (in radians) to rotate
- * @returns {quat} out
+ * @returns {Quat} out
  */
 export function rotateY(out, a, rad) {
   rad *= 0.5;
@@ -150,10 +150,10 @@ export function rotateY(out, a, rad) {
 /**
  * Rotates a quaternion by the given angle about the Z axis
  *
- * @param {quat} out quat receiving operation result
- * @param {quat} a quat to rotate
+ * @param {Quat} out quat receiving operation result
+ * @param {Quat} a quat to rotate
  * @param {number} rad angle (in radians) to rotate
- * @returns {quat} out
+ * @returns {Quat} out
  */
 export function rotateZ(out, a, rad) {
   rad *= 0.5;
@@ -173,9 +173,9 @@ export function rotateZ(out, a, rad) {
  * Assumes that quaternion is 1 unit in length.
  * Any existing W component will be ignored.
  *
- * @param {quat} out the receiving quaternion
- * @param {quat} a quat to calculate W component of
- * @returns {quat} out
+ * @param {Quat} out the receiving quaternion
+ * @param {Quat} a quat to calculate W component of
+ * @returns {Quat} out
  */
 export function calculateW(out, a) {
   let x = a[0], y = a[1], z = a[2];
@@ -190,11 +190,11 @@ export function calculateW(out, a) {
 /**
  * Performs a spherical linear interpolation between two quat
  *
- * @param {quat} out the receiving quaternion
- * @param {quat} a the first operand
- * @param {quat} b the second operand
+ * @param {Quat} out the receiving quaternion
+ * @param {Quat} a the first operand
+ * @param {Quat} b the second operand
  * @param {Number} t interpolation amount, in the range [0-1], between the two inputs
- * @returns {quat} out
+ * @returns {Quat} out
  */
 export function slerp(out, a, b, t) {
   // benchmarks:
@@ -239,8 +239,8 @@ export function slerp(out, a, b, t) {
 /**
  * Generates a random quaternion
  *
- * @param {quat} out the receiving quaternion
- * @returns {quat} out
+ * @param {Quat} out the receiving quaternion
+ * @returns {Quat} out
  */
 export function random(out) {
   // Implementation of http://planning.cs.uiuc.edu/node198.html
@@ -262,9 +262,9 @@ export function random(out) {
 /**
  * Calculates the inverse of a quat
  *
- * @param {quat} out the receiving quaternion
- * @param {quat} a quat to calculate inverse of
- * @returns {quat} out
+ * @param {Quat} out the receiving quaternion
+ * @param {Quat} a quat to calculate inverse of
+ * @returns {Quat} out
  */
 export function invert(out, a) {
   let a0 = a[0], a1 = a[1], a2 = a[2], a3 = a[3];
@@ -284,9 +284,9 @@ export function invert(out, a) {
  * Calculates the conjugate of a quat
  * If the quaternion is normalized, this function is faster than quat.inverse and produces the same result.
  *
- * @param {quat} out the receiving quaternion
- * @param {quat} a quat to calculate conjugate of
- * @returns {quat} out
+ * @param {Quat} out the receiving quaternion
+ * @param {Quat} a quat to calculate conjugate of
+ * @returns {Quat} out
  */
 export function conjugate(out, a) {
   out[0] = -a[0];
@@ -302,9 +302,9 @@ export function conjugate(out, a) {
  * NOTE: The resultant quaternion is not normalized, so you should be sure
  * to renormalize the quaternion yourself where necessary.
  *
- * @param {quat} out the receiving quaternion
- * @param {mat3} m rotation matrix
- * @returns {quat} out
+ * @param {Quat} out the receiving quaternion
+ * @param {Mat3} m rotation matrix
+ * @returns {Quat} out
  * @function
  */
 export function fromMat3(out, m) {
@@ -345,11 +345,11 @@ export function fromMat3(out, m) {
 /**
  * Creates a quaternion from the given euler angle x, y, z.
  *
- * @param {quat} out the receiving quaternion
+ * @param {Quat} out the receiving quaternion
  * @param {x} Angle to rotate around X axis in degrees.
  * @param {y} Angle to rotate around Y axis in degrees.
  * @param {z} Angle to rotate around Z axis in degrees.
- * @returns {quat} out
+ * @returns {Quat} out
  * @function
  */
 export function fromEuler(out, x, y, z) {
@@ -376,7 +376,7 @@ export function fromEuler(out, x, y, z) {
 /**
  * Returns a string representation of a quatenion
  *
- * @param {quat} a vector to represent as a string
+ * @param {Quat} a vector to represent as a string
  * @returns {String} string representation of the vector
  */
 export function str(a) {
@@ -386,8 +386,8 @@ export function str(a) {
 /**
  * Creates a new quat initialized with values from an existing quaternion
  *
- * @param {quat} a quaternion to clone
- * @returns {quat} a new quaternion
+ * @param {Quat} a quaternion to clone
+ * @returns {Quat} a new quaternion
  * @function
  */
 export const clone = vec4.clone;
@@ -399,7 +399,7 @@ export const clone = vec4.clone;
  * @param {Number} y Y component
  * @param {Number} z Z component
  * @param {Number} w W component
- * @returns {quat} a new quaternion
+ * @returns {Quat} a new quaternion
  * @function
  */
 export const fromValues = vec4.fromValues;
@@ -407,9 +407,9 @@ export const fromValues = vec4.fromValues;
 /**
  * Copy the values from one quat to another
  *
- * @param {quat} out the receiving quaternion
- * @param {quat} a the source quaternion
- * @returns {quat} out
+ * @param {Quat} out the receiving quaternion
+ * @param {Quat} a the source quaternion
+ * @returns {Quat} out
  * @function
  */
 export const copy = vec4.copy;
@@ -417,12 +417,12 @@ export const copy = vec4.copy;
 /**
  * Set the components of a quat to the given values
  *
- * @param {quat} out the receiving quaternion
+ * @param {Quat} out the receiving quaternion
  * @param {Number} x X component
  * @param {Number} y Y component
  * @param {Number} z Z component
  * @param {Number} w W component
- * @returns {quat} out
+ * @returns {Quat} out
  * @function
  */
 export const set = vec4.set;
@@ -430,10 +430,10 @@ export const set = vec4.set;
 /**
  * Adds two quat's
  *
- * @param {quat} out the receiving quaternion
- * @param {quat} a the first operand
- * @param {quat} b the second operand
- * @returns {quat} out
+ * @param {Quat} out the receiving quaternion
+ * @param {Quat} a the first operand
+ * @param {Quat} b the second operand
+ * @returns {Quat} out
  * @function
  */
 export const add = vec4.add;
@@ -447,10 +447,10 @@ export const mul = multiply;
 /**
  * Scales a quat by a scalar number
  *
- * @param {quat} out the receiving vector
- * @param {quat} a the vector to scale
+ * @param {Quat} out the receiving vector
+ * @param {Quat} a the vector to scale
  * @param {Number} b amount to scale the vector by
- * @returns {quat} out
+ * @returns {Quat} out
  * @function
  */
 export const scale = vec4.scale;
@@ -458,8 +458,8 @@ export const scale = vec4.scale;
 /**
  * Calculates the dot product of two quat's
  *
- * @param {quat} a the first operand
- * @param {quat} b the second operand
+ * @param {Quat} a the first operand
+ * @param {Quat} b the second operand
  * @returns {Number} dot product of a and b
  * @function
  */
@@ -468,11 +468,11 @@ export const dot = vec4.dot;
 /**
  * Performs a linear interpolation between two quat's
  *
- * @param {quat} out the receiving quaternion
- * @param {quat} a the first operand
- * @param {quat} b the second operand
+ * @param {Quat} out the receiving quaternion
+ * @param {Quat} a the first operand
+ * @param {Quat} b the second operand
  * @param {Number} t interpolation amount, in the range [0-1], between the two inputs
- * @returns {quat} out
+ * @returns {Quat} out
  * @function
  */
 export const lerp = vec4.lerp;
@@ -480,7 +480,7 @@ export const lerp = vec4.lerp;
 /**
  * Calculates the length of a quat
  *
- * @param {quat} a vector to calculate length of
+ * @param {Quat} a vector to calculate length of
  * @returns {Number} length of a
  */
 export const length = vec4.length;
@@ -494,7 +494,7 @@ export const len = length;
 /**
  * Calculates the squared length of a quat
  *
- * @param {quat} a vector to calculate squared length of
+ * @param {Quat} a vector to calculate squared length of
  * @returns {Number} squared length of a
  * @function
  */
@@ -509,9 +509,9 @@ export const sqrLen = squaredLength;
 /**
  * Normalize a quat
  *
- * @param {quat} out the receiving quaternion
- * @param {quat} a quaternion to normalize
- * @returns {quat} out
+ * @param {Quat} out the receiving quaternion
+ * @param {Quat} a quaternion to normalize
+ * @returns {Quat} out
  * @function
  */
 export const normalize = vec4.normalize;
@@ -519,8 +519,8 @@ export const normalize = vec4.normalize;
 /**
  * Returns whether or not the quaternions have exactly the same elements in the same position (when compared with ===)
  *
- * @param {quat} a The first quaternion.
- * @param {quat} b The second quaternion.
+ * @param {Quat} a The first quaternion.
+ * @param {Quat} b The second quaternion.
  * @returns {Boolean} True if the vectors are equal, false otherwise.
  */
 export const exactEquals = vec4.exactEquals;
@@ -528,8 +528,8 @@ export const exactEquals = vec4.exactEquals;
 /**
  * Returns whether or not the quaternions have approximately the same elements in the same position.
  *
- * @param {quat} a The first vector.
- * @param {quat} b The second vector.
+ * @param {Quat} a The first vector.
+ * @param {Quat} b The second vector.
  * @returns {Boolean} True if the vectors are equal, false otherwise.
  */
 export const equals = vec4.equals;
@@ -540,10 +540,10 @@ export const equals = vec4.equals;
  *
  * Both vectors are assumed to be unit length.
  *
- * @param {quat} out the receiving quaternion.
- * @param {vec3} a the initial vector
- * @param {vec3} b the destination vector
- * @returns {quat} out
+ * @param {Quat} out the receiving quaternion.
+ * @param {Vec3} a the initial vector
+ * @param {Vec3} b the destination vector
+ * @returns {Quat} out
  */
 export const rotationTo = (function() {
   let tmpvec3 = vec3.create();
@@ -579,13 +579,13 @@ export const rotationTo = (function() {
 /**
  * Performs a spherical linear interpolation with two control points
  *
- * @param {quat} out the receiving quaternion
- * @param {quat} a the first operand
- * @param {quat} b the second operand
- * @param {quat} c the third operand
- * @param {quat} d the fourth operand
+ * @param {Quat} out the receiving quaternion
+ * @param {Quat} a the first operand
+ * @param {Quat} b the second operand
+ * @param {Quat} c the third operand
+ * @param {Quat} d the fourth operand
  * @param {Number} t interpolation amount, in the range [0-1], between the two inputs
- * @returns {quat} out
+ * @returns {Quat} out
  */
 export const sqlerp = (function () {
   let temp1 = create();
@@ -605,10 +605,10 @@ export const sqlerp = (function () {
  * axes. Each axis is a vec3 and is expected to be unit length and
  * perpendicular to all other specified axes.
  *
- * @param {vec3} view  the vector representing the viewing direction
- * @param {vec3} right the vector representing the local "right" direction
- * @param {vec3} up    the vector representing the local "up" direction
- * @returns {quat} out
+ * @param {Vec3} view  the vector representing the viewing direction
+ * @param {Vec3} right the vector representing the local "right" direction
+ * @param {Vec3} up    the vector representing the local "up" direction
+ * @returns {Quat} out
  */
 export const setAxes = (function() {
   let matr = mat3.create();

--- a/src/quat.js
+++ b/src/quat.js
@@ -9,6 +9,10 @@ import * as vec4 from "./vec4.js"
  */
 
 /**
+ * @typedef {[number, number, number, number] | Float32Array} Quat
+ */
+
+/**
  * Creates a new identity quat
  *
  * @returns {Quat} a new quaternion

--- a/src/quat2.js
+++ b/src/quat2.js
@@ -14,7 +14,7 @@ import * as mat4 from "./mat4.js";
 /**
  * Creates a new identity dual quat
  *
- * @returns {quat2} a new dual quaternion [real -> rotation, dual -> translation]
+ * @returns {Quat2} a new dual quaternion [real -> rotation, dual -> translation]
  */
 export function create() {
   let dq = new glMatrix.ARRAY_TYPE(8);
@@ -34,8 +34,8 @@ export function create() {
 /**
  * Creates a new quat initialized with values from an existing quaternion
  *
- * @param {quat2} a dual quaternion to clone
- * @returns {quat2} new dual quaternion
+ * @param {Quat2} a dual quaternion to clone
+ * @returns {Quat2} new dual quaternion
  * @function
  */
 export function clone(a) {
@@ -62,7 +62,7 @@ export function clone(a) {
  * @param {Number} y2 Y component
  * @param {Number} z2 Z component
  * @param {Number} w2 W component
- * @returns {quat2} new dual quaternion
+ * @returns {Quat2} new dual quaternion
  * @function
  */
 export function fromValues(x1, y1, z1, w1, x2, y2, z2, w2) {
@@ -88,7 +88,7 @@ export function fromValues(x1, y1, z1, w1, x2, y2, z2, w2) {
  * @param {Number} x2 X component (translation)
  * @param {Number} y2 Y component (translation)
  * @param {Number} z2 Z component (translation)
- * @returns {quat2} new dual quaternion
+ * @returns {Quat2} new dual quaternion
  * @function
  */
 export function fromRotationTranslationValues(x1, y1, z1, w1, x2, y2, z2) {
@@ -110,10 +110,10 @@ export function fromRotationTranslationValues(x1, y1, z1, w1, x2, y2, z2) {
 /**
  * Creates a dual quat from a quaternion and a translation
  *
- * @param {quat2} dual quaternion receiving operation result
- * @param {quat} q quaternion
- * @param {vec3} t tranlation vector
- * @returns {quat2} dual quaternion receiving operation result
+ * @param {Quat2} dual quaternion receiving operation result
+ * @param {Quat} q quaternion
+ * @param {Vec3} t tranlation vector
+ * @returns {Quat2} dual quaternion receiving operation result
  * @function
  */
 export function fromRotationTranslation(out, q, t) {
@@ -138,9 +138,9 @@ export function fromRotationTranslation(out, q, t) {
 /**
  * Creates a dual quat from a translation
  *
- * @param {quat2} dual quaternion receiving operation result
- * @param {vec3} t translation vector
- * @returns {quat2} dual quaternion receiving operation result
+ * @param {Quat2} dual quaternion receiving operation result
+ * @param {Vec3} t translation vector
+ * @returns {Quat2} dual quaternion receiving operation result
  * @function
  */
 export function fromTranslation(out, t) {
@@ -158,9 +158,9 @@ export function fromTranslation(out, t) {
 /**
  * Creates a dual quat from a quaternion
  *
- * @param {quat2} dual quaternion receiving operation result
- * @param {quat} q the quaternion
- * @returns {quat2} dual quaternion receiving operation result
+ * @param {Quat2} dual quaternion receiving operation result
+ * @param {Quat} q the quaternion
+ * @returns {Quat2} dual quaternion receiving operation result
  * @function
  */
 export function fromRotation(out, q) {
@@ -178,9 +178,9 @@ export function fromRotation(out, q) {
 /**
  * Creates a new dual quat from a matrix (4x4)
  *
- * @param {quat2} out the dual quaternion
- * @param {mat4} a the matrix
- * @returns {quat2} dual quat receiving operation result
+ * @param {Quat2} out the dual quaternion
+ * @param {Mat4} a the matrix
+ * @returns {Quat2} dual quat receiving operation result
  * @function
  */
 export function fromMat4(out, a) {
@@ -196,9 +196,9 @@ export function fromMat4(out, a) {
 /**
  * Copy the values from one dual quat to another
  *
- * @param {quat2} out the receiving dual quaternion
- * @param {quat2} a the source dual quaternion
- * @returns {quat2} out
+ * @param {Quat2} out the receiving dual quaternion
+ * @param {Quat2} a the source dual quaternion
+ * @returns {Quat2} out
  * @function
  */
 export function copy(out, a) {
@@ -216,8 +216,8 @@ export function copy(out, a) {
 /**
  * Set a dual quat to the identity dual quaternion
  *
- * @param {quat2} out the receiving quaternion
- * @returns {quat2} out
+ * @param {Quat2} out the receiving quaternion
+ * @returns {Quat2} out
  */
 export function identity(out) {
   out[0] = 0;
@@ -234,7 +234,7 @@ export function identity(out) {
 /**
  * Set the components of a dual quat to the given values
  *
- * @param {quat2} out the receiving quaternion
+ * @param {Quat2} out the receiving quaternion
  * @param {Number} x1 X component
  * @param {Number} y1 Y component
  * @param {Number} z1 Z component
@@ -243,7 +243,7 @@ export function identity(out) {
  * @param {Number} y2 Y component
  * @param {Number} z2 Z component
  * @param {Number} w2 W component
- * @returns {quat2} out
+ * @returns {Quat2} out
  * @function
  */
 export function set(out, x1, y1, z1, w1, x2, y2, z2, w2) {
@@ -261,17 +261,17 @@ export function set(out, x1, y1, z1, w1, x2, y2, z2, w2) {
 
 /**
  * Gets the real part of a dual quat
- * @param  {quat} out real part
- * @param  {quat2} a Dual Quaternion
- * @return {quat} real part
+ * @param  {Quat} out real part
+ * @param  {Quat2} a Dual Quaternion
+ * @return {Quat} real part
  */
 export const getReal = quat.copy;
 
 /**
  * Gets the dual part of a dual quat
- * @param  {quat} out dual part
- * @param  {quat2} a Dual Quaternion
- * @return {quat} dual part
+ * @param  {Quat} out dual part
+ * @param  {Quat2} a Dual Quaternion
+ * @return {Quat} dual part
  */
 export function getDual(out, a) {
   out[0] = a[4];
@@ -284,9 +284,9 @@ export function getDual(out, a) {
 /**
  * Set the real component of a dual quat to the given quaternion
  *
- * @param {quat2} out the receiving quaternion
- * @param {quat} q a quaternion representing the real part
- * @returns {quat2} out
+ * @param {Quat2} out the receiving quaternion
+ * @param {Quat} q a quaternion representing the real part
+ * @returns {Quat2} out
  * @function
  */
 export const setReal = quat.copy;
@@ -294,9 +294,9 @@ export const setReal = quat.copy;
 /**
  * Set the dual component of a dual quat to the given quaternion
  *
- * @param {quat2} out the receiving quaternion
- * @param {quat} q a quaternion representing the dual part
- * @returns {quat2} out
+ * @param {Quat2} out the receiving quaternion
+ * @param {Quat} q a quaternion representing the dual part
+ * @returns {Quat2} out
  * @function
  */
 export function setDual(out, q) {
@@ -309,9 +309,9 @@ export function setDual(out, q) {
 
 /**
  * Gets the translation of a normalized dual quat
- * @param  {vec3} out translation
- * @param  {quat2} a Dual Quaternion to be decomposed
- * @return {vec3} translation
+ * @param  {Vec3} out translation
+ * @param  {Quat2} a Dual Quaternion to be decomposed
+ * @return {Vec3} translation
  */
 export function getTranslation(out, a) {
   let ax = a[4],
@@ -331,10 +331,10 @@ export function getTranslation(out, a) {
 /**
  * Translates a dual quat by the given vector
  *
- * @param {quat2} out the receiving dual quaternion
- * @param {quat2} a the dual quaternion to translate
- * @param {vec3} v vector to translate by
- * @returns {quat2} out
+ * @param {Quat2} out the receiving dual quaternion
+ * @param {Quat2} a the dual quaternion to translate
+ * @param {Vec3} v vector to translate by
+ * @returns {Quat2} out
  */
 export function translate(out, a, v) {
   let ax1 = a[0],
@@ -362,10 +362,10 @@ export function translate(out, a, v) {
 /**
  * Rotates a dual quat around the X axis
  *
- * @param {quat2} out the receiving dual quaternion
- * @param {quat2} a the dual quaternion to rotate
+ * @param {Quat2} out the receiving dual quaternion
+ * @param {Quat2} a the dual quaternion to rotate
  * @param {number} rad how far should the rotation be
- * @returns {quat2} out
+ * @returns {Quat2} out
  */
 export function rotateX(out, a, rad) {
   let bx = -a[0],
@@ -395,10 +395,10 @@ export function rotateX(out, a, rad) {
 /**
  * Rotates a dual quat around the Y axis
  *
- * @param {quat2} out the receiving dual quaternion
- * @param {quat2} a the dual quaternion to rotate
+ * @param {Quat2} out the receiving dual quaternion
+ * @param {Quat2} a the dual quaternion to rotate
  * @param {number} rad how far should the rotation be
- * @returns {quat2} out
+ * @returns {Quat2} out
  */
 export function rotateY(out, a, rad) {
   let bx = -a[0],
@@ -428,10 +428,10 @@ export function rotateY(out, a, rad) {
 /**
  * Rotates a dual quat around the Z axis
  *
- * @param {quat2} out the receiving dual quaternion
- * @param {quat2} a the dual quaternion to rotate
+ * @param {Quat2} out the receiving dual quaternion
+ * @param {Quat2} a the dual quaternion to rotate
  * @param {number} rad how far should the rotation be
- * @returns {quat2} out
+ * @returns {Quat2} out
  */
 export function rotateZ(out, a, rad) {
   let bx = -a[0],
@@ -461,10 +461,10 @@ export function rotateZ(out, a, rad) {
 /**
  * Rotates a dual quat by a given quaternion (a * q)
  *
- * @param {quat2} out the receiving dual quaternion
- * @param {quat2} a the dual quaternion to rotate
- * @param {quat} q quaternion to rotate by
- * @returns {quat2} out
+ * @param {Quat2} out the receiving dual quaternion
+ * @param {Quat2} a the dual quaternion to rotate
+ * @param {Quat} q quaternion to rotate by
+ * @returns {Quat2} out
  */
 export function rotateByQuatAppend(out, a, q) {
   let qx = q[0],
@@ -494,10 +494,10 @@ export function rotateByQuatAppend(out, a, q) {
 /**
  * Rotates a dual quat by a given quaternion (q * a)
  *
- * @param {quat2} out the receiving dual quaternion
- * @param {quat} q quaternion to rotate by
- * @param {quat2} a the dual quaternion to rotate
- * @returns {quat2} out
+ * @param {Quat2} out the receiving dual quaternion
+ * @param {Quat} q quaternion to rotate by
+ * @param {Quat2} a the dual quaternion to rotate
+ * @returns {Quat2} out
  */
 export function rotateByQuatPrepend(out, q, a) {
   let qx = q[0],
@@ -527,11 +527,11 @@ export function rotateByQuatPrepend(out, q, a) {
 /**
  * Rotates a dual quat around a given axis. Does the normalisation automatically
  *
- * @param {quat2} out the receiving dual quaternion
- * @param {quat2} a the dual quaternion to rotate
- * @param {vec3} axis the axis to rotate around
+ * @param {Quat2} out the receiving dual quaternion
+ * @param {Quat2} a the dual quaternion to rotate
+ * @param {Vec3} axis the axis to rotate around
  * @param {Number} rad how far the rotation should be
- * @returns {quat2} out
+ * @returns {Quat2} out
  */
 export function rotateAroundAxis(out, a, axis, rad) {
   //Special case for rad = 0
@@ -571,10 +571,10 @@ export function rotateAroundAxis(out, a, axis, rad) {
 /**
  * Adds two dual quat's
  *
- * @param {quat2} out the receiving dual quaternion
- * @param {quat2} a the first operand
- * @param {quat2} b the second operand
- * @returns {quat2} out
+ * @param {Quat2} out the receiving dual quaternion
+ * @param {Quat2} a the first operand
+ * @param {Quat2} b the second operand
+ * @returns {Quat2} out
  * @function
  */
 export function add(out, a, b) {
@@ -592,10 +592,10 @@ export function add(out, a, b) {
 /**
  * Multiplies two dual quat's
  *
- * @param {quat2} out the receiving dual quaternion
- * @param {quat2} a the first operand
- * @param {quat2} b the second operand
- * @returns {quat2} out
+ * @param {Quat2} out the receiving dual quaternion
+ * @param {Quat2} a the first operand
+ * @param {Quat2} b the second operand
+ * @returns {Quat2} out
  */
 export function multiply(out, a, b) {
   let ax0 = a[0],
@@ -634,10 +634,10 @@ export const mul = multiply;
 /**
  * Scales a dual quat by a scalar number
  *
- * @param {quat2} out the receiving dual quat
- * @param {quat2} a the dual quat to scale
+ * @param {Quat2} out the receiving dual quat
+ * @param {Quat2} a the dual quat to scale
  * @param {Number} b amount to scale the dual quat by
- * @returns {quat2} out
+ * @returns {Quat2} out
  * @function
  */
 export function scale(out, a, b) {
@@ -655,8 +655,8 @@ export function scale(out, a, b) {
 /**
  * Calculates the dot product of two dual quat's (The dot product of the real parts)
  *
- * @param {quat2} a the first operand
- * @param {quat2} b the second operand
+ * @param {Quat2} a the first operand
+ * @param {Quat2} b the second operand
  * @returns {Number} dot product of a and b
  * @function
  */
@@ -666,11 +666,11 @@ export const dot = quat.dot;
  * Performs a linear interpolation between two dual quats's
  * NOTE: The resulting dual quaternions won't always be normalized (The error is most noticeable when t = 0.5)
  *
- * @param {quat2} out the receiving dual quat
- * @param {quat2} a the first operand
- * @param {quat2} b the second operand
+ * @param {Quat2} out the receiving dual quat
+ * @param {Quat2} a the first operand
+ * @param {Quat2} b the second operand
  * @param {Number} t interpolation amount, in the range [0-1], between the two inputs
- * @returns {quat2} out
+ * @returns {Quat2} out
  */
 export function lerp(out, a, b, t) {
   let mt = 1 - t;
@@ -691,9 +691,9 @@ export function lerp(out, a, b, t) {
 /**
  * Calculates the inverse of a dual quat. If they are normalized, conjugate is cheaper
  *
- * @param {quat2} out the receiving dual quaternion
- * @param {quat2} a dual quat to calculate inverse of
- * @returns {quat2} out
+ * @param {Quat2} out the receiving dual quaternion
+ * @param {Quat2} a dual quat to calculate inverse of
+ * @returns {Quat2} out
  */
 export function invert(out, a) {
   let sqlen = squaredLength(a);
@@ -712,9 +712,9 @@ export function invert(out, a) {
  * Calculates the conjugate of a dual quat
  * If the dual quaternion is normalized, this function is faster than quat2.inverse and produces the same result.
  *
- * @param {quat2} out the receiving quaternion
- * @param {quat2} a quat to calculate conjugate of
- * @returns {quat2} out
+ * @param {Quat2} out the receiving quaternion
+ * @param {Quat2} a quat to calculate conjugate of
+ * @returns {Quat2} out
  */
 export function conjugate(out, a) {
   out[0] = -a[0];
@@ -731,7 +731,7 @@ export function conjugate(out, a) {
 /**
  * Calculates the length of a dual quat
  *
- * @param {quat2} a dual quat to calculate length of
+ * @param {Quat2} a dual quat to calculate length of
  * @returns {Number} length of a
  * @function
  */
@@ -746,7 +746,7 @@ export const len = length;
 /**
  * Calculates the squared length of a dual quat
  *
- * @param {quat2} a dual quat to calculate squared length of
+ * @param {Quat2} a dual quat to calculate squared length of
  * @returns {Number} squared length of a
  * @function
  */
@@ -761,9 +761,9 @@ export const sqrLen = squaredLength;
 /**
  * Normalize a dual quat
  *
- * @param {quat2} out the receiving dual quaternion
- * @param {quat2} a dual quaternion to normalize
- * @returns {quat2} out
+ * @param {Quat2} out the receiving dual quaternion
+ * @param {Quat2} a dual quaternion to normalize
+ * @returns {Quat2} out
  * @function
  */
 export function normalize(out, a) {
@@ -799,7 +799,7 @@ export function normalize(out, a) {
 /**
  * Returns a string representation of a dual quatenion
  *
- * @param {quat2} a dual quaternion to represent as a string
+ * @param {Quat2} a dual quaternion to represent as a string
  * @returns {String} string representation of the dual quat
  */
 export function str(a) {
@@ -810,8 +810,8 @@ export function str(a) {
 /**
  * Returns whether or not the dual quaternions have exactly the same elements in the same position (when compared with ===)
  *
- * @param {quat2} a the first dual quaternion.
- * @param {quat2} b the second dual quaternion.
+ * @param {Quat2} a the first dual quaternion.
+ * @param {Quat2} b the second dual quaternion.
  * @returns {Boolean} true if the dual quaternions are equal, false otherwise.
  */
 export function exactEquals(a, b) {
@@ -822,8 +822,8 @@ export function exactEquals(a, b) {
 /**
  * Returns whether or not the dual quaternions have approximately the same elements in the same position.
  *
- * @param {quat2} a the first dual quat.
- * @param {quat2} b the second dual quat.
+ * @param {Quat2} a the first dual quat.
+ * @param {Quat2} b the second dual quat.
  * @returns {Boolean} true if the dual quats are equal, false otherwise.
  */
 export function equals(a, b) {

--- a/src/quat2.js
+++ b/src/quat2.js
@@ -10,6 +10,12 @@ import * as mat4 from "./mat4.js";
  * @module quat2
  */
 
+ 
+/**
+ * @typedef {[
+  number, number, number, number,
+  number, number, number, number] | Float32Array} Quat2
+ */
 
 /**
  * Creates a new identity dual quat

--- a/src/vec2.js
+++ b/src/vec2.js
@@ -8,7 +8,7 @@ import * as glMatrix from "./common.js";
 /**
  * Creates a new, empty vec2
  *
- * @returns {vec2} a new 2D vector
+ * @returns {Vec2} a new 2D vector
  */
 export function create() {
   let out = new glMatrix.ARRAY_TYPE(2);
@@ -22,8 +22,8 @@ export function create() {
 /**
  * Creates a new vec2 initialized with values from an existing vector
  *
- * @param {vec2} a vector to clone
- * @returns {vec2} a new 2D vector
+ * @param {Vec2} a vector to clone
+ * @returns {Vec2} a new 2D vector
  */
 export function clone(a) {
   let out = new glMatrix.ARRAY_TYPE(2);
@@ -37,7 +37,7 @@ export function clone(a) {
  *
  * @param {Number} x X component
  * @param {Number} y Y component
- * @returns {vec2} a new 2D vector
+ * @returns {Vec2} a new 2D vector
  */
 export function fromValues(x, y) {
   let out = new glMatrix.ARRAY_TYPE(2);
@@ -49,9 +49,9 @@ export function fromValues(x, y) {
 /**
  * Copy the values from one vec2 to another
  *
- * @param {vec2} out the receiving vector
- * @param {vec2} a the source vector
- * @returns {vec2} out
+ * @param {Vec2} out the receiving vector
+ * @param {Vec2} a the source vector
+ * @returns {Vec2} out
  */
 export function copy(out, a) {
   out[0] = a[0];
@@ -62,10 +62,10 @@ export function copy(out, a) {
 /**
  * Set the components of a vec2 to the given values
  *
- * @param {vec2} out the receiving vector
+ * @param {Vec2} out the receiving vector
  * @param {Number} x X component
  * @param {Number} y Y component
- * @returns {vec2} out
+ * @returns {Vec2} out
  */
 export function set(out, x, y) {
   out[0] = x;
@@ -76,10 +76,10 @@ export function set(out, x, y) {
 /**
  * Adds two vec2's
  *
- * @param {vec2} out the receiving vector
- * @param {vec2} a the first operand
- * @param {vec2} b the second operand
- * @returns {vec2} out
+ * @param {Vec2} out the receiving vector
+ * @param {Vec2} a the first operand
+ * @param {Vec2} b the second operand
+ * @returns {Vec2} out
  */
 export function add(out, a, b) {
   out[0] = a[0] + b[0];
@@ -90,10 +90,10 @@ export function add(out, a, b) {
 /**
  * Subtracts vector b from vector a
  *
- * @param {vec2} out the receiving vector
- * @param {vec2} a the first operand
- * @param {vec2} b the second operand
- * @returns {vec2} out
+ * @param {Vec2} out the receiving vector
+ * @param {Vec2} a the first operand
+ * @param {Vec2} b the second operand
+ * @returns {Vec2} out
  */
 export function subtract(out, a, b) {
   out[0] = a[0] - b[0];
@@ -104,10 +104,10 @@ export function subtract(out, a, b) {
 /**
  * Multiplies two vec2's
  *
- * @param {vec2} out the receiving vector
- * @param {vec2} a the first operand
- * @param {vec2} b the second operand
- * @returns {vec2} out
+ * @param {Vec2} out the receiving vector
+ * @param {Vec2} a the first operand
+ * @param {Vec2} b the second operand
+ * @returns {Vec2} out
  */
 export function multiply(out, a, b) {
   out[0] = a[0] * b[0];
@@ -118,10 +118,10 @@ export function multiply(out, a, b) {
 /**
  * Divides two vec2's
  *
- * @param {vec2} out the receiving vector
- * @param {vec2} a the first operand
- * @param {vec2} b the second operand
- * @returns {vec2} out
+ * @param {Vec2} out the receiving vector
+ * @param {Vec2} a the first operand
+ * @param {Vec2} b the second operand
+ * @returns {Vec2} out
  */
 export function divide(out, a, b) {
   out[0] = a[0] / b[0];
@@ -132,9 +132,9 @@ export function divide(out, a, b) {
 /**
  * Math.ceil the components of a vec2
  *
- * @param {vec2} out the receiving vector
- * @param {vec2} a vector to ceil
- * @returns {vec2} out
+ * @param {Vec2} out the receiving vector
+ * @param {Vec2} a vector to ceil
+ * @returns {Vec2} out
  */
 export function ceil(out, a) {
   out[0] = Math.ceil(a[0]);
@@ -145,9 +145,9 @@ export function ceil(out, a) {
 /**
  * Math.floor the components of a vec2
  *
- * @param {vec2} out the receiving vector
- * @param {vec2} a vector to floor
- * @returns {vec2} out
+ * @param {Vec2} out the receiving vector
+ * @param {Vec2} a vector to floor
+ * @returns {Vec2} out
  */
 export function floor(out, a) {
   out[0] = Math.floor(a[0]);
@@ -158,10 +158,10 @@ export function floor(out, a) {
 /**
  * Returns the minimum of two vec2's
  *
- * @param {vec2} out the receiving vector
- * @param {vec2} a the first operand
- * @param {vec2} b the second operand
- * @returns {vec2} out
+ * @param {Vec2} out the receiving vector
+ * @param {Vec2} a the first operand
+ * @param {Vec2} b the second operand
+ * @returns {Vec2} out
  */
 export function min(out, a, b) {
   out[0] = Math.min(a[0], b[0]);
@@ -172,10 +172,10 @@ export function min(out, a, b) {
 /**
  * Returns the maximum of two vec2's
  *
- * @param {vec2} out the receiving vector
- * @param {vec2} a the first operand
- * @param {vec2} b the second operand
- * @returns {vec2} out
+ * @param {Vec2} out the receiving vector
+ * @param {Vec2} a the first operand
+ * @param {Vec2} b the second operand
+ * @returns {Vec2} out
  */
 export function max(out, a, b) {
   out[0] = Math.max(a[0], b[0]);
@@ -186,9 +186,9 @@ export function max(out, a, b) {
 /**
  * Math.round the components of a vec2
  *
- * @param {vec2} out the receiving vector
- * @param {vec2} a vector to round
- * @returns {vec2} out
+ * @param {Vec2} out the receiving vector
+ * @param {Vec2} a vector to round
+ * @returns {Vec2} out
  */
 export function round (out, a) {
   out[0] = Math.round(a[0]);
@@ -199,10 +199,10 @@ export function round (out, a) {
 /**
  * Scales a vec2 by a scalar number
  *
- * @param {vec2} out the receiving vector
- * @param {vec2} a the vector to scale
+ * @param {Vec2} out the receiving vector
+ * @param {Vec2} a the vector to scale
  * @param {Number} b amount to scale the vector by
- * @returns {vec2} out
+ * @returns {Vec2} out
  */
 export function scale(out, a, b) {
   out[0] = a[0] * b;
@@ -213,11 +213,11 @@ export function scale(out, a, b) {
 /**
  * Adds two vec2's after scaling the second operand by a scalar value
  *
- * @param {vec2} out the receiving vector
- * @param {vec2} a the first operand
- * @param {vec2} b the second operand
+ * @param {Vec2} out the receiving vector
+ * @param {Vec2} a the first operand
+ * @param {Vec2} b the second operand
  * @param {Number} scale the amount to scale b by before adding
- * @returns {vec2} out
+ * @returns {Vec2} out
  */
 export function scaleAndAdd(out, a, b, scale) {
   out[0] = a[0] + (b[0] * scale);
@@ -228,8 +228,8 @@ export function scaleAndAdd(out, a, b, scale) {
 /**
  * Calculates the euclidian distance between two vec2's
  *
- * @param {vec2} a the first operand
- * @param {vec2} b the second operand
+ * @param {Vec2} a the first operand
+ * @param {Vec2} b the second operand
  * @returns {Number} distance between a and b
  */
 export function distance(a, b) {
@@ -241,8 +241,8 @@ export function distance(a, b) {
 /**
  * Calculates the squared euclidian distance between two vec2's
  *
- * @param {vec2} a the first operand
- * @param {vec2} b the second operand
+ * @param {Vec2} a the first operand
+ * @param {Vec2} b the second operand
  * @returns {Number} squared distance between a and b
  */
 export function squaredDistance(a, b) {
@@ -254,7 +254,7 @@ export function squaredDistance(a, b) {
 /**
  * Calculates the length of a vec2
  *
- * @param {vec2} a vector to calculate length of
+ * @param {Vec2} a vector to calculate length of
  * @returns {Number} length of a
  */
 export function length(a) {
@@ -266,7 +266,7 @@ export function length(a) {
 /**
  * Calculates the squared length of a vec2
  *
- * @param {vec2} a vector to calculate squared length of
+ * @param {Vec2} a vector to calculate squared length of
  * @returns {Number} squared length of a
  */
 export function squaredLength (a) {
@@ -278,9 +278,9 @@ export function squaredLength (a) {
 /**
  * Negates the components of a vec2
  *
- * @param {vec2} out the receiving vector
- * @param {vec2} a vector to negate
- * @returns {vec2} out
+ * @param {Vec2} out the receiving vector
+ * @param {Vec2} a vector to negate
+ * @returns {Vec2} out
  */
 export function negate(out, a) {
   out[0] = -a[0];
@@ -291,9 +291,9 @@ export function negate(out, a) {
 /**
  * Returns the inverse of the components of a vec2
  *
- * @param {vec2} out the receiving vector
- * @param {vec2} a vector to invert
- * @returns {vec2} out
+ * @param {Vec2} out the receiving vector
+ * @param {Vec2} a vector to invert
+ * @returns {Vec2} out
  */
 export function inverse(out, a) {
   out[0] = 1.0 / a[0];
@@ -304,9 +304,9 @@ export function inverse(out, a) {
 /**
  * Normalize a vec2
  *
- * @param {vec2} out the receiving vector
- * @param {vec2} a vector to normalize
- * @returns {vec2} out
+ * @param {Vec2} out the receiving vector
+ * @param {Vec2} a vector to normalize
+ * @returns {Vec2} out
  */
 export function normalize(out, a) {
   var x = a[0],
@@ -324,8 +324,8 @@ export function normalize(out, a) {
 /**
  * Calculates the dot product of two vec2's
  *
- * @param {vec2} a the first operand
- * @param {vec2} b the second operand
+ * @param {Vec2} a the first operand
+ * @param {Vec2} b the second operand
  * @returns {Number} dot product of a and b
  */
 export function dot(a, b) {
@@ -336,10 +336,10 @@ export function dot(a, b) {
  * Computes the cross product of two vec2's
  * Note that the cross product must by definition produce a 3D vector
  *
- * @param {vec3} out the receiving vector
- * @param {vec2} a the first operand
- * @param {vec2} b the second operand
- * @returns {vec3} out
+ * @param {Vec3} out the receiving vector
+ * @param {Vec2} a the first operand
+ * @param {Vec2} b the second operand
+ * @returns {Vec3} out
  */
 export function cross(out, a, b) {
   var z = a[0] * b[1] - a[1] * b[0];
@@ -351,11 +351,11 @@ export function cross(out, a, b) {
 /**
  * Performs a linear interpolation between two vec2's
  *
- * @param {vec2} out the receiving vector
- * @param {vec2} a the first operand
- * @param {vec2} b the second operand
+ * @param {Vec2} out the receiving vector
+ * @param {Vec2} a the first operand
+ * @param {Vec2} b the second operand
  * @param {Number} t interpolation amount, in the range [0-1], between the two inputs
- * @returns {vec2} out
+ * @returns {Vec2} out
  */
 export function lerp(out, a, b, t) {
   var ax = a[0],
@@ -368,9 +368,9 @@ export function lerp(out, a, b, t) {
 /**
  * Generates a random vector with the given scale
  *
- * @param {vec2} out the receiving vector
+ * @param {Vec2} out the receiving vector
  * @param {Number} [scale] Length of the resulting vector. If ommitted, a unit vector will be returned
- * @returns {vec2} out
+ * @returns {Vec2} out
  */
 export function random(out, scale) {
   scale = scale || 1.0;
@@ -383,10 +383,10 @@ export function random(out, scale) {
 /**
  * Transforms the vec2 with a mat2
  *
- * @param {vec2} out the receiving vector
- * @param {vec2} a the vector to transform
- * @param {mat2} m matrix to transform with
- * @returns {vec2} out
+ * @param {Vec2} out the receiving vector
+ * @param {Vec2} a the vector to transform
+ * @param {Mat2} m matrix to transform with
+ * @returns {Vec2} out
  */
 export function transformMat2(out, a, m) {
   var x = a[0],
@@ -399,10 +399,10 @@ export function transformMat2(out, a, m) {
 /**
  * Transforms the vec2 with a mat2d
  *
- * @param {vec2} out the receiving vector
- * @param {vec2} a the vector to transform
- * @param {mat2d} m matrix to transform with
- * @returns {vec2} out
+ * @param {Vec2} out the receiving vector
+ * @param {Vec2} a the vector to transform
+ * @param {Mat2d} m matrix to transform with
+ * @returns {Vec2} out
  */
 export function transformMat2d(out, a, m) {
   var x = a[0],
@@ -416,10 +416,10 @@ export function transformMat2d(out, a, m) {
  * Transforms the vec2 with a mat3
  * 3rd vector component is implicitly '1'
  *
- * @param {vec2} out the receiving vector
- * @param {vec2} a the vector to transform
- * @param {mat3} m matrix to transform with
- * @returns {vec2} out
+ * @param {Vec2} out the receiving vector
+ * @param {Vec2} a the vector to transform
+ * @param {Mat3} m matrix to transform with
+ * @returns {Vec2} out
  */
 export function transformMat3(out, a, m) {
   var x = a[0],
@@ -434,10 +434,10 @@ export function transformMat3(out, a, m) {
  * 3rd vector component is implicitly '0'
  * 4th vector component is implicitly '1'
  *
- * @param {vec2} out the receiving vector
- * @param {vec2} a the vector to transform
- * @param {mat4} m matrix to transform with
- * @returns {vec2} out
+ * @param {Vec2} out the receiving vector
+ * @param {Vec2} a the vector to transform
+ * @param {Mat4} m matrix to transform with
+ * @returns {Vec2} out
  */
 export function transformMat4(out, a, m) {
   let x = a[0];
@@ -449,11 +449,11 @@ export function transformMat4(out, a, m) {
 
 /**
  * Rotate a 2D vector
- * @param {vec2} out The receiving vec2
- * @param {vec2} a The vec2 point to rotate
- * @param {vec2} b The origin of the rotation
+ * @param {Vec2} out The receiving vec2
+ * @param {Vec2} a The vec2 point to rotate
+ * @param {Vec2} b The origin of the rotation
  * @param {Number} c The angle of rotation
- * @returns {vec2} out
+ * @returns {Vec2} out
  */
 export function rotate(out, a, b, c) {
   //Translate point to the origin
@@ -471,8 +471,8 @@ export function rotate(out, a, b, c) {
 
 /**
  * Get the angle between two 2D vectors
- * @param {vec2} a The first operand
- * @param {vec2} b The second operand
+ * @param {Vec2} a The first operand
+ * @param {Vec2} b The second operand
  * @returns {Number} The angle in radians
  */
 export function angle(a, b) {
@@ -509,7 +509,7 @@ export function angle(a, b) {
 /**
  * Returns a string representation of a vector
  *
- * @param {vec2} a vector to represent as a string
+ * @param {Vec2} a vector to represent as a string
  * @returns {String} string representation of the vector
  */
 export function str(a) {
@@ -519,8 +519,8 @@ export function str(a) {
 /**
  * Returns whether or not the vectors exactly have the same elements in the same position (when compared with ===)
  *
- * @param {vec2} a The first vector.
- * @param {vec2} b The second vector.
+ * @param {Vec2} a The first vector.
+ * @param {Vec2} b The second vector.
  * @returns {Boolean} True if the vectors are equal, false otherwise.
  */
 export function exactEquals(a, b) {
@@ -530,8 +530,8 @@ export function exactEquals(a, b) {
 /**
  * Returns whether or not the vectors have approximately the same elements in the same position.
  *
- * @param {vec2} a The first vector.
- * @param {vec2} b The second vector.
+ * @param {Vec2} a The first vector.
+ * @param {Vec2} b The second vector.
  * @returns {Boolean} True if the vectors are equal, false otherwise.
  */
 export function equals(a, b) {

--- a/src/vec2.js
+++ b/src/vec2.js
@@ -6,6 +6,10 @@ import * as glMatrix from "./common.js";
  */
 
 /**
+ * @typedef {[number, number] | Float32Array} Vec2
+ */
+
+/**
  * Creates a new, empty vec2
  *
  * @returns {Vec2} a new 2D vector

--- a/src/vec3.js
+++ b/src/vec3.js
@@ -8,7 +8,7 @@ import * as glMatrix from "./common.js";
 /**
  * Creates a new, empty vec3
  *
- * @returns {vec3} a new 3D vector
+ * @returns {Vec3} a new 3D vector
  */
 export function create() {
   let out = new glMatrix.ARRAY_TYPE(3);
@@ -23,8 +23,8 @@ export function create() {
 /**
  * Creates a new vec3 initialized with values from an existing vector
  *
- * @param {vec3} a vector to clone
- * @returns {vec3} a new 3D vector
+ * @param {Vec3} a vector to clone
+ * @returns {Vec3} a new 3D vector
  */
 export function clone(a) {
   var out = new glMatrix.ARRAY_TYPE(3);
@@ -37,7 +37,7 @@ export function clone(a) {
 /**
  * Calculates the length of a vec3
  *
- * @param {vec3} a vector to calculate length of
+ * @param {Vec3} a vector to calculate length of
  * @returns {Number} length of a
  */
 export function length(a) {
@@ -53,7 +53,7 @@ export function length(a) {
  * @param {Number} x X component
  * @param {Number} y Y component
  * @param {Number} z Z component
- * @returns {vec3} a new 3D vector
+ * @returns {Vec3} a new 3D vector
  */
 export function fromValues(x, y, z) {
   let out = new glMatrix.ARRAY_TYPE(3);
@@ -66,9 +66,9 @@ export function fromValues(x, y, z) {
 /**
  * Copy the values from one vec3 to another
  *
- * @param {vec3} out the receiving vector
- * @param {vec3} a the source vector
- * @returns {vec3} out
+ * @param {Vec3} out the receiving vector
+ * @param {Vec3} a the source vector
+ * @returns {Vec3} out
  */
 export function copy(out, a) {
   out[0] = a[0];
@@ -80,11 +80,11 @@ export function copy(out, a) {
 /**
  * Set the components of a vec3 to the given values
  *
- * @param {vec3} out the receiving vector
+ * @param {Vec3} out the receiving vector
  * @param {Number} x X component
  * @param {Number} y Y component
  * @param {Number} z Z component
- * @returns {vec3} out
+ * @returns {Vec3} out
  */
 export function set(out, x, y, z) {
   out[0] = x;
@@ -96,10 +96,10 @@ export function set(out, x, y, z) {
 /**
  * Adds two vec3's
  *
- * @param {vec3} out the receiving vector
- * @param {vec3} a the first operand
- * @param {vec3} b the second operand
- * @returns {vec3} out
+ * @param {Vec3} out the receiving vector
+ * @param {Vec3} a the first operand
+ * @param {Vec3} b the second operand
+ * @returns {Vec3} out
  */
 export function add(out, a, b) {
   out[0] = a[0] + b[0];
@@ -111,10 +111,10 @@ export function add(out, a, b) {
 /**
  * Subtracts vector b from vector a
  *
- * @param {vec3} out the receiving vector
- * @param {vec3} a the first operand
- * @param {vec3} b the second operand
- * @returns {vec3} out
+ * @param {Vec3} out the receiving vector
+ * @param {Vec3} a the first operand
+ * @param {Vec3} b the second operand
+ * @returns {Vec3} out
  */
 export function subtract(out, a, b) {
   out[0] = a[0] - b[0];
@@ -126,10 +126,10 @@ export function subtract(out, a, b) {
 /**
  * Multiplies two vec3's
  *
- * @param {vec3} out the receiving vector
- * @param {vec3} a the first operand
- * @param {vec3} b the second operand
- * @returns {vec3} out
+ * @param {Vec3} out the receiving vector
+ * @param {Vec3} a the first operand
+ * @param {Vec3} b the second operand
+ * @returns {Vec3} out
  */
 export function multiply(out, a, b) {
   out[0] = a[0] * b[0];
@@ -141,10 +141,10 @@ export function multiply(out, a, b) {
 /**
  * Divides two vec3's
  *
- * @param {vec3} out the receiving vector
- * @param {vec3} a the first operand
- * @param {vec3} b the second operand
- * @returns {vec3} out
+ * @param {Vec3} out the receiving vector
+ * @param {Vec3} a the first operand
+ * @param {Vec3} b the second operand
+ * @returns {Vec3} out
  */
 export function divide(out, a, b) {
   out[0] = a[0] / b[0];
@@ -156,9 +156,9 @@ export function divide(out, a, b) {
 /**
  * Math.ceil the components of a vec3
  *
- * @param {vec3} out the receiving vector
- * @param {vec3} a vector to ceil
- * @returns {vec3} out
+ * @param {Vec3} out the receiving vector
+ * @param {Vec3} a vector to ceil
+ * @returns {Vec3} out
  */
 export function ceil(out, a) {
   out[0] = Math.ceil(a[0]);
@@ -170,9 +170,9 @@ export function ceil(out, a) {
 /**
  * Math.floor the components of a vec3
  *
- * @param {vec3} out the receiving vector
- * @param {vec3} a vector to floor
- * @returns {vec3} out
+ * @param {Vec3} out the receiving vector
+ * @param {Vec3} a vector to floor
+ * @returns {Vec3} out
  */
 export function floor(out, a) {
   out[0] = Math.floor(a[0]);
@@ -184,10 +184,10 @@ export function floor(out, a) {
 /**
  * Returns the minimum of two vec3's
  *
- * @param {vec3} out the receiving vector
- * @param {vec3} a the first operand
- * @param {vec3} b the second operand
- * @returns {vec3} out
+ * @param {Vec3} out the receiving vector
+ * @param {Vec3} a the first operand
+ * @param {Vec3} b the second operand
+ * @returns {Vec3} out
  */
 export function min(out, a, b) {
   out[0] = Math.min(a[0], b[0]);
@@ -199,10 +199,10 @@ export function min(out, a, b) {
 /**
  * Returns the maximum of two vec3's
  *
- * @param {vec3} out the receiving vector
- * @param {vec3} a the first operand
- * @param {vec3} b the second operand
- * @returns {vec3} out
+ * @param {Vec3} out the receiving vector
+ * @param {Vec3} a the first operand
+ * @param {Vec3} b the second operand
+ * @returns {Vec3} out
  */
 export function max(out, a, b) {
   out[0] = Math.max(a[0], b[0]);
@@ -214,9 +214,9 @@ export function max(out, a, b) {
 /**
  * Math.round the components of a vec3
  *
- * @param {vec3} out the receiving vector
- * @param {vec3} a vector to round
- * @returns {vec3} out
+ * @param {Vec3} out the receiving vector
+ * @param {Vec3} a vector to round
+ * @returns {Vec3} out
  */
 export function round(out, a) {
   out[0] = Math.round(a[0]);
@@ -228,10 +228,10 @@ export function round(out, a) {
 /**
  * Scales a vec3 by a scalar number
  *
- * @param {vec3} out the receiving vector
- * @param {vec3} a the vector to scale
+ * @param {Vec3} out the receiving vector
+ * @param {Vec3} a the vector to scale
  * @param {Number} b amount to scale the vector by
- * @returns {vec3} out
+ * @returns {Vec3} out
  */
 export function scale(out, a, b) {
   out[0] = a[0] * b;
@@ -243,11 +243,11 @@ export function scale(out, a, b) {
 /**
  * Adds two vec3's after scaling the second operand by a scalar value
  *
- * @param {vec3} out the receiving vector
- * @param {vec3} a the first operand
- * @param {vec3} b the second operand
+ * @param {Vec3} out the receiving vector
+ * @param {Vec3} a the first operand
+ * @param {Vec3} b the second operand
  * @param {Number} scale the amount to scale b by before adding
- * @returns {vec3} out
+ * @returns {Vec3} out
  */
 export function scaleAndAdd(out, a, b, scale) {
   out[0] = a[0] + (b[0] * scale);
@@ -259,8 +259,8 @@ export function scaleAndAdd(out, a, b, scale) {
 /**
  * Calculates the euclidian distance between two vec3's
  *
- * @param {vec3} a the first operand
- * @param {vec3} b the second operand
+ * @param {Vec3} a the first operand
+ * @param {Vec3} b the second operand
  * @returns {Number} distance between a and b
  */
 export function distance(a, b) {
@@ -273,8 +273,8 @@ export function distance(a, b) {
 /**
  * Calculates the squared euclidian distance between two vec3's
  *
- * @param {vec3} a the first operand
- * @param {vec3} b the second operand
+ * @param {Vec3} a the first operand
+ * @param {Vec3} b the second operand
  * @returns {Number} squared distance between a and b
  */
 export function squaredDistance(a, b) {
@@ -287,7 +287,7 @@ export function squaredDistance(a, b) {
 /**
  * Calculates the squared length of a vec3
  *
- * @param {vec3} a vector to calculate squared length of
+ * @param {Vec3} a vector to calculate squared length of
  * @returns {Number} squared length of a
  */
 export function squaredLength(a) {
@@ -300,9 +300,9 @@ export function squaredLength(a) {
 /**
  * Negates the components of a vec3
  *
- * @param {vec3} out the receiving vector
- * @param {vec3} a vector to negate
- * @returns {vec3} out
+ * @param {Vec3} out the receiving vector
+ * @param {Vec3} a vector to negate
+ * @returns {Vec3} out
  */
 export function negate(out, a) {
   out[0] = -a[0];
@@ -314,9 +314,9 @@ export function negate(out, a) {
 /**
  * Returns the inverse of the components of a vec3
  *
- * @param {vec3} out the receiving vector
- * @param {vec3} a vector to invert
- * @returns {vec3} out
+ * @param {Vec3} out the receiving vector
+ * @param {Vec3} a vector to invert
+ * @returns {Vec3} out
  */
 export function inverse(out, a) {
   out[0] = 1.0 / a[0];
@@ -328,9 +328,9 @@ export function inverse(out, a) {
 /**
  * Normalize a vec3
  *
- * @param {vec3} out the receiving vector
- * @param {vec3} a vector to normalize
- * @returns {vec3} out
+ * @param {Vec3} out the receiving vector
+ * @param {Vec3} a vector to normalize
+ * @returns {Vec3} out
  */
 export function normalize(out, a) {
   let x = a[0];
@@ -350,8 +350,8 @@ export function normalize(out, a) {
 /**
  * Calculates the dot product of two vec3's
  *
- * @param {vec3} a the first operand
- * @param {vec3} b the second operand
+ * @param {Vec3} a the first operand
+ * @param {Vec3} b the second operand
  * @returns {Number} dot product of a and b
  */
 export function dot(a, b) {
@@ -361,10 +361,10 @@ export function dot(a, b) {
 /**
  * Computes the cross product of two vec3's
  *
- * @param {vec3} out the receiving vector
- * @param {vec3} a the first operand
- * @param {vec3} b the second operand
- * @returns {vec3} out
+ * @param {Vec3} out the receiving vector
+ * @param {Vec3} a the first operand
+ * @param {Vec3} b the second operand
+ * @returns {Vec3} out
  */
 export function cross(out, a, b) {
   let ax = a[0], ay = a[1], az = a[2];
@@ -379,11 +379,11 @@ export function cross(out, a, b) {
 /**
  * Performs a linear interpolation between two vec3's
  *
- * @param {vec3} out the receiving vector
- * @param {vec3} a the first operand
- * @param {vec3} b the second operand
+ * @param {Vec3} out the receiving vector
+ * @param {Vec3} a the first operand
+ * @param {Vec3} b the second operand
  * @param {Number} t interpolation amount, in the range [0-1], between the two inputs
- * @returns {vec3} out
+ * @returns {Vec3} out
  */
 export function lerp(out, a, b, t) {
   let ax = a[0];
@@ -398,13 +398,13 @@ export function lerp(out, a, b, t) {
 /**
  * Performs a hermite interpolation with two control points
  *
- * @param {vec3} out the receiving vector
- * @param {vec3} a the first operand
- * @param {vec3} b the second operand
- * @param {vec3} c the third operand
- * @param {vec3} d the fourth operand
+ * @param {Vec3} out the receiving vector
+ * @param {Vec3} a the first operand
+ * @param {Vec3} b the second operand
+ * @param {Vec3} c the third operand
+ * @param {Vec3} d the fourth operand
  * @param {Number} t interpolation amount, in the range [0-1], between the two inputs
- * @returns {vec3} out
+ * @returns {Vec3} out
  */
 export function hermite(out, a, b, c, d, t) {
   let factorTimes2 = t * t;
@@ -423,13 +423,13 @@ export function hermite(out, a, b, c, d, t) {
 /**
  * Performs a bezier interpolation with two control points
  *
- * @param {vec3} out the receiving vector
- * @param {vec3} a the first operand
- * @param {vec3} b the second operand
- * @param {vec3} c the third operand
- * @param {vec3} d the fourth operand
+ * @param {Vec3} out the receiving vector
+ * @param {Vec3} a the first operand
+ * @param {Vec3} b the second operand
+ * @param {Vec3} c the third operand
+ * @param {Vec3} d the fourth operand
  * @param {Number} t interpolation amount, in the range [0-1], between the two inputs
- * @returns {vec3} out
+ * @returns {Vec3} out
  */
 export function bezier(out, a, b, c, d, t) {
   let inverseFactor = 1 - t;
@@ -450,9 +450,9 @@ export function bezier(out, a, b, c, d, t) {
 /**
  * Generates a random vector with the given scale
  *
- * @param {vec3} out the receiving vector
+ * @param {Vec3} out the receiving vector
  * @param {Number} [scale] Length of the resulting vector. If ommitted, a unit vector will be returned
- * @returns {vec3} out
+ * @returns {Vec3} out
  */
 export function random(out, scale) {
   scale = scale || 1.0;
@@ -471,10 +471,10 @@ export function random(out, scale) {
  * Transforms the vec3 with a mat4.
  * 4th vector component is implicitly '1'
  *
- * @param {vec3} out the receiving vector
- * @param {vec3} a the vector to transform
- * @param {mat4} m matrix to transform with
- * @returns {vec3} out
+ * @param {Vec3} out the receiving vector
+ * @param {Vec3} a the vector to transform
+ * @param {Mat4} m matrix to transform with
+ * @returns {Vec3} out
  */
 export function transformMat4(out, a, m) {
   let x = a[0], y = a[1], z = a[2];
@@ -489,10 +489,10 @@ export function transformMat4(out, a, m) {
 /**
  * Transforms the vec3 with a mat3.
  *
- * @param {vec3} out the receiving vector
- * @param {vec3} a the vector to transform
- * @param {mat3} m the 3x3 matrix to transform with
- * @returns {vec3} out
+ * @param {Vec3} out the receiving vector
+ * @param {Vec3} a the vector to transform
+ * @param {Mat3} m the 3x3 matrix to transform with
+ * @returns {Vec3} out
  */
 export function transformMat3(out, a, m) {
   let x = a[0], y = a[1], z = a[2];
@@ -506,10 +506,10 @@ export function transformMat3(out, a, m) {
  * Transforms the vec3 with a quat
  * Can also be used for dual quaternions. (Multiply it with the real part)
  *
- * @param {vec3} out the receiving vector
- * @param {vec3} a the vector to transform
- * @param {quat} q quaternion to transform with
- * @returns {vec3} out
+ * @param {Vec3} out the receiving vector
+ * @param {Vec3} a the vector to transform
+ * @param {Quat} q quaternion to transform with
+ * @returns {Vec3} out
  */
 export function transformQuat(out, a, q) {
     // benchmarks: https://jsperf.com/quaternion-transform-vec3-implementations-fixed
@@ -542,11 +542,11 @@ export function transformQuat(out, a, q) {
 
 /**
  * Rotate a 3D vector around the x-axis
- * @param {vec3} out The receiving vec3
- * @param {vec3} a The vec3 point to rotate
- * @param {vec3} b The origin of the rotation
+ * @param {Vec3} out The receiving vec3
+ * @param {Vec3} a The vec3 point to rotate
+ * @param {Vec3} b The origin of the rotation
  * @param {Number} c The angle of rotation
- * @returns {vec3} out
+ * @returns {Vec3} out
  */
 export function rotateX(out, a, b, c){
   let p = [], r=[];
@@ -570,11 +570,11 @@ export function rotateX(out, a, b, c){
 
 /**
  * Rotate a 3D vector around the y-axis
- * @param {vec3} out The receiving vec3
- * @param {vec3} a The vec3 point to rotate
- * @param {vec3} b The origin of the rotation
+ * @param {Vec3} out The receiving vec3
+ * @param {Vec3} a The vec3 point to rotate
+ * @param {Vec3} b The origin of the rotation
  * @param {Number} c The angle of rotation
- * @returns {vec3} out
+ * @returns {Vec3} out
  */
 export function rotateY(out, a, b, c){
   let p = [], r=[];
@@ -598,11 +598,11 @@ export function rotateY(out, a, b, c){
 
 /**
  * Rotate a 3D vector around the z-axis
- * @param {vec3} out The receiving vec3
- * @param {vec3} a The vec3 point to rotate
- * @param {vec3} b The origin of the rotation
+ * @param {Vec3} out The receiving vec3
+ * @param {Vec3} a The vec3 point to rotate
+ * @param {Vec3} b The origin of the rotation
  * @param {Number} c The angle of rotation
- * @returns {vec3} out
+ * @returns {Vec3} out
  */
 export function rotateZ(out, a, b, c){
   let p = [], r=[];
@@ -626,8 +626,8 @@ export function rotateZ(out, a, b, c){
 
 /**
  * Get the angle between two 3D vectors
- * @param {vec3} a The first operand
- * @param {vec3} b The second operand
+ * @param {Vec3} a The first operand
+ * @param {Vec3} b The second operand
  * @returns {Number} The angle in radians
  */
 export function angle(a, b) {
@@ -652,7 +652,7 @@ export function angle(a, b) {
 /**
  * Returns a string representation of a vector
  *
- * @param {vec3} a vector to represent as a string
+ * @param {Vec3} a vector to represent as a string
  * @returns {String} string representation of the vector
  */
 export function str(a) {
@@ -662,8 +662,8 @@ export function str(a) {
 /**
  * Returns whether or not the vectors have exactly the same elements in the same position (when compared with ===)
  *
- * @param {vec3} a The first vector.
- * @param {vec3} b The second vector.
+ * @param {Vec3} a The first vector.
+ * @param {Vec3} b The second vector.
  * @returns {Boolean} True if the vectors are equal, false otherwise.
  */
 export function exactEquals(a, b) {
@@ -673,8 +673,8 @@ export function exactEquals(a, b) {
 /**
  * Returns whether or not the vectors have approximately the same elements in the same position.
  *
- * @param {vec3} a The first vector.
- * @param {vec3} b The second vector.
+ * @param {Vec3} a The first vector.
+ * @param {Vec3} b The second vector.
  * @returns {Boolean} True if the vectors are equal, false otherwise.
  */
 export function equals(a, b) {

--- a/src/vec3.js
+++ b/src/vec3.js
@@ -6,6 +6,10 @@ import * as glMatrix from "./common.js";
  */
 
 /**
+ * @typedef {[number, number, number] | Float32Array} Vec3
+ */
+
+/**
  * Creates a new, empty vec3
  *
  * @returns {Vec3} a new 3D vector

--- a/src/vec4.js
+++ b/src/vec4.js
@@ -8,7 +8,7 @@ import * as glMatrix from "./common.js";
 /**
  * Creates a new, empty vec4
  *
- * @returns {vec4} a new 4D vector
+ * @returns {Vec4} a new 4D vector
  */
 export function create() {
   let out = new glMatrix.ARRAY_TYPE(4);
@@ -24,8 +24,8 @@ export function create() {
 /**
  * Creates a new vec4 initialized with values from an existing vector
  *
- * @param {vec4} a vector to clone
- * @returns {vec4} a new 4D vector
+ * @param {Vec4} a vector to clone
+ * @returns {Vec4} a new 4D vector
  */
 export function clone(a) {
   let out = new glMatrix.ARRAY_TYPE(4);
@@ -43,7 +43,7 @@ export function clone(a) {
  * @param {Number} y Y component
  * @param {Number} z Z component
  * @param {Number} w W component
- * @returns {vec4} a new 4D vector
+ * @returns {Vec4} a new 4D vector
  */
 export function fromValues(x, y, z, w) {
   let out = new glMatrix.ARRAY_TYPE(4);
@@ -57,9 +57,9 @@ export function fromValues(x, y, z, w) {
 /**
  * Copy the values from one vec4 to another
  *
- * @param {vec4} out the receiving vector
- * @param {vec4} a the source vector
- * @returns {vec4} out
+ * @param {Vec4} out the receiving vector
+ * @param {Vec4} a the source vector
+ * @returns {Vec4} out
  */
 export function copy(out, a) {
   out[0] = a[0];
@@ -72,12 +72,12 @@ export function copy(out, a) {
 /**
  * Set the components of a vec4 to the given values
  *
- * @param {vec4} out the receiving vector
+ * @param {Vec4} out the receiving vector
  * @param {Number} x X component
  * @param {Number} y Y component
  * @param {Number} z Z component
  * @param {Number} w W component
- * @returns {vec4} out
+ * @returns {Vec4} out
  */
 export function set(out, x, y, z, w) {
   out[0] = x;
@@ -90,10 +90,10 @@ export function set(out, x, y, z, w) {
 /**
  * Adds two vec4's
  *
- * @param {vec4} out the receiving vector
- * @param {vec4} a the first operand
- * @param {vec4} b the second operand
- * @returns {vec4} out
+ * @param {Vec4} out the receiving vector
+ * @param {Vec4} a the first operand
+ * @param {Vec4} b the second operand
+ * @returns {Vec4} out
  */
 export function add(out, a, b) {
   out[0] = a[0] + b[0];
@@ -106,10 +106,10 @@ export function add(out, a, b) {
 /**
  * Subtracts vector b from vector a
  *
- * @param {vec4} out the receiving vector
- * @param {vec4} a the first operand
- * @param {vec4} b the second operand
- * @returns {vec4} out
+ * @param {Vec4} out the receiving vector
+ * @param {Vec4} a the first operand
+ * @param {Vec4} b the second operand
+ * @returns {Vec4} out
  */
 export function subtract(out, a, b) {
   out[0] = a[0] - b[0];
@@ -122,10 +122,10 @@ export function subtract(out, a, b) {
 /**
  * Multiplies two vec4's
  *
- * @param {vec4} out the receiving vector
- * @param {vec4} a the first operand
- * @param {vec4} b the second operand
- * @returns {vec4} out
+ * @param {Vec4} out the receiving vector
+ * @param {Vec4} a the first operand
+ * @param {Vec4} b the second operand
+ * @returns {Vec4} out
  */
 export function multiply(out, a, b) {
   out[0] = a[0] * b[0];
@@ -138,10 +138,10 @@ export function multiply(out, a, b) {
 /**
  * Divides two vec4's
  *
- * @param {vec4} out the receiving vector
- * @param {vec4} a the first operand
- * @param {vec4} b the second operand
- * @returns {vec4} out
+ * @param {Vec4} out the receiving vector
+ * @param {Vec4} a the first operand
+ * @param {Vec4} b the second operand
+ * @returns {Vec4} out
  */
 export function divide(out, a, b) {
   out[0] = a[0] / b[0];
@@ -154,9 +154,9 @@ export function divide(out, a, b) {
 /**
  * Math.ceil the components of a vec4
  *
- * @param {vec4} out the receiving vector
- * @param {vec4} a vector to ceil
- * @returns {vec4} out
+ * @param {Vec4} out the receiving vector
+ * @param {Vec4} a vector to ceil
+ * @returns {Vec4} out
  */
 export function ceil(out, a) {
   out[0] = Math.ceil(a[0]);
@@ -169,9 +169,9 @@ export function ceil(out, a) {
 /**
  * Math.floor the components of a vec4
  *
- * @param {vec4} out the receiving vector
- * @param {vec4} a vector to floor
- * @returns {vec4} out
+ * @param {Vec4} out the receiving vector
+ * @param {Vec4} a vector to floor
+ * @returns {Vec4} out
  */
 export function floor(out, a) {
   out[0] = Math.floor(a[0]);
@@ -184,10 +184,10 @@ export function floor(out, a) {
 /**
  * Returns the minimum of two vec4's
  *
- * @param {vec4} out the receiving vector
- * @param {vec4} a the first operand
- * @param {vec4} b the second operand
- * @returns {vec4} out
+ * @param {Vec4} out the receiving vector
+ * @param {Vec4} a the first operand
+ * @param {Vec4} b the second operand
+ * @returns {Vec4} out
  */
 export function min(out, a, b) {
   out[0] = Math.min(a[0], b[0]);
@@ -200,10 +200,10 @@ export function min(out, a, b) {
 /**
  * Returns the maximum of two vec4's
  *
- * @param {vec4} out the receiving vector
- * @param {vec4} a the first operand
- * @param {vec4} b the second operand
- * @returns {vec4} out
+ * @param {Vec4} out the receiving vector
+ * @param {Vec4} a the first operand
+ * @param {Vec4} b the second operand
+ * @returns {Vec4} out
  */
 export function max(out, a, b) {
   out[0] = Math.max(a[0], b[0]);
@@ -216,9 +216,9 @@ export function max(out, a, b) {
 /**
  * Math.round the components of a vec4
  *
- * @param {vec4} out the receiving vector
- * @param {vec4} a vector to round
- * @returns {vec4} out
+ * @param {Vec4} out the receiving vector
+ * @param {Vec4} a vector to round
+ * @returns {Vec4} out
  */
 export function round(out, a) {
   out[0] = Math.round(a[0]);
@@ -231,10 +231,10 @@ export function round(out, a) {
 /**
  * Scales a vec4 by a scalar number
  *
- * @param {vec4} out the receiving vector
- * @param {vec4} a the vector to scale
+ * @param {Vec4} out the receiving vector
+ * @param {Vec4} a the vector to scale
  * @param {Number} b amount to scale the vector by
- * @returns {vec4} out
+ * @returns {Vec4} out
  */
 export function scale(out, a, b) {
   out[0] = a[0] * b;
@@ -247,11 +247,11 @@ export function scale(out, a, b) {
 /**
  * Adds two vec4's after scaling the second operand by a scalar value
  *
- * @param {vec4} out the receiving vector
- * @param {vec4} a the first operand
- * @param {vec4} b the second operand
+ * @param {Vec4} out the receiving vector
+ * @param {Vec4} a the first operand
+ * @param {Vec4} b the second operand
  * @param {Number} scale the amount to scale b by before adding
- * @returns {vec4} out
+ * @returns {Vec4} out
  */
 export function scaleAndAdd(out, a, b, scale) {
   out[0] = a[0] + (b[0] * scale);
@@ -264,8 +264,8 @@ export function scaleAndAdd(out, a, b, scale) {
 /**
  * Calculates the euclidian distance between two vec4's
  *
- * @param {vec4} a the first operand
- * @param {vec4} b the second operand
+ * @param {Vec4} a the first operand
+ * @param {Vec4} b the second operand
  * @returns {Number} distance between a and b
  */
 export function distance(a, b) {
@@ -279,8 +279,8 @@ export function distance(a, b) {
 /**
  * Calculates the squared euclidian distance between two vec4's
  *
- * @param {vec4} a the first operand
- * @param {vec4} b the second operand
+ * @param {Vec4} a the first operand
+ * @param {Vec4} b the second operand
  * @returns {Number} squared distance between a and b
  */
 export function squaredDistance(a, b) {
@@ -294,7 +294,7 @@ export function squaredDistance(a, b) {
 /**
  * Calculates the length of a vec4
  *
- * @param {vec4} a vector to calculate length of
+ * @param {Vec4} a vector to calculate length of
  * @returns {Number} length of a
  */
 export function length(a) {
@@ -308,7 +308,7 @@ export function length(a) {
 /**
  * Calculates the squared length of a vec4
  *
- * @param {vec4} a vector to calculate squared length of
+ * @param {Vec4} a vector to calculate squared length of
  * @returns {Number} squared length of a
  */
 export function squaredLength(a) {
@@ -322,9 +322,9 @@ export function squaredLength(a) {
 /**
  * Negates the components of a vec4
  *
- * @param {vec4} out the receiving vector
- * @param {vec4} a vector to negate
- * @returns {vec4} out
+ * @param {Vec4} out the receiving vector
+ * @param {Vec4} a vector to negate
+ * @returns {Vec4} out
  */
 export function negate(out, a) {
   out[0] = -a[0];
@@ -337,9 +337,9 @@ export function negate(out, a) {
 /**
  * Returns the inverse of the components of a vec4
  *
- * @param {vec4} out the receiving vector
- * @param {vec4} a vector to invert
- * @returns {vec4} out
+ * @param {Vec4} out the receiving vector
+ * @param {Vec4} a vector to invert
+ * @returns {Vec4} out
  */
 export function inverse(out, a) {
   out[0] = 1.0 / a[0];
@@ -352,9 +352,9 @@ export function inverse(out, a) {
 /**
  * Normalize a vec4
  *
- * @param {vec4} out the receiving vector
- * @param {vec4} a vector to normalize
- * @returns {vec4} out
+ * @param {Vec4} out the receiving vector
+ * @param {Vec4} a vector to normalize
+ * @returns {Vec4} out
  */
 export function normalize(out, a) {
   let x = a[0];
@@ -375,8 +375,8 @@ export function normalize(out, a) {
 /**
  * Calculates the dot product of two vec4's
  *
- * @param {vec4} a the first operand
- * @param {vec4} b the second operand
+ * @param {Vec4} a the first operand
+ * @param {Vec4} b the second operand
  * @returns {Number} dot product of a and b
  */
 export function dot(a, b) {
@@ -386,11 +386,11 @@ export function dot(a, b) {
 /**
  * Performs a linear interpolation between two vec4's
  *
- * @param {vec4} out the receiving vector
- * @param {vec4} a the first operand
- * @param {vec4} b the second operand
+ * @param {Vec4} out the receiving vector
+ * @param {Vec4} a the first operand
+ * @param {Vec4} b the second operand
  * @param {Number} t interpolation amount, in the range [0-1], between the two inputs
- * @returns {vec4} out
+ * @returns {Vec4} out
  */
 export function lerp(out, a, b, t) {
   let ax = a[0];
@@ -407,9 +407,9 @@ export function lerp(out, a, b, t) {
 /**
  * Generates a random vector with the given scale
  *
- * @param {vec4} out the receiving vector
+ * @param {Vec4} out the receiving vector
  * @param {Number} [scale] Length of the resulting vector. If ommitted, a unit vector will be returned
- * @returns {vec4} out
+ * @returns {Vec4} out
  */
 export function random(out, scale) {
   scale = scale || 1.0;
@@ -441,10 +441,10 @@ export function random(out, scale) {
 /**
  * Transforms the vec4 with a mat4.
  *
- * @param {vec4} out the receiving vector
- * @param {vec4} a the vector to transform
- * @param {mat4} m matrix to transform with
- * @returns {vec4} out
+ * @param {Vec4} out the receiving vector
+ * @param {Vec4} a the vector to transform
+ * @param {Mat4} m matrix to transform with
+ * @returns {Vec4} out
  */
 export function transformMat4(out, a, m) {
   let x = a[0], y = a[1], z = a[2], w = a[3];
@@ -458,10 +458,10 @@ export function transformMat4(out, a, m) {
 /**
  * Transforms the vec4 with a quat
  *
- * @param {vec4} out the receiving vector
- * @param {vec4} a the vector to transform
- * @param {quat} q quaternion to transform with
- * @returns {vec4} out
+ * @param {Vec4} out the receiving vector
+ * @param {Vec4} a the vector to transform
+ * @param {Quat} q quaternion to transform with
+ * @returns {Vec4} out
  */
 export function transformQuat(out, a, q) {
   let x = a[0], y = a[1], z = a[2];
@@ -484,7 +484,7 @@ export function transformQuat(out, a, q) {
 /**
  * Returns a string representation of a vector
  *
- * @param {vec4} a vector to represent as a string
+ * @param {Vec4} a vector to represent as a string
  * @returns {String} string representation of the vector
  */
 export function str(a) {
@@ -494,8 +494,8 @@ export function str(a) {
 /**
  * Returns whether or not the vectors have exactly the same elements in the same position (when compared with ===)
  *
- * @param {vec4} a The first vector.
- * @param {vec4} b The second vector.
+ * @param {Vec4} a The first vector.
+ * @param {Vec4} b The second vector.
  * @returns {Boolean} True if the vectors are equal, false otherwise.
  */
 export function exactEquals(a, b) {
@@ -505,8 +505,8 @@ export function exactEquals(a, b) {
 /**
  * Returns whether or not the vectors have approximately the same elements in the same position.
  *
- * @param {vec4} a The first vector.
- * @param {vec4} b The second vector.
+ * @param {Vec4} a The first vector.
+ * @param {Vec4} b The second vector.
  * @returns {Boolean} True if the vectors are equal, false otherwise.
  */
 export function equals(a, b) {

--- a/src/vec4.js
+++ b/src/vec4.js
@@ -6,6 +6,10 @@ import * as glMatrix from "./common.js";
  */
 
 /**
+ * @typedef {[number, number, number, number] | Float32Array} Vec4
+ */
+
+/**
  * Creates a new, empty vec4
  *
  * @returns {Vec4} a new 4D vector


### PR DESCRIPTION
An attempt to address #323. This PR renames all data types to Pascal case and adds @typedefs describing them. It's the cheapest solution I came up with that requires minimum maintenance.

Also I intentionally renamed types in docs. Is this okay?

Typechecks now working a bit better relying solely on JSDocs:
```typescript
import { vec2, vec3 } from './src/index';

let a: vec2.Vec2;

a = vec3.create();

/* tsc outputs

Type 'Float32Array | [number, number, number]' is not assignable to type '[number, number] | Float32Array'.
  Type '[number, number, number]' is not assignable to type '[number, number] | Float32Array'.
    Type '[number, number, number]' is not assignable to type '[number, number]'.
      Types of property 'length' are incompatible.
        Type '3' is not assignable to type '2'.

*/
```

