### PR TITLE
Set correct type for setMatrixArrayType

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -11,7 +11,7 @@ export const RANDOM = Math.random;
 /**
  * Sets the type of array used when creating new vectors and matrices
  *
- * @param {Type} type Array type, such as Float32Array or Array
+ * @param {Float32ArrayConstructor | ArrayConstructor} type Array type, such as Float32Array or Array
  */
 export function setMatrixArrayType(type) {
   ARRAY_TYPE = type;


### PR DESCRIPTION
Typescript complained about unknown "Type". Judging from the code `Float32ArrayConstructor | ArrayConstructor` is appropriate.