### PR TITLE
GitHub npm dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "Javascript Matrix and Vector library for High Performance WebGL apps",
   "private": true,
   "sideEffects": false,
-  "main": "cjs/index.js",
-  "module": "esm/index.js",
+  "main": "dist/cjs/index.js",
+  "module": "dist/esm/index.js",
   "homepage": "http://glmatrix.net",
   "license": "MIT",
   "bugs": {
@@ -33,7 +33,8 @@
     "build-umd": "rollup -c",
     "build-esm": "cross-env BABEL_ENV=esm babel src -d dist/esm",
     "build-cjs": "babel src -d dist/cjs",
-    "build": "del dist && npm run update-license-version && npm run build-umd && npm run build-esm && npm run build-cjs && node ./utils/build.js"
+    "build": "del dist && npm run update-license-version && npm run build-umd && npm run build-esm && npm run build-cjs && node ./utils/build.js",
+    "prepare": "npm run build"
   },
   "devDependencies": {
     "@babel/cli": "^7.2.3",

--- a/utils/build.js
+++ b/utils/build.js
@@ -8,6 +8,8 @@ const copyFileSync = (source, dest) => {
 };
 
 delete pkg.private;
+delete pkg.scripts;
+delete pkg.devDependencies;
 pkg.main = 'cjs/index.js'
 pkg.module = 'esm/index.js'
 fs.writeFileSync('dist/package.json', JSON.stringify(pkg, null, 2));

--- a/utils/build.js
+++ b/utils/build.js
@@ -8,7 +8,10 @@ const copyFileSync = (source, dest) => {
 };
 
 delete pkg.private;
+pkg.main = 'cjs/index.js'
+pkg.module = 'esm/index.js'
 fs.writeFileSync('dist/package.json', JSON.stringify(pkg, null, 2));
+
 copyFileSync('README.md', 'dist/README.md');
 copyFileSync('LICENSE.md', 'dist/LICENSE.md');
 


### PR DESCRIPTION
This change allows me to use the git repository directly as a dependency in my packages.json
.e.g 

```
"dependencies": { "gl-matrix": "git@github.com:stygianguest/gl-matrix.git#github_npm_dependency" }
```

might be useful to others as well