### PR TITLE
Improve the Performance of `vec4.random`

### DIFF
--- a/src/vec4.js
+++ b/src/vec4.js
@@ -448,16 +448,17 @@ export function random(out, scale) {
   // http://projecteuclid.org/euclid.aoms/1177692644;
   var v1, v2, v3, v4;
   var s1, s2;
-  do {
-    v1 = glMatrix.RANDOM() * 2 - 1;
-    v2 = glMatrix.RANDOM() * 2 - 1;
-    s1 = v1 * v1 + v2 * v2;
-  } while (s1 >= 1);
-  do {
-    v3 = glMatrix.RANDOM() * 2 - 1;
-    v4 = glMatrix.RANDOM() * 2 - 1;
-    s2 = v3 * v3 + v4 * v4;
-  } while (s2 >= 1);
+  var rand;
+  
+  rand = glMatrix.RANDOM();
+  v1 = rand * 2 - 1;
+  v2 = (4 * glMatrix.RANDOM() - 2) * Math.sqrt(rand * -rand + rand);
+  s1 = v1 * v1 + v2 * v2;
+
+  rand = glMatrix.RANDOM();
+  v3 = rand * 2 - 1;
+  v4 = (4 * glMatrix.RANDOM() - 2) * Math.sqrt(rand * -rand + rand);
+  s2 = v3 * v3 + v4 * v4;
 
   var d = Math.sqrt((1 - s1) / s2);
   out[0] = scale * v1;


### PR DESCRIPTION
This pull request improves the performance of calculating `vec4.random`. See the benchmark [here](https://jsperf.app/yosado/3).

The old solution used a `while` loop to recalculate until `s1 <= 1` and `s2 <= 1`. This solution instead sets minimum and maximum values for `v2` and `v4` based on the values of `v1` and `v3`, respectively, using the standard formula `random * (max - min) + min`.

## Explanation of the Math

Let `v` be `v1` or `v3`. `a` is the random value in the range `[0,1]` that is used to calculate `v`. That is:

```ts
const a: number = Math.random();
const v: number = a * 2 - 1;
```

Let `w` be `v2` or `v4`. `b` is the random value in the range `[min,max]` that is used to calculate `w`. That is:

```ts
const b: number = Math.random() * (max - min) + min;
const w: number = b * 2 - 1;
```

Let `s` be `s1` or `s2`. That is:

```ts
const s: number = v * v + w * w;
```

In terms of `a` and `b`, that is:

```ts
const s: number = (a * 2 - 1) ** 2 + (b * 2 - 1) ** 2;
```

Setting `s <= 1` and `0 <= a <= 1`, we can calculate `max` and `min` as follows:

```ts
const halfRange: number = Math.sqrt(a * -a + a);
const min: number = 1 / 2 - halfRange;
const max: number = 1 / 2 + halfRange;
```

Finally, plugging that back in to the formula for `w`, we can simplify to the following:

```ts
const w: number = (4 * Math.random() - 2) * Math.sqrt(a * -a + a);
```
