### PR TITLE
Add mat4.perspectiveZO, mat4.orthoZO for WebGPU

### DIFF
--- a/src/mat4.js
+++ b/src/mat4.js
@@ -1525,6 +1525,8 @@ export function frustum(out, left, right, bottom, top, near, far) {
 
 /**
  * Generates a perspective projection matrix with the given bounds.
+ * The near/far clip planes correspond to a normalized device coordinate Z range of [-1, 1],
+ * which matches WebGL/OpenGL's clip volume.
  * Passing null/undefined/no value for far will generate infinite projection matrix.
  *
  * @param {mat4} out mat4 frustum matrix will be written into
@@ -1534,7 +1536,7 @@ export function frustum(out, left, right, bottom, top, near, far) {
  * @param {number} far Far bound of the frustum, can be null or Infinity
  * @returns {mat4} out
  */
-export function perspective(out, fovy, aspect, near, far) {
+export function perspectiveNO(out, fovy, aspect, near, far) {
   let f = 1.0 / Math.tan(fovy / 2),
     nf;
   out[0] = f / aspect;
@@ -1558,6 +1560,53 @@ export function perspective(out, fovy, aspect, near, far) {
   } else {
     out[10] = -1;
     out[14] = -2 * near;
+  }
+  return out;
+}
+
+/**
+ * Alias for {@link mat4.perspectiveNO}
+ * @function
+ */
+export const perspective = perspectiveNO;
+
+/**
+ * Generates a perspective projection matrix suitable for WebGPU with the given bounds.
+ * The near/far clip planes correspond to a normalized device coordinate Z range of [0, 1],
+ * which matches WebGPU/Vulkan/DirectX/Metal's clip volume.
+ * Passing null/undefined/no value for far will generate infinite projection matrix.
+ *
+ * @param {mat4} out mat4 frustum matrix will be written into
+ * @param {number} fovy Vertical field of view in radians
+ * @param {number} aspect Aspect ratio. typically viewport width/height
+ * @param {number} near Near bound of the frustum
+ * @param {number} far Far bound of the frustum, can be null or Infinity
+ * @returns {mat4} out
+ */
+export function perspectiveZO(out, fovy, aspect, near, far) {
+  let f = 1.0 / Math.tan(fovy / 2),
+    nf;
+  out[0] = f / aspect;
+  out[1] = 0;
+  out[2] = 0;
+  out[3] = 0;
+  out[4] = 0;
+  out[5] = f;
+  out[6] = 0;
+  out[7] = 0;
+  out[8] = 0;
+  out[9] = 0;
+  out[11] = -1;
+  out[12] = 0;
+  out[13] = 0;
+  out[15] = 0;
+  if (far != null && far !== Infinity) {
+    nf = 1 / (near - far);
+    out[10] = far * nf;
+    out[14] = far * near * nf;
+  } else {
+    out[10] = -1;
+    out[14] = -near;
   }
   return out;
 }

--- a/src/mat4.js
+++ b/src/mat4.js
@@ -1650,7 +1650,9 @@ export function perspectiveFromFieldOfView(out, fov, near, far) {
 }
 
 /**
- * Generates a orthogonal projection matrix with the given bounds
+ * Generates a orthogonal projection matrix with the given bounds.
+ * The near/far clip planes correspond to a normalized device coordinate Z range of [-1, 1],
+ * which matches WebGL/OpenGL's clip volume.
  *
  * @param {mat4} out mat4 frustum matrix will be written into
  * @param {number} left Left bound of the frustum
@@ -1661,7 +1663,7 @@ export function perspectiveFromFieldOfView(out, fov, near, far) {
  * @param {number} far Far bound of the frustum
  * @returns {mat4} out
  */
-export function ortho(out, left, right, bottom, top, near, far) {
+export function orthoNO(out, left, right, bottom, top, near, far) {
   let lr = 1 / (left - right);
   let bt = 1 / (bottom - top);
   let nf = 1 / (near - far);
@@ -1680,6 +1682,49 @@ export function ortho(out, left, right, bottom, top, near, far) {
   out[12] = (left + right) * lr;
   out[13] = (top + bottom) * bt;
   out[14] = (far + near) * nf;
+  out[15] = 1;
+  return out;
+}
+
+/**
+ * Alias for {@link mat4.orthoNO}
+ * @function
+ */
+export const ortho = orthoNO;
+
+/**
+ * Generates a orthogonal projection matrix with the given bounds.
+ * The near/far clip planes correspond to a normalized device coordinate Z range of [0, 1],
+ * which matches WebGPU/Vulkan/DirectX/Metal's clip volume.
+ *
+ * @param {mat4} out mat4 frustum matrix will be written into
+ * @param {number} left Left bound of the frustum
+ * @param {number} right Right bound of the frustum
+ * @param {number} bottom Bottom bound of the frustum
+ * @param {number} top Top bound of the frustum
+ * @param {number} near Near bound of the frustum
+ * @param {number} far Far bound of the frustum
+ * @returns {mat4} out
+ */
+export function orthoZO(out, left, right, bottom, top, near, far) {
+  let lr = 1 / (left - right);
+  let bt = 1 / (bottom - top);
+  let nf = 1 / (near - far);
+  out[0] = -2 * lr;
+  out[1] = 0;
+  out[2] = 0;
+  out[3] = 0;
+  out[4] = 0;
+  out[5] = -2 * bt;
+  out[6] = 0;
+  out[7] = 0;
+  out[8] = 0;
+  out[9] = 0;
+  out[10] = nf;
+  out[11] = 0;
+  out[12] = (left + right) * lr;
+  out[13] = (top + bottom) * bt;
+  out[14] = near * nf;
   out[15] = 1;
   return out;
 }

--- a/src/mat4.js
+++ b/src/mat4.js
@@ -1537,8 +1537,7 @@ export function frustum(out, left, right, bottom, top, near, far) {
  * @returns {mat4} out
  */
 export function perspectiveNO(out, fovy, aspect, near, far) {
-  let f = 1.0 / Math.tan(fovy / 2),
-    nf;
+  const f = 1.0 / Math.tan(fovy / 2);
   out[0] = f / aspect;
   out[1] = 0;
   out[2] = 0;
@@ -1554,7 +1553,7 @@ export function perspectiveNO(out, fovy, aspect, near, far) {
   out[13] = 0;
   out[15] = 0;
   if (far != null && far !== Infinity) {
-    nf = 1 / (near - far);
+    const nf = 1 / (near - far);
     out[10] = (far + near) * nf;
     out[14] = 2 * far * near * nf;
   } else {
@@ -1584,8 +1583,7 @@ export const perspective = perspectiveNO;
  * @returns {mat4} out
  */
 export function perspectiveZO(out, fovy, aspect, near, far) {
-  let f = 1.0 / Math.tan(fovy / 2),
-    nf;
+  const f = 1.0 / Math.tan(fovy / 2);
   out[0] = f / aspect;
   out[1] = 0;
   out[2] = 0;
@@ -1601,7 +1599,7 @@ export function perspectiveZO(out, fovy, aspect, near, far) {
   out[13] = 0;
   out[15] = 0;
   if (far != null && far !== Infinity) {
-    nf = 1 / (near - far);
+    const nf = 1 / (near - far);
     out[10] = far * nf;
     out[14] = far * near * nf;
   } else {
@@ -1664,9 +1662,9 @@ export function perspectiveFromFieldOfView(out, fov, near, far) {
  * @returns {mat4} out
  */
 export function orthoNO(out, left, right, bottom, top, near, far) {
-  let lr = 1 / (left - right);
-  let bt = 1 / (bottom - top);
-  let nf = 1 / (near - far);
+  const lr = 1 / (left - right);
+  const bt = 1 / (bottom - top);
+  const nf = 1 / (near - far);
   out[0] = -2 * lr;
   out[1] = 0;
   out[2] = 0;
@@ -1707,9 +1705,9 @@ export const ortho = orthoNO;
  * @returns {mat4} out
  */
 export function orthoZO(out, left, right, bottom, top, near, far) {
-  let lr = 1 / (left - right);
-  let bt = 1 / (bottom - top);
-  let nf = 1 / (near - far);
+  const lr = 1 / (left - right);
+  const bt = 1 / (bottom - top);
+  const nf = 1 / (near - far);
   out[0] = -2 * lr;
   out[1] = 0;
   out[2] = 0;


### PR DESCRIPTION
Putting this up as a pull request in case there's any feedback.

The upcoming WebGPU API uses Normalized Device Coordinates with a [0, 1] Z range, which differs from WebGL's [-1, 1] range. To get the best precision out of WebGPU pages will need to create perspective matrices a bit differently.

This change introduces the `mat4.perspectiveZO()`, which is identical in functionality to the previous `mat4.perspective()` method except it maps to the [0, -1] range. For consistency the previous method has been renamed to `mat4.perspectiveNO()` with an alias of `mat4.perspective()`. This could later allow users to configure the library to use one projection method or the other by default. Naming convention borrowed from the native [glm library](https://github.com/g-truc/glm) because I can't think of anything better that doesn't end up with 50 character long method names.