### PR TITLE
Update mat4.js.html

### DIFF
--- a/docs/mat4.js.html
+++ b/docs/mat4.js.html
@@ -1215,7 +1215,7 @@ export function getTranslation(out, mat) {
 /**
  * Returns the scaling factor component of a transformation
  *  matrix. If a matrix is built with fromRotationTranslationScale
- *  with a normalized Quaternion paramter, the returned vector will be
+ *  with a normalized Quaternion parameter, the returned vector will be
  *  the same as the scaling vector
  *  originally supplied.
  * @param  {vec3} out Vector to receive scaling factor component


### PR DESCRIPTION
https://glmatrix.net/docs/module-mat4.html#.getScaling
Changes 'paramter' to 'parameter'.
There is no useful functionality. This is just a spelling mistake in the docs. 