### PR TITLE
fix!: use dot product to compute quaternions equality

### DIFF
--- a/spec/gl-matrix/quat-spec.js
+++ b/spec/gl-matrix/quat-spec.js
@@ -776,20 +776,23 @@ describe("quat", function() {
     });
 
     describe("equals", function() {
-        let quatC, quatD, r0, r1, r2;
+        let quatC, quatD, quatE, r0, r1, r2, r3;
         beforeEach(function() {
-            quatA = [0, 1, 2, 3];
-            quatB = [0, 1, 2, 3];
-            quatC = [1, 2, 3, 4];
+            quatA = [0, 0, 0, 1];
+            quatB = [0, 0, 0, 1];
+            quatC = [0, 1, 0, 0];
             quatD = [1e-16, 1, 2, 3];
+            quatE = [0, -1, 0, 0];
             r0 = quat.equals(quatA, quatB);
             r1 = quat.equals(quatA, quatC);
             r2 = quat.equals(quatA, quatD);
+            r3 = quat.equals(quatC, quatE);
         });
         it("should return true for identical quaternions", function() { expect(r0).toBe(true); });
         it("should return false for different quaternions", function() { expect(r1).toBe(false); });
         it("should return true for close but not identical quaternions", function() { expect(r2).toBe(true); });
-        it("should not modify quatA", function() { expect(quatA).toBeEqualish([0, 1, 2, 3]); });
-        it("should not modify quatB", function() { expect(quatB).toBeEqualish([0, 1, 2, 3]); });
+        it("should return true for identical quaternions with flipped orientation", function() { expect(r3).toBe(true); });
+        it("should not modify quatA", function() { expect(quatA).toBeEqualish([0, 0, 0, 1]); });
+        it("should not modify quatB", function() { expect(quatB).toBeEqualish([0, 0, 0, 1]); });
     });
 });

--- a/src/quat.js
+++ b/src/quat.js
@@ -513,7 +513,7 @@ export function fromEuler(out, x, y, z, order = glMatrix.ANGLE_ORDER) {
       out[3] = cx * cy * cz + sx * sy * sz;
       break;
 
-    default: 
+    default:
       throw new Error('Unknown angle order ' + order);
   }
 
@@ -673,13 +673,17 @@ export const normalize = vec4.normalize;
 export const exactEquals = vec4.exactEquals;
 
 /**
- * Returns whether or not the quaternions have approximately the same elements in the same position.
+ * Returns whether or not the quaternions point approximately to the same direction.
  *
- * @param {ReadonlyQuat} a The first vector.
- * @param {ReadonlyQuat} b The second vector.
- * @returns {Boolean} True if the vectors are equal, false otherwise.
+ * Both quaternions are assumed to be unit length.
+ *
+ * @param {ReadonlyQuat} a The first unit quaternion.
+ * @param {ReadonlyQuat} b The second unit quaternion.
+ * @returns {Boolean} True if the quaternions are equal, false otherwise.
  */
-export const equals = vec4.equals;
+export function equals(a, b) {
+    return Math.abs(vec4.dot(a, b)) >= 1 - glMatrix.EPSILON;
+}
 
 /**
  * Sets a quaternion to represent the shortest rotation from one


### PR DESCRIPTION
The old method for quaternions equality returns false with flipped orientation (eg [0, 0, 0, 1] and [0, 0, 0, -1])
This pull request uses dot product instead, assuming quaternions are unit length

It is breaking change because old checks for equality when quaternions are not unit length won't work anymore

fixes #292 