### PR TITLE
random should only return unit vector when scale is undefined

### DIFF
--- a/spec/gl-matrix/vec2-spec.js
+++ b/spec/gl-matrix/vec2-spec.js
@@ -433,7 +433,14 @@ describe("vec2", function() {
         describe("with a scale", function() {
             beforeEach(function() { result = vec2.random(out, 5.0); });
 
-            it("should result in a unit length vector", function() { expect(vec2.len(out)).toBeEqualish(5.0); });
+            it("should result in a vector of correct length", function() { expect(vec2.len(out)).toBeEqualish(5.0); });
+            it("should return out", function() { expect(result).toBe(out); });
+        });
+
+        describe("with a scale of zero", function() {
+            beforeEach(function() { result = vec2.random(out, 0); });
+
+            it("should result in a zero vector", function() { expect(vec2.len(out)).toBeEqualish(0); });
             it("should return out", function() { expect(result).toBe(out); });
         });
     });

--- a/spec/gl-matrix/vec3-spec.js
+++ b/spec/gl-matrix/vec3-spec.js
@@ -602,7 +602,14 @@ describe("vec3", function() {
         describe("with a scale", function() {
             beforeEach(function() { result = vec3.random(out, 5.0); });
 
-            it("should result in a unit length vector", function() { expect(vec3.len(out)).toBeEqualish(5.0); });
+            it("should result in a vector of correct length", function() { expect(vec3.len(out)).toBeEqualish(5.0); });
+            it("should return out", function() { expect(result).toBe(out); });
+        });
+
+        describe("with a scale of zero", function() {
+            beforeEach(function() { result = vec3.random(out, 0); });
+
+            it("should result in a zero vector", function() { expect(vec3.len(out)).toBeEqualish(0); });
             it("should return out", function() { expect(result).toBe(out); });
         });
     });

--- a/spec/gl-matrix/vec4-spec.js
+++ b/spec/gl-matrix/vec4-spec.js
@@ -420,7 +420,14 @@ describe("vec4", function() {
         describe("with a scale", function() {
             beforeEach(function() { result = vec4.random(out, 5.0); });
 
-            it("should result in a unit length vector", function() { expect(vec4.len(out)).toBeEqualish(5.0); });
+            it("should result in a vector of correct length", function() { expect(vec4.len(out)).toBeEqualish(5.0); });
+            it("should return out", function() { expect(result).toBe(out); });
+        });
+
+        describe("with a scale of zero", function() {
+            beforeEach(function() { result = vec4.random(out, 0); });
+
+            it("should result in a zero vector", function() { expect(vec4.len(out)).toBeEqualish(0); });
             it("should return out", function() { expect(result).toBe(out); });
         });
     });

--- a/src/vec2.js
+++ b/src/vec2.js
@@ -373,7 +373,7 @@ export function lerp(out, a, b, t) {
  * @returns {vec2} out
  */
 export function random(out, scale) {
-  scale = scale || 1.0;
+  scale = scale === undefined ? 1.0 : scale;
   var r = glMatrix.RANDOM() * 2.0 * Math.PI;
   out[0] = Math.cos(r) * scale;
   out[1] = Math.sin(r) * scale;

--- a/src/vec3.js
+++ b/src/vec3.js
@@ -481,7 +481,7 @@ export function bezier(out, a, b, c, d, t) {
  * @returns {vec3} out
  */
 export function random(out, scale) {
-  scale = scale || 1.0;
+  scale = scale === undefined ? 1.0 : scale;
 
   let r = glMatrix.RANDOM() * 2.0 * Math.PI;
   let z = glMatrix.RANDOM() * 2.0 - 1.0;

--- a/src/vec4.js
+++ b/src/vec4.js
@@ -441,7 +441,7 @@ export function lerp(out, a, b, t) {
  * @returns {vec4} out
  */
 export function random(out, scale) {
-  scale = scale || 1.0;
+  scale = scale === undefined ? 1.0 : scale;
 
   // Marsaglia, George. Choosing a Point from the Surface of a
   // Sphere. Ann. Math. Statist. 43 (1972), no. 2, 645--646.


### PR DESCRIPTION
I encountered unexpected behaviour when passing dynamic values to the `scale` parameter of `vec2.random`.

calling `random(vec, 0)` should return a vector of length `0`, not `1`.