### PR TITLE
add combined TRS decompose for mat4

### DIFF
--- a/spec/gl-matrix/mat4-spec.js
+++ b/spec/gl-matrix/mat4-spec.js
@@ -625,6 +625,98 @@ function buildMat4Tests() {
             });
         });
 
+        let out_t, out_s;
+        describe("decompose", function() {
+            describe("from the identity matrix", function() {
+                beforeEach(function() {
+                    result = quat.fromValues(1, 2, 3, 4);
+                    out_t = vec3.fromValues(7, 8, 9);
+                    out_s = vec3.fromValues(4, 5, 6);
+                    out = quat.fromValues(1, 2, 3, 4);
+                    result = mat4.decompose(out, out_t, out_s, identity);
+                });
+                it("should place result both in result and out", function() { expect(result).toBe(out); });
+                it("should return the unit quaternion", function() {
+                    let unitQuat = quat.create();
+                    quat.identity(unitQuat);
+                    expect(result).toBeEqualish(unitQuat);
+                });
+                it("out_s should be the identity vector", function() { expect(out_s).toBeEqualish([1, 1, 1]); });
+                it("out_t should be the zero vector", function() { expect(out_t).toBeEqualish([0, 0, 0]); });
+            });
+
+            describe("from a translation-only matrix", function() {
+                beforeEach(function() {
+                    result = quat.fromValues(1, 2, 3, 4);
+                    out_t = vec3.fromValues(7, 8, 9);
+                    out_s = vec3.fromValues(4, 5, 6);
+                    out = quat.fromValues(1, 2, 3, 4);
+                    result = mat4.decompose(out, out_t, out_s, matB);
+                });
+                it("should return the unit quaternion", function() {
+                    let unitQuat = quat.create();
+                    quat.identity(unitQuat);
+                    expect(result).toBeEqualish(unitQuat);
+                });
+                it("out_s should be the identity vector", function() { expect(out_s).toBeEqualish([1, 1, 1]); });
+                it("out_t should be translation vector", function() { expect(out_t).toBeEqualish([4, 5, 6]); });
+            });
+
+            describe("from a scale-only matrix", function() {
+                beforeEach(function() {
+                    let v = vec3.fromValues(4, 5, 6);
+                    result = vec3.fromValues(1, 2, 3)
+                    out_t = vec3.fromValues(7, 8, 9);
+                    out_s = vec3.fromValues(1, 2, 3);
+                    out = quat.fromValues(1, 2, 3, 4);
+                    mat4.fromScaling(matA, v);
+                    result = mat4.decompose(out, out_t, out_s, matA);
+                });
+                it("out_s should be translation vector", function() { expect(out_s).toBeEqualish([4, 5, 6]); });
+            });
+
+            describe("from a translation and rotation matrix", function() {
+                it("should keep the same rotation and translation as when created", function() {
+                    let q = quat.create();
+                    let outVec = vec3.fromValues(5, 6, 7);
+                    let testVec = vec3.fromValues(1, 5, 2);
+                    let ang = 0.78972;
+
+                    vec3.normalize(testVec, testVec);
+                    q = quat.setAxisAngle(q, testVec, ang);
+                    mat4.fromRotationTranslation(out, q, outVec);
+
+                    result = quat.fromValues(2, 3, 4, 6);
+                    out_t = vec3.fromValues(7, 8, 9);
+                    out_s = vec3.fromValues(4, 5, 6);
+                    mat4.decompose(result, out_t, out_s, out);
+                    let outaxis = vec3.create();
+                    let outangle = quat.getAxisAngle(outaxis, result);
+
+                    expect(outaxis).toBeEqualish(testVec);
+                    expect(outangle).toBeEqualish(ang);
+                    expect(out_t).toBeEqualish(outVec);
+                });
+            });
+
+            describe("from a translation, rotation and scale matrix", function() {
+                beforeEach(function() {
+                    let q = quat.create();
+                    let t = vec3.fromValues(1, 2, 3);
+                    let s = vec3.fromValues(5, 6, 7);
+                    q = quat.setAxisAngle(q, [0, 1, 0], 0.7);
+                    mat4.fromRotationTranslationScale(out, q, t, s);
+                    out_t = vec3.fromValues(7, 8, 9);
+                    out_s = vec3.fromValues(4, 5, 6);
+                    result = quat.fromValues(2, 3, 4, 6);
+                    mat4.decompose(result, out_t, out_s, out);
+                })
+                it("should return the same scaling factor when created", function() { expect(out_s).toBeEqualish([5, 6, 7]); });
+                it("should return the same translation when created", function() { expect(out_t).toBeEqualish([1, 2, 3]); });
+            });
+
+        });
+
         describe("frustum", function() {
             beforeEach(function() { result = mat4.frustum(out, -1, 1, -1, 1, -1, 1); });
             it("should place values into out", function() { expect(result).toBeEqualish([

--- a/src/mat4.js
+++ b/src/mat4.js
@@ -1227,6 +1227,65 @@ export function getRotation(out, mat) {
 }
 
 /**
+ * Decomposes a transformation matrix into its rotation, translation
+ * and scale components. Returns only the rotation component
+ * @param  {quat} out_r Quaternion to receive the rotation component
+ * @param  {vec3} out_t Vector to receive the translation vector
+ * @param  {vec3} out_s Vector to receive the scaling factor
+ * @param  {ReadonlyMat4} mat Matrix to be decomposed (input)
+ * @returns {quat} out_r
+ */
+export function decompose(out_r, out_t, out_s, mat) {
+  getTranslation(out_t, mat);
+  getScaling(out_s, mat);
+
+  let is1 = 1 / out_s[0];
+  let is2 = 1 / out_s[1];
+  let is3 = 1 / out_s[2];
+
+  let sm11 = mat[0] * is1;
+  let sm12 = mat[1] * is2;
+  let sm13 = mat[2] * is3;
+  let sm21 = mat[4] * is1;
+  let sm22 = mat[5] * is2;
+  let sm23 = mat[6] * is3;
+  let sm31 = mat[8] * is1;
+  let sm32 = mat[9] * is2;
+  let sm33 = mat[10] * is3;
+
+  let trace = sm11 + sm22 + sm33;
+  let S = 0;
+
+  if (trace > 0) {
+    S = Math.sqrt(trace + 1.0) * 2;
+    out_r[3] = 0.25 * S;
+    out_r[0] = (sm23 - sm32) / S;
+    out_r[1] = (sm31 - sm13) / S;
+    out_r[2] = (sm12 - sm21) / S;
+  } else if (sm11 > sm22 && sm11 > sm33) {
+    S = Math.sqrt(1.0 + sm11 - sm22 - sm33) * 2;
+    out_r[3] = (sm23 - sm32) / S;
+    out_r[0] = 0.25 * S;
+    out_r[1] = (sm12 + sm21) / S;
+    out_r[2] = (sm31 + sm13) / S;
+  } else if (sm22 > sm33) {
+    S = Math.sqrt(1.0 + sm22 - sm11 - sm33) * 2;
+    out_r[3] = (sm31 - sm13) / S;
+    out_r[0] = (sm12 + sm21) / S;
+    out_r[1] = 0.25 * S;
+    out_r[2] = (sm23 + sm32) / S;
+  } else {
+    S = Math.sqrt(1.0 + sm33 - sm11 - sm22) * 2;
+    out_r[3] = (sm12 - sm21) / S;
+    out_r[0] = (sm31 + sm13) / S;
+    out_r[1] = (sm23 + sm32) / S;
+    out_r[2] = 0.25 * S;
+  }
+
+  return out_r;
+}
+
+/**
  * Creates a matrix from a quaternion rotation, vector translation and vector scale
  * This is equivalent to (but much faster than):
  *

--- a/src/mat4.js
+++ b/src/mat4.js
@@ -1236,22 +1236,37 @@ export function getRotation(out, mat) {
  * @returns {quat} out_r
  */
 export function decompose(out_r, out_t, out_s, mat) {
-  getTranslation(out_t, mat);
-  getScaling(out_s, mat);
+  out_t[0] = mat[12];
+  out_t[1] = mat[13];
+  out_t[2] = mat[14];
+
+  let m11 = mat[0];
+  let m12 = mat[1];
+  let m13 = mat[2];
+  let m21 = mat[4];
+  let m22 = mat[5];
+  let m23 = mat[6];
+  let m31 = mat[8];
+  let m32 = mat[9];
+  let m33 = mat[10];
+
+  out_s[0] = Math.hypot(m11, m12, m13);
+  out_s[1] = Math.hypot(m21, m22, m23);
+  out_s[2] = Math.hypot(m31, m32, m33);
 
   let is1 = 1 / out_s[0];
   let is2 = 1 / out_s[1];
   let is3 = 1 / out_s[2];
 
-  let sm11 = mat[0] * is1;
-  let sm12 = mat[1] * is2;
-  let sm13 = mat[2] * is3;
-  let sm21 = mat[4] * is1;
-  let sm22 = mat[5] * is2;
-  let sm23 = mat[6] * is3;
-  let sm31 = mat[8] * is1;
-  let sm32 = mat[9] * is2;
-  let sm33 = mat[10] * is3;
+  let sm11 = m11 * is1;
+  let sm12 = m12 * is2;
+  let sm13 = m13 * is3;
+  let sm21 = m21 * is1;
+  let sm22 = m22 * is2;
+  let sm23 = m23 * is3;
+  let sm31 = m31 * is1;
+  let sm32 = m32 * is2;
+  let sm33 = m33 * is3;
 
   let trace = sm11 + sm22 + sm33;
   let S = 0;


### PR DESCRIPTION
closes #401 . I settled on returning only the rotation quaternion.

I added some tests which are basically copies of the other `getX` functions, but let me know if some are spurious or more are required.