### PR TITLE
mat4: Support infinite far planes in mat4.frustum

### DIFF
--- a/src/mat4.js
+++ b/src/mat4.js
@@ -1240,6 +1240,7 @@ export function fromQuat(out, q) {
 
 /**
  * Generates a frustum matrix with the given bounds
+ * Passing null/undefined/no value for far will generate infinite projection matrix.
  *
  * @param {mat4} out mat4 frustum matrix will be written into
  * @param {Number} left Left bound of the frustum
@@ -1247,13 +1248,12 @@ export function fromQuat(out, q) {
  * @param {Number} bottom Bottom bound of the frustum
  * @param {Number} top Top bound of the frustum
  * @param {Number} near Near bound of the frustum
- * @param {Number} far Far bound of the frustum
+ * @param {Number} far Far bound of the frustum, can be null or Infinity
  * @returns {mat4} out
  */
 export function frustum(out, left, right, bottom, top, near, far) {
   let rl = 1 / (right - left);
   let tb = 1 / (top - bottom);
-  let nf = 1 / (near - far);
   out[0] = (near * 2) * rl;
   out[1] = 0;
   out[2] = 0;
@@ -1264,12 +1264,18 @@ export function frustum(out, left, right, bottom, top, near, far) {
   out[7] = 0;
   out[8] = (right + left) * rl;
   out[9] = (top + bottom) * tb;
-  out[10] = (far + near) * nf;
   out[11] = -1;
   out[12] = 0;
   out[13] = 0;
-  out[14] = (far * near * 2) * nf;
   out[15] = 0;
+  if (far != null && far !== Infinity) {
+    let nf = 1 / (near - far);
+    out[10] = (far + near) * nf;
+    out[14] = 2 * far * near * nf;
+  } else {
+    out[10] = -1;
+    out[14] = -2 * near;
+  }
   return out;
 }
 


### PR DESCRIPTION
This is supported in mat4.perspective, so why not mat4.frustum?