### PR TITLE
Fixes #245 - getRotation scaled matrix

### DIFF
--- a/src/mat4.js
+++ b/src/mat4.js
@@ -1030,7 +1030,7 @@ export function getRotation(out, mat) {
   let trace = sm11 + sm22 + sm33;
   let S = 0;
 
-  if (trace > 0) { 
+  if (trace > 0) {
     S = Math.sqrt(trace + 1.0) * 2;
     out[3] = 0.25 * S;
     out[0] = (sm23 - sm32) / S;
@@ -1049,7 +1049,7 @@ export function getRotation(out, mat) {
     out[1] = 0.25 * S;
     out[2] = (sm23 + sm32) / S;
   } else {
-    S = Math.sqrt(1.0 + sm33 - sm11- sm22) * 2;
+    S = Math.sqrt(1.0 + sm33 - sm11 - sm22) * 2;
     out[3] = (sm12 - sm21) / S;
     out[0] = (sm31 + sm13) / S;
     out[1] = (sm23 + sm32) / S;

--- a/src/mat4.js
+++ b/src/mat4.js
@@ -1010,33 +1010,49 @@ export function getScaling(out, mat) {
  * @return {quat} out
  */
 export function getRotation(out, mat) {
-  // Algorithm taken from http://www.euclideanspace.com/maths/geometry/rotations/conversions/matrixToQuaternion/index.htm
-  let trace = mat[0] + mat[5] + mat[10];
+  let scaling = new glMatrix.ARRAY_TYPE(3);
+  getScaling(scaling, mat);
+
+  let is1 = 1 / scaling[0];
+  let is2 = 1 / scaling[1];
+  let is3 = 1 / scaling[2];
+
+  let sm11 = mat[0] * is1;
+  let sm12 = mat[1] * is2;
+  let sm13 = mat[2] * is3;
+  let sm21 = mat[4] * is1;
+  let sm22 = mat[5] * is2;
+  let sm23 = mat[6] * is3;
+  let sm31 = mat[8] * is1;
+  let sm32 = mat[9] * is2;
+  let sm33 = mat[10] * is3;
+
+  let trace = sm11 + sm22 + sm33;
   let S = 0;
 
-  if (trace > 0) {
+  if (trace > 0) { 
     S = Math.sqrt(trace + 1.0) * 2;
     out[3] = 0.25 * S;
-    out[0] = (mat[6] - mat[9]) / S;
-    out[1] = (mat[8] - mat[2]) / S;
-    out[2] = (mat[1] - mat[4]) / S;
-  } else if ((mat[0] > mat[5]) && (mat[0] > mat[10])) {
-    S = Math.sqrt(1.0 + mat[0] - mat[5] - mat[10]) * 2;
-    out[3] = (mat[6] - mat[9]) / S;
+    out[0] = (sm23 - sm32) / S;
+    out[1] = (sm31 - sm13) / S;
+    out[2] = (sm12 - sm21) / S;
+  } else if ((sm11 > sm22) && (sm11 > sm33)) {
+    S = Math.sqrt(1.0 + sm11 - sm22- sm33) * 2;
+    out[3] = (sm23 - sm32) / S;
     out[0] = 0.25 * S;
-    out[1] = (mat[1] + mat[4]) / S;
-    out[2] = (mat[8] + mat[2]) / S;
-  } else if (mat[5] > mat[10]) {
-    S = Math.sqrt(1.0 + mat[5] - mat[0] - mat[10]) * 2;
-    out[3] = (mat[8] - mat[2]) / S;
-    out[0] = (mat[1] + mat[4]) / S;
+    out[1] = (sm12 + sm21) / S;
+    out[2] = (sm31 + sm13) / S;
+  } else if (sm22 > sm33) {
+    S = Math.sqrt(1.0 + sm22 - sm11 - sm33) * 2;
+    out[3] = (sm31 - sm13) / S;
+    out[0] = (sm12 + sm21) / S;
     out[1] = 0.25 * S;
-    out[2] = (mat[6] + mat[9]) / S;
+    out[2] = (sm23 + sm32) / S;
   } else {
-    S = Math.sqrt(1.0 + mat[10] - mat[0] - mat[5]) * 2;
-    out[3] = (mat[1] - mat[4]) / S;
-    out[0] = (mat[8] + mat[2]) / S;
-    out[1] = (mat[6] + mat[9]) / S;
+    S = Math.sqrt(1.0 + sm33 - sm11- sm22) * 2;
+    out[3] = (sm12 - sm21) / S;
+    out[0] = (sm31 + sm13) / S;
+    out[1] = (sm23 + sm32) / S;
     out[2] = 0.25 * S;
   }
 


### PR DESCRIPTION
Currently, using `mat4.getRotation` causes unexpected behaviors. I just took the implementation proposed by @kyasbal-1994 in #245
This leads to some tests breaking in quat2.
Maybe we should have separates functions, something like `getRotation` & `getUnscaledRotation`?