### PR TITLE
Fix return types of matrix invert functions

### DIFF
--- a/spec/gl-matrix/mat2-spec.js
+++ b/spec/gl-matrix/mat2-spec.js
@@ -1,7 +1,7 @@
 import * as mat2 from "../../src/mat2.js"
 
 describe("mat2", function() {
-    let out, matA, matB, identity, result;
+    let out, matA, matB, identity, nonInvertible, result;
 
     beforeEach(function() {
         matA = [1, 2,
@@ -12,6 +12,9 @@ describe("mat2", function() {
 
         out =  [0, 0,
                 0, 0];
+
+        nonInvertible = [1, 0,
+                         1, 0];
 
         identity = [1, 0,
                     0, 1];
@@ -70,6 +73,12 @@ describe("mat2", function() {
 
             it("should place values into matA", function() { expect(matA).toBeEqualish([-2, 1, 1.5, -0.5]); });
             it("should return matA", function() { expect(result).toBe(matA); });
+        });
+
+        describe("when matrix is not invertible", function() {
+            beforeEach(function() { result = mat2.invert(out, nonInvertible); });
+
+            it("should return null", function() { expect(result).toBe(null); });
         });
     });
 

--- a/spec/gl-matrix/mat2d-spec.js
+++ b/spec/gl-matrix/mat2d-spec.js
@@ -1,7 +1,7 @@
 import * as mat2d from "../../src/mat2d.js"
 
 describe("mat2d", function() {
-    let out, matA, matB, oldA, oldB, identity, result;
+    let out, matA, matB, oldA, oldB, identity, nonInvertible, result;
 
     beforeEach(function() {
         matA = [1, 2,
@@ -27,6 +27,10 @@ describe("mat2d", function() {
         identity = [1, 0,
                     0, 1,
                     0, 0];
+
+        nonInvertible = [1, 0,
+                         1, 0,
+                         1, 0];
     });
 
     describe("create", function() {
@@ -65,6 +69,12 @@ describe("mat2d", function() {
 
             it("should place values into matA", function() { expect(matA).toBeEqualish([ -2, 1, 1.5, -0.5, 1, -2 ]); });
             it("should return matA", function() { expect(result).toBe(matA); });
+        });
+
+        describe("when matrix is not invertible", function() {
+            beforeEach(function() { result = mat2d.invert(out, nonInvertible); });
+
+            it("should return null", function() { expect(result).toBe(null); });
         });
     });
 

--- a/spec/gl-matrix/mat3-spec.js
+++ b/spec/gl-matrix/mat3-spec.js
@@ -3,7 +3,7 @@ import * as mat4 from "../../src/mat4.js"
 import * as vec3 from "../../src/vec3.js"
 
 describe("mat3", function() {
-    let out, matA, matB, identity, result;
+    let out, matA, matB, identity, nonInvertible, result;
 
     beforeEach(function() {
         matA = [1, 0, 0,
@@ -21,6 +21,10 @@ describe("mat3", function() {
         identity = [1, 0, 0,
                     0, 1, 0,
                     0, 0, 1];
+
+        nonInvertible = [1, 2, 3,
+                         1, 2, 3,
+                         1, 2, 3];
     });
 
     describe("normalFromMat4", function() {
@@ -198,6 +202,12 @@ describe("mat3", function() {
                 ]);
             });
             it("should return matA", function() { expect(result).toBe(matA); });
+        });
+
+        describe("when matrix is not invertible", function() {
+            beforeEach(function() { result = mat3.invert(out, nonInvertible); });
+
+            it("should return null", function() { expect(result).toBe(null); });
         });
     });
 

--- a/spec/gl-matrix/mat4-spec.js
+++ b/spec/gl-matrix/mat4-spec.js
@@ -5,7 +5,7 @@ import * as vec3 from "../../src/vec3.js"
 
 function buildMat4Tests() {
     return function() {
-        let out, matA, matB, identity, result;
+        let out, matA, matB, identity, nonInvertible, result;
 
         beforeEach(function() {
             // Attempting to portray a semi-realistic transform matrix
@@ -28,6 +28,11 @@ function buildMat4Tests() {
                                          0, 1, 0, 0,
                                          0, 0, 1, 0,
                                          0, 0, 0, 1]);
+
+            nonInvertible = new Float32Array([1, 2, 3, 4,
+                                              1, 2, 3, 4,
+                                              1, 2, 3, 4,
+                                              1, 2, 3, 4]);
         });
 
         describe("create", function() {
@@ -125,6 +130,12 @@ function buildMat4Tests() {
                     ]);
                 });
                 it("should return matA", function() { expect(result).toBe(matA); });
+            });
+
+            describe("when matrix is not invertible", function() {
+                beforeEach(function() { result = mat4.invert(out, nonInvertible); });
+
+                it("should return null", function() { expect(result).toBe(null); });
             });
         });
 

--- a/src/mat2.js
+++ b/src/mat2.js
@@ -130,7 +130,7 @@ export function transpose(out, a) {
  *
  * @param {mat2} out the receiving matrix
  * @param {ReadonlyMat2} a the source matrix
- * @returns {mat2} out
+ * @returns {mat2 | null} out, or null if source matrix is not invertible
  */
 export function invert(out, a) {
   let a0 = a[0],

--- a/src/mat2d.js
+++ b/src/mat2d.js
@@ -136,7 +136,7 @@ export function set(out, a, b, c, d, tx, ty) {
  *
  * @param {mat2d} out the receiving matrix
  * @param {ReadonlyMat2d} a the source matrix
- * @returns {mat2d} out
+ * @returns {mat2d | null} out, or null if source matrix is not invertible
  */
 export function invert(out, a) {
   let aa = a[0],

--- a/src/mat3.js
+++ b/src/mat3.js
@@ -200,7 +200,7 @@ export function transpose(out, a) {
  *
  * @param {mat3} out the receiving matrix
  * @param {ReadonlyMat3} a the source matrix
- * @returns {mat3} out
+ * @returns {mat3 | null} out, or null if source matrix is not invertible
  */
 export function invert(out, a) {
   let a00 = a[0],

--- a/src/mat4.js
+++ b/src/mat4.js
@@ -288,7 +288,7 @@ export function transpose(out, a) {
  *
  * @param {mat4} out the receiving matrix
  * @param {ReadonlyMat4} a the source matrix
- * @returns {mat4} out
+ * @returns {mat4 | null} out, or null if source matrix is not invertible
  */
 export function invert(out, a) {
   let a00 = a[0],


### PR DESCRIPTION
Fix return types of matrix `invert()` functions to allow `null`.

Fixing the return type is important because it lets us catch errors in TypeScript before we ship them to customers.