### PR TITLE
Align docs with parameters names

### DIFF
--- a/src/mat4.js
+++ b/src/mat4.js
@@ -1822,7 +1822,7 @@ export function lookAt(out, eye, center, up) {
  *
  * @param {mat4} out mat4 frustum matrix will be written into
  * @param {ReadonlyVec3} eye Position of the viewer
- * @param {ReadonlyVec3} center Point the viewer is looking at
+ * @param {ReadonlyVec3} target Point the viewer is looking at
  * @param {ReadonlyVec3} up vec3 pointing up
  * @returns {mat4} out
  */

--- a/src/vec4.js
+++ b/src/vec4.js
@@ -386,10 +386,10 @@ export function dot(a, b) {
 /**
  * Returns the cross-product of three vectors in a 4-dimensional space
  *
- * @param {ReadonlyVec4} result the receiving vector
- * @param {ReadonlyVec4} U the first vector
- * @param {ReadonlyVec4} V the second vector
- * @param {ReadonlyVec4} W the third vector
+ * @param {ReadonlyVec4} out the receiving vector
+ * @param {ReadonlyVec4} u the first vector
+ * @param {ReadonlyVec4} v the second vector
+ * @param {ReadonlyVec4} w the third vector
  * @returns {vec4} result
  */
 export function cross(out, u, v, w) {


### PR DESCRIPTION
This is to align parameters names to comments.

I'm using typedoc which complains about misalignment between docs comments and actual code.
I've fixed what it found (although the version I'm using is not from latest code).
Regardless, these fixes are correct.

It would be great if you could also release a new version after merging this.
Thanks!