### PR TITLE
Replace Math.hypot with Math.sqrt

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -55,11 +55,3 @@ export function toRadian(a) {
 export function equals(a, b) {
   return Math.abs(a - b) <= EPSILON * Math.max(1.0, Math.abs(a), Math.abs(b));
 }
-
-if (!Math.hypot)
-  Math.hypot = function () {
-    var y = 0,
-      i = arguments.length;
-    while (i--) y += arguments[i] * arguments[i];
-    return Math.sqrt(y);
-  };

--- a/src/mat2.js
+++ b/src/mat2.js
@@ -307,7 +307,7 @@ export function str(a) {
  * @returns {Number} Frobenius norm
  */
 export function frob(a) {
-  return Math.hypot(a[0], a[1], a[2], a[3]);
+  return Math.sqrt(a[0] * a[0] + a[1] * a[1] + a[2] * a[2] + a[3] * a[3]);
 }
 
 /**

--- a/src/mat2d.js
+++ b/src/mat2d.js
@@ -375,7 +375,7 @@ export function str(a) {
  * @returns {Number} Frobenius norm
  */
 export function frob(a) {
-  return Math.hypot(a[0], a[1], a[2], a[3], a[4], a[5], 1);
+  return Math.sqrt(a[0] * a[0] + a[1] * a[1] + a[2] * a[2] + a[3] * a[3] + a[4] * a[4] + a[5] * a[5] + 1);
 }
 
 /**

--- a/src/mat3.js
+++ b/src/mat3.js
@@ -694,7 +694,17 @@ export function str(a) {
  * @returns {Number} Frobenius norm
  */
 export function frob(a) {
-  return Math.hypot(a[0], a[1], a[2], a[3], a[4], a[5], a[6], a[7], a[8]);
+  return Math.sqrt(
+    a[0] * a[0] +
+    a[1] * a[1] +
+    a[2] * a[2] +
+    a[3] * a[3] +
+    a[4] * a[4] +
+    a[5] * a[5] +
+    a[6] * a[6] +
+    a[7] * a[7] +
+    a[8] * a[8]
+  );
 }
 
 /**

--- a/src/mat4.js
+++ b/src/mat4.js
@@ -613,7 +613,7 @@ export function rotate(out, a, rad, axis) {
   let x = axis[0],
     y = axis[1],
     z = axis[2];
-  let len = Math.hypot(x, y, z);
+  let len = Math.sqrt(x * x + y * y + z * z);
   let s, c, t;
   let a00, a01, a02, a03;
   let a10, a11, a12, a13;
@@ -893,7 +893,7 @@ export function fromRotation(out, rad, axis) {
   let x = axis[0],
     y = axis[1],
     z = axis[2];
-  let len = Math.hypot(x, y, z);
+  let len = Math.sqrt(x * x + y * y + z * z);
   let s, c, t;
 
   if (len < glMatrix.EPSILON) {
@@ -1160,9 +1160,9 @@ export function getScaling(out, mat) {
   let m32 = mat[9];
   let m33 = mat[10];
 
-  out[0] = Math.hypot(m11, m12, m13);
-  out[1] = Math.hypot(m21, m22, m23);
-  out[2] = Math.hypot(m31, m32, m33);
+  out[0] = Math.sqrt(m11 * m11 + m12 * m12 + m13 * m13);
+  out[1] = Math.sqrt(m21 * m21 + m22 * m22 + m23 * m23);
+  out[2] = Math.sqrt(m31 * m31 + m32 * m32 + m33 * m33);
 
   return out;
 }
@@ -1250,9 +1250,9 @@ export function decompose(out_r, out_t, out_s, mat) {
   let m32 = mat[9];
   let m33 = mat[10];
 
-  out_s[0] = Math.hypot(m11, m12, m13);
-  out_s[1] = Math.hypot(m21, m22, m23);
-  out_s[2] = Math.hypot(m31, m32, m33);
+  out_s[0] = Math.sqrt(m11 * m11 + m12 * m12 + m13 * m13);
+  out_s[1] = Math.sqrt(m21 * m21 + m22 * m22 + m23 * m23);
+  out_s[2] = Math.sqrt(m31 * m31 + m32 * m32 + m33 * m33);
 
   let is1 = 1 / out_s[0];
   let is2 = 1 / out_s[1];
@@ -1761,7 +1761,7 @@ export function lookAt(out, eye, center, up) {
   z1 = eyey - centery;
   z2 = eyez - centerz;
 
-  len = 1 / Math.hypot(z0, z1, z2);
+  len = 1 / Math.sqrt(z0 * z0 + z1 * z1 + z2 * z2);
   z0 *= len;
   z1 *= len;
   z2 *= len;
@@ -1769,7 +1769,7 @@ export function lookAt(out, eye, center, up) {
   x0 = upy * z2 - upz * z1;
   x1 = upz * z0 - upx * z2;
   x2 = upx * z1 - upy * z0;
-  len = Math.hypot(x0, x1, x2);
+  len = Math.sqrt(x0 * x0 + x1 * x1 + x2 * x2);
   if (!len) {
     x0 = 0;
     x1 = 0;
@@ -1785,7 +1785,7 @@ export function lookAt(out, eye, center, up) {
   y1 = z2 * x0 - z0 * x2;
   y2 = z0 * x1 - z1 * x0;
 
-  len = Math.hypot(y0, y1, y2);
+  len = Math.sqrt(y0 * y0 + y1 * y1 + y2 * y2);
   if (!len) {
     y0 = 0;
     y1 = 0;
@@ -1928,23 +1928,23 @@ export function str(a) {
  * @returns {Number} Frobenius norm
  */
 export function frob(a) {
-  return Math.hypot(
-    a[0],
-    a[1],
-    a[2],
-    a[3],
-    a[4],
-    a[5],
-    a[6],
-    a[7],
-    a[8],
-    a[9],
-    a[10],
-    a[11],
-    a[12],
-    a[13],
-    a[14],
-    a[15]
+  return Math.sqrt(
+    a[0] * a[0] +
+    a[1] * a[1] +
+    a[2] * a[2] +
+    a[3] * a[3] +
+    a[4] * a[4] +
+    a[5] * a[5] +
+    a[6] * a[6] +
+    a[7] * a[7] +
+    a[8] * a[8] +
+    a[9] * a[9] +
+    a[10] * a[10] +
+    a[11] * a[11] +
+    a[12] * a[12] +
+    a[13] * a[13] +
+    a[14] * a[14] +
+    a[15] * a[15]
   );
 }
 

--- a/src/quat2.js
+++ b/src/quat2.js
@@ -537,7 +537,7 @@ export function rotateAroundAxis(out, a, axis, rad) {
   if (Math.abs(rad) < glMatrix.EPSILON) {
     return copy(out, a);
   }
-  let axisLength = Math.hypot(axis[0], axis[1], axis[2]);
+  let axisLength = Math.sqrt(axis[0] * axis[0] + axis[1] * axis[1] + axis[2] * axis[2]);
 
   rad = rad * 0.5;
   let s = Math.sin(rad);

--- a/src/vec2.js
+++ b/src/vec2.js
@@ -235,7 +235,7 @@ export function scaleAndAdd(out, a, b, scale) {
 export function distance(a, b) {
   var x = b[0] - a[0],
     y = b[1] - a[1];
-  return Math.hypot(x, y);
+  return Math.sqrt(x * x + y * y);
 }
 
 /**
@@ -260,7 +260,7 @@ export function squaredDistance(a, b) {
 export function length(a) {
   var x = a[0],
     y = a[1];
-  return Math.hypot(x, y);
+  return Math.sqrt(x * x + y * y);
 }
 
 /**

--- a/src/vec3.js
+++ b/src/vec3.js
@@ -44,7 +44,7 @@ export function length(a) {
   let x = a[0];
   let y = a[1];
   let z = a[2];
-  return Math.hypot(x, y, z);
+  return Math.sqrt(x * x + y * y + z * z);
 }
 
 /**
@@ -267,7 +267,7 @@ export function distance(a, b) {
   let x = b[0] - a[0];
   let y = b[1] - a[1];
   let z = b[2] - a[2];
-  return Math.hypot(x, y, z);
+  return Math.sqrt(x * x + y * y + z * z);
 }
 
 /**

--- a/src/vec4.js
+++ b/src/vec4.js
@@ -273,7 +273,7 @@ export function distance(a, b) {
   let y = b[1] - a[1];
   let z = b[2] - a[2];
   let w = b[3] - a[3];
-  return Math.hypot(x, y, z, w);
+  return Math.sqrt(x * x + y * y + z * z + w * w);
 }
 
 /**
@@ -302,7 +302,7 @@ export function length(a) {
   let y = a[1];
   let z = a[2];
   let w = a[3];
-  return Math.hypot(x, y, z, w);
+  return Math.sqrt(x * x + y * y + z * z + w * w);
 }
 
 /**


### PR DESCRIPTION
Fixes #446 

This PR replaces all instances of `Math.hypot` with `Math.sqrt`. It also removes the polyfill for hypot on really old browsers.

The reason is that `sqrt` is MUCH faster than `hypot` on all modern javascript engines. See #446 for some benchmarks.

While hypot is nicer to write, and is technically more accurate especially for very large and very small numbers, I think that the performance gains from switching to `sqrt` are worth it. Especially for a library with the goal:

> glMatrix is designed to perform vector and matrix operations stupidly fast!

Suggestions and feedback appreciated.