### PR TITLE
Run tests on push using GitHub Actions

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,0 +1,16 @@
+name: Push
+on:
+  push:
+    branches: "*"
+
+jobs:
+  tests:
+    name: Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+      - run: npm ci
+      - run: npm test


### PR DESCRIPTION
Following up on toji/gl-matrix#480, this adds a basic CI pipeline to the repository which runs tests on all branch pushes. A small change, but hopefully helpful :)

An example run is here, it should stick around for another week or two: https://github.com/hughsk-canva/gl-matrix/actions/runs/12759586150/job/35563603100

<img width="1164" alt="Screenshot 2025-01-14 at 13 09 45" src="https://github.com/user-attachments/assets/959f776e-f1e7-4baf-a90c-69f40571b601" />
