### PR TITLE
Update docs to express angles are in radians

### DIFF
--- a/src/vec2.js
+++ b/src/vec2.js
@@ -452,7 +452,7 @@ export function transformMat4(out, a, m) {
  * @param {vec2} out The receiving vec2
  * @param {vec2} a The vec2 point to rotate
  * @param {vec2} b The origin of the rotation
- * @param {Number} c The angle of rotation
+ * @param {Number} c The angle of rotation in radians
  * @returns {vec2} out
  */
 export function rotate(out, a, b, c) {

--- a/src/vec2.js
+++ b/src/vec2.js
@@ -315,7 +315,7 @@ export function normalize(out, a) {
   if (len > 0) {
     //TODO: evaluate use of glm_invsqrt here?
     len = 1 / Math.sqrt(len);
-  }    
+  }
   out[0] = a[0] * len;
   out[1] = a[1] * len;
   return out;
@@ -452,16 +452,16 @@ export function transformMat4(out, a, m) {
  * @param {vec2} out The receiving vec2
  * @param {vec2} a The vec2 point to rotate
  * @param {vec2} b The origin of the rotation
- * @param {Number} c The angle of rotation in radians
+ * @param {Number} rad The angle of rotation in radians
  * @returns {vec2} out
  */
-export function rotate(out, a, b, c) {
+export function rotate(out, a, b, rad) {
   //Translate point to the origin
   let p0 = a[0] - b[0],
   p1 = a[1] - b[1],
-  sinC = Math.sin(c),
-  cosC = Math.cos(c);
-  
+  sinC = Math.sin(rad),
+  cosC = Math.cos(rad);
+
   //perform rotation and translate to correct position
   out[0] = p0*cosC - p1*sinC + b[0];
   out[1] = p0*sinC + p1*cosC + b[1];
@@ -480,22 +480,21 @@ export function angle(a, b) {
     y1 = a[1],
     x2 = b[0],
     y2 = b[1];
-  
+
   let len1 = x1*x1 + y1*y1;
   if (len1 > 0) {
     //TODO: evaluate use of glm_invsqrt here?
     len1 = 1 / Math.sqrt(len1);
   }
-  
+
   let len2 = x2*x2 + y2*y2;
   if (len2 > 0) {
     //TODO: evaluate use of glm_invsqrt here?
     len2 = 1 / Math.sqrt(len2);
   }
-  
+
   let cosine = (x1 * x2 + y1 * y2) * len1 * len2;
-  
-  
+
   if(cosine > 1.0) {
     return 0;
   }

--- a/src/vec3.js
+++ b/src/vec3.js
@@ -545,10 +545,10 @@ export function transformQuat(out, a, q) {
  * @param {vec3} out The receiving vec3
  * @param {vec3} a The vec3 point to rotate
  * @param {vec3} b The origin of the rotation
- * @param {Number} c The angle of rotation
+ * @param {Number} rad The angle of rotation in radians
  * @returns {vec3} out
  */
-export function rotateX(out, a, b, c){
+export function rotateX(out, a, b, rad){
   let p = [], r=[];
   //Translate point to the origin
   p[0] = a[0] - b[0];
@@ -557,8 +557,8 @@ export function rotateX(out, a, b, c){
 
   //perform rotation
   r[0] = p[0];
-  r[1] = p[1]*Math.cos(c) - p[2]*Math.sin(c);
-  r[2] = p[1]*Math.sin(c) + p[2]*Math.cos(c);
+  r[1] = p[1]*Math.cos(rad) - p[2]*Math.sin(rad);
+  r[2] = p[1]*Math.sin(rad) + p[2]*Math.cos(rad);
 
   //translate to correct position
   out[0] = r[0] + b[0];
@@ -573,10 +573,10 @@ export function rotateX(out, a, b, c){
  * @param {vec3} out The receiving vec3
  * @param {vec3} a The vec3 point to rotate
  * @param {vec3} b The origin of the rotation
- * @param {Number} c The angle of rotation
+ * @param {Number} rad The angle of rotation in radians
  * @returns {vec3} out
  */
-export function rotateY(out, a, b, c){
+export function rotateY(out, a, b, rad){
   let p = [], r=[];
   //Translate point to the origin
   p[0] = a[0] - b[0];
@@ -584,9 +584,9 @@ export function rotateY(out, a, b, c){
   p[2] = a[2] - b[2];
 
   //perform rotation
-  r[0] = p[2]*Math.sin(c) + p[0]*Math.cos(c);
+  r[0] = p[2]*Math.sin(rad) + p[0]*Math.cos(rad);
   r[1] = p[1];
-  r[2] = p[2]*Math.cos(c) - p[0]*Math.sin(c);
+  r[2] = p[2]*Math.cos(rad) - p[0]*Math.sin(rad);
 
   //translate to correct position
   out[0] = r[0] + b[0];
@@ -601,10 +601,10 @@ export function rotateY(out, a, b, c){
  * @param {vec3} out The receiving vec3
  * @param {vec3} a The vec3 point to rotate
  * @param {vec3} b The origin of the rotation
- * @param {Number} c The angle of rotation
+ * @param {Number} rad The angle of rotation in radians
  * @returns {vec3} out
  */
-export function rotateZ(out, a, b, c){
+export function rotateZ(out, a, b, rad){
   let p = [], r=[];
   //Translate point to the origin
   p[0] = a[0] - b[0];
@@ -612,8 +612,8 @@ export function rotateZ(out, a, b, c){
   p[2] = a[2] - b[2];
 
   //perform rotation
-  r[0] = p[0]*Math.cos(c) - p[1]*Math.sin(c);
-  r[1] = p[0]*Math.sin(c) + p[1]*Math.cos(c);
+  r[0] = p[0]*Math.cos(rad) - p[1]*Math.sin(rad);
+  r[1] = p[0]*Math.sin(rad) + p[1]*Math.cos(rad);
   r[2] = p[2];
 
   //translate to correct position


### PR DESCRIPTION
No functionality changes, but some function inputs were renamed to match the usage in other classes, and the jsdoc updated to match. 

I lost an hour of debugging because it wasn't explicit in the docs that vec2/vec3 rotations were in radians, hopefully this prevents others from the same problem.

Also cleaned up some messy whitespace.