### PR TITLE
[glmatrix-next] Allow undefined as argument to class constructors

### DIFF
--- a/src/mat2.ts
+++ b/src/mat2.ts
@@ -27,7 +27,7 @@ export class Mat2 extends Float32Array {
   /**
    * Create a {@link Mat2}.
    */
-  constructor(...values: [Readonly<Mat2Like> | ArrayBufferLike, number?] | number[] ) {
+  constructor(...values: [Readonly<Mat2Like> | ArrayBufferLike, number?] | number[] | [undefined]) {
     switch(values.length) {
       case 4:
         super(values); break;
@@ -35,7 +35,9 @@ export class Mat2 extends Float32Array {
         super(values[0] as ArrayBufferLike, values[1], 4); break;
       case 1:
         const v = values[0];
-        if (typeof v === 'number') {
+        if (v === undefined) {
+          super(IDENTITY_2X2);
+        } else if (typeof v === 'number') {
           super([
             v, v,
             v, v]);

--- a/src/mat2d.ts
+++ b/src/mat2d.ts
@@ -29,7 +29,7 @@ export class Mat2d extends Float32Array {
   /**
    * Create a {@link Mat2}.
    */
-  constructor(...values: [Readonly<Mat2dLike> | ArrayBufferLike, number?] | number[] ) {
+  constructor(...values: [Readonly<Mat2dLike> | ArrayBufferLike, number?] | number[] | [undefined]) {
     switch(values.length) {
       case 6:
         super(values); break;
@@ -37,7 +37,9 @@ export class Mat2d extends Float32Array {
         super(values[0] as ArrayBufferLike, values[1], 6); break;
       case 1:
         const v = values[0];
-        if (typeof v === 'number') {
+        if (v === undefined) {
+          super(IDENTITY_2X3);
+        } else if (typeof v === 'number') {
           super([
             v, v,
             v, v,

--- a/src/mat3.ts
+++ b/src/mat3.ts
@@ -32,7 +32,7 @@ export class Mat3 extends Float32Array {
   /**
    * Create a {@link Mat3}.
    */
-  constructor(...values: [Readonly<Mat3Like> | ArrayBufferLike, number?] | number[] ) {
+  constructor(...values: [Readonly<Mat3Like> | ArrayBufferLike, number?] | number[] | [undefined]) {
     switch(values.length) {
       case 9:
         super(values); break;
@@ -40,7 +40,9 @@ export class Mat3 extends Float32Array {
         super(values[0] as ArrayBufferLike, values[1], 9); break;
       case 1:
         const v = values[0];
-        if (typeof v === 'number') {
+        if (v === undefined) {
+          super(IDENTITY_3X3);
+        } else if (typeof v === 'number') {
           super([
             v, v, v,
             v, v, v,

--- a/src/mat4.ts
+++ b/src/mat4.ts
@@ -33,7 +33,7 @@ export class Mat4 extends Float32Array {
   /**
    * Create a {@link Mat4}.
    */
-  constructor(...values: [Readonly<Mat4Like> | ArrayBufferLike, number?] | number[] ) {
+  constructor(...values: [Readonly<Mat4Like> | ArrayBufferLike, number?] | number[] | [undefined]) {
     switch(values.length) {
       case 16:
         super(values); break;
@@ -41,7 +41,9 @@ export class Mat4 extends Float32Array {
         super(values[0] as ArrayBufferLike, values[1], 16); break;
       case 1:
         const v = values[0];
-        if (typeof v === 'number') {
+        if (v === undefined) {
+          super(IDENTITY_4X4);
+        } else if (typeof v === 'number') {
           super([
             v, v, v, v,
             v, v, v, v,

--- a/src/quat.ts
+++ b/src/quat.ts
@@ -9,6 +9,10 @@ import { Vec4, Vec4Like } from './vec4.js';
  */
 export type QuatLike = Vec4Like;
 
+const IDENTITY_QUAT = new Float32Array([
+  0, 0, 0, 1
+]);
+
 /**
  * Quaternion
  */
@@ -21,7 +25,7 @@ export class Quat extends Float32Array {
   /**
    * Create a {@link Quat}.
    */
-   constructor(...values: [Readonly<QuatLike> | ArrayBufferLike, number?] | number[]) {
+  constructor(...values: [Readonly<QuatLike> | ArrayBufferLike, number?] | number[] | [undefined]) {
     switch(values.length) {
       case 4:
         super(values); break;
@@ -29,7 +33,9 @@ export class Quat extends Float32Array {
         super(values[0] as ArrayBufferLike, values[1], 4); break;
       case 1: {
         const v = values[0];
-        if (typeof v === 'number') {
+        if (v === undefined) {
+          super(IDENTITY_QUAT);
+        } else if (typeof v === 'number') {
           super([v, v, v, v]);
         } else {
           super(v as ArrayBufferLike, 0, 4);
@@ -37,8 +43,7 @@ export class Quat extends Float32Array {
         break;
       }
       default:
-        super(4);
-        this[3] = 1;
+        super(IDENTITY_QUAT);
         break;
     }
   }
@@ -128,10 +133,7 @@ export class Quat extends Float32Array {
    * @returns `this`
    */
   identity(): Quat {
-    this[0] = 0;
-    this[1] = 0;
-    this[2] = 0;
-    this[3] = 1;
+    this.set(IDENTITY_QUAT);
     return this;
   }
 

--- a/src/quat2.ts
+++ b/src/quat2.ts
@@ -12,6 +12,11 @@ export type Quat2Like = [
   number, number, number, number
 ] | FloatArray;
 
+const IDENTITY_QUAT2 = new Float32Array([
+  0, 0, 0, 1,
+  0, 0, 0, 0
+]);
+
 /**
  * Dual Quaternion
  */
@@ -24,7 +29,7 @@ export class Quat2 extends Float32Array {
   /**
    * Create a {@link Quat2}.
    */
-   constructor(...values: [Readonly<Quat2Like> | ArrayBufferLike, number?] | number[]) {
+  constructor(...values: [Readonly<Quat2Like> | ArrayBufferLike, number?] | number[] | [undefined]) {
     switch(values.length) {
       case 8:
         super(values); break;
@@ -32,7 +37,9 @@ export class Quat2 extends Float32Array {
         super(values[0] as ArrayBufferLike, values[1], 8); break;
       case 1: {
         const v = values[0];
-        if (typeof v === 'number') {
+        if (v === undefined) {
+          super(IDENTITY_QUAT2);
+        } else if (typeof v === 'number') {
           super([v, v, v, v, v, v, v, v]);
         } else {
           super(v as ArrayBufferLike, 0, 8);
@@ -40,8 +47,7 @@ export class Quat2 extends Float32Array {
         break;
       }
       default:
-        super(8);
-        this[3] = 1;
+        super(IDENTITY_QUAT2);
         break;
     }
   }

--- a/src/vec2.ts
+++ b/src/vec2.ts
@@ -22,7 +22,7 @@ export class Vec2 extends Float32Array {
   /**
    * Create a {@link Vec2}.
    */
-   constructor(...values: [Readonly<Vec2Like> | ArrayBufferLike, number?] | number[]) {
+  constructor(...values: [Readonly<Vec2Like> | ArrayBufferLike, number?] | number[] | [undefined]) {
     switch(values.length) {
       case 2:{
         const v = values[0];
@@ -35,7 +35,9 @@ export class Vec2 extends Float32Array {
       }
       case 1: {
         const v = values[0];
-        if (typeof v === 'number') {
+        if (v === undefined) {
+          super(2);
+        } else if (typeof v === 'number') {
           super([v, v]);
         } else {
           super(v as ArrayBufferLike, 0, 2);

--- a/src/vec3.ts
+++ b/src/vec3.ts
@@ -21,7 +21,7 @@ export class Vec3 extends Float32Array {
   /**
   * Create a {@link Vec3}.
   */
-  constructor(...values: [Readonly<Vec3Like> | ArrayBufferLike, number?] | number[]) {
+  constructor(...values: [Readonly<Vec3Like> | ArrayBufferLike, number?] | number[] | [undefined]) {
     switch(values.length) {
       case 3:
         super(values); break;
@@ -29,7 +29,9 @@ export class Vec3 extends Float32Array {
         super(values[0] as ArrayBufferLike, values[1], 3); break;
       case 1: {
         const v = values[0];
-        if (typeof v === 'number') {
+        if (v === undefined) {
+          super(3);
+        } else if (typeof v === 'number') {
           super([v, v, v]);
         } else {
           super(v as ArrayBufferLike, 0, 3);

--- a/src/vec4.ts
+++ b/src/vec4.ts
@@ -20,7 +20,7 @@ export class Vec4 extends Float32Array {
   /**
    * Create a {@link Vec4}.
    */
-  constructor(...values: [Readonly<Vec4Like> | ArrayBufferLike, number?] | number[]) {
+  constructor(...values: [Readonly<Vec4Like> | ArrayBufferLike, number?] | number[] | [undefined]) {
     switch(values.length) {
       case 4:
         super(values); break;
@@ -28,7 +28,9 @@ export class Vec4 extends Float32Array {
         super(values[0] as ArrayBufferLike, values[1], 4); break;
       case 1: {
         const v = values[0];
-        if (typeof v === 'number') {
+        if (v === undefined) {
+          super(4);
+        } else if (typeof v === 'number') {
           super([v, v, v, v]);
         } else {
           super(v as ArrayBufferLike, 0, 4);

--- a/tests/mat2.spec.ts
+++ b/tests/mat2.spec.ts
@@ -10,6 +10,12 @@ describe("Mat2", function() {
         0, 1)
     });
 
+    it("should return an identity Mat2 if called with undefined argument", () => {
+      expect(new Mat2(undefined)).toBeVec(
+        1, 0,
+        0, 1)
+    });
+
     it("should return Mat2(m0, m1, ...m8) if called with (m0, m1, ...m8)", () => {
       expect(new Mat2(
         1, 2,

--- a/tests/mat2d.spec.ts
+++ b/tests/mat2d.spec.ts
@@ -11,6 +11,13 @@ describe("Mat2d", function() {
         0, 0)
     });
 
+    it("should return an identity Mat2d if called with undefined argument", () => {
+      expect(new Mat2d(undefined)).toBeVec(
+        1, 0,
+        0, 1,
+        0, 0)
+    });
+
     it("should return Mat2d(m0, m1, ...m5) if called with (m0, m1, ...m5)", () => {
       expect(new Mat2d(
         1, 2,

--- a/tests/mat3.spec.ts
+++ b/tests/mat3.spec.ts
@@ -13,6 +13,13 @@ describe("Mat3", function() {
         0, 0, 1)
     });
 
+    it("should return an identity Mat3 if called with undefined argument", () => {
+      expect(new Mat3(undefined)).toBeVec(
+        1, 0, 0,
+        0, 1, 0,
+        0, 0, 1)
+    });
+
     it("should return Mat3(m0, m1, ...m8) if called with (m0, m1, ...m8)", () => {
       expect(new Mat3(
         1, 2, 3,

--- a/tests/mat4.spec.ts
+++ b/tests/mat4.spec.ts
@@ -14,6 +14,14 @@ describe("Mat4", () => {
         0, 0, 0, 1);
     });
 
+    it("should return an identity Mat4 if called with undefined argument", () => {
+      expect(new Mat4(undefined)).toBeVec(
+        1, 0, 0, 0,
+        0, 1, 0, 0,
+        0, 0, 1, 0,
+        0, 0, 0, 1);
+    });
+
     it("should return Mat4(m0, m1, ...m15) if called with (m0, m1, ...m15)", () => {
       expect(new Mat4(
         1, 2, 3, 4,

--- a/tests/quat.spec.ts
+++ b/tests/quat.spec.ts
@@ -9,6 +9,10 @@ describe("Quat", () => {
       expect(new Quat()).toBeVec(0, 0, 0, 1);
     });
 
+    it("should return Quat(0, 0, 0, 1) if called with undefined argument", () => {
+      expect(new Quat(undefined)).toBeVec(0, 0, 0, 1);
+    });
+
     it("should return Quat(x, y, z, w) if called with (x, y, z, w)", () => {
       expect(new Quat(1, 2, 3, 4)).toBeVec(1, 2, 3, 4);
       expect(new Quat(-3, 4.4, -5.6, 7.8)).toBeVec(-3, 4.4, -5.6, 7.8);

--- a/tests/quat2.spec.ts
+++ b/tests/quat2.spec.ts
@@ -11,6 +11,10 @@ describe("Quat2", () => {
       expect(new Quat2()).toBeVec(0, 0, 0, 1, 0, 0, 0, 0);
     });
 
+    it("should return Quat2(0, 0, 0, 1, 0, 0, 0, 0) if called with undefined argument", () => {
+      expect(new Quat2(undefined)).toBeVec(0, 0, 0, 1, 0, 0, 0, 0);
+    });
+
     it("should return Quat(x, y, z, w, x2, y2, z2, w2) if called with (x, y, z, w, x2, y2, z2, w2)", () => {
       expect(new Quat2(1, 2, 3, 4, 5, 6, 7, 8)).toBeVec(1, 2, 3, 4, 5, 6, 7, 8);
       expect(new Quat2(-3, 4.4, -5.6, 7.8, 9.0, -10.11, 12.13, -14.15)).toBeVec(-3, 4.4, -5.6, 7.8, 9.0, -10.11, 12.13, -14.15);

--- a/tests/vec2.spec.ts
+++ b/tests/vec2.spec.ts
@@ -18,6 +18,10 @@ describe("Vec2", () => {
       expect(new Vec2()).toBeVec(0, 0);
     });
 
+    it("should return Vec2(0, 0) if called with undefined argument", () => {
+      expect(new Vec2(undefined)).toBeVec(0, 0);
+    });
+
     it("should return Vec2(x, y) if called with (x, y)", () => {
       expect(new Vec2(1, 2)).toBeVec(1, 2);
       expect(new Vec2(-3, 4.4)).toBeVec(-3, 4.4);

--- a/tests/vec3.spec.ts
+++ b/tests/vec3.spec.ts
@@ -9,6 +9,10 @@ describe("Vec3", () => {
       expect(new Vec3()).toBeVec(0, 0, 0);
     });
 
+    it("should return Vec3(0, 0, 0) if called with undefined argument", () => {
+      expect(new Vec3(undefined)).toBeVec(0, 0, 0);
+    });
+
     it("should return Vec3(x, y, z) if called with (x, y, z)", () => {
       expect(new Vec3(1, 2, 3)).toBeVec(1, 2, 3);
       expect(new Vec3(-3, 4.4, -5.6)).toBeVec(-3, 4.4, -5.6);

--- a/tests/vec4.spec.ts
+++ b/tests/vec4.spec.ts
@@ -8,6 +8,10 @@ describe("Vec4", () => {
       expect(new Vec4()).toBeVec(0, 0, 0, 0);
     });
 
+    it("should return Vec4(0, 0, 0, 0) if called with undefined argument", () => {
+      expect(new Vec4(undefined)).toBeVec(0, 0, 0, 0);
+    });
+
     it("should return Vec4(x, y, z, w) if called with (x, y, z, w)", () => {
       expect(new Vec4(1, 2, 3, 4)).toBeVec(1, 2, 3, 4);
       expect(new Vec4(-3, 4.4, -5.6, 7.8)).toBeVec(-3, 4.4, -5.6, 7.8);


### PR DESCRIPTION
While working with gl-matrix v4, I bumped into an issue where Typescript in strict mode wouldn't allow undefinable types to be passed to the gl-matrix class constructors, due to the way the rest operator works. This change should allow a single undefined argument to be passed to the constructor, and handle it as an empty initialization.

This is often desirable when building interfaces with optional parameters e.g.

```typescript
class WorldObject {
  translation: Vec3;
  
  constructor(translation?: Vec3Like) {
    this.translation = new Vec3(translation); // error: Type 'undefined' is not assignable to type 'Readonly<Vec3Like> | ArrayBufferLike'
  }
}
```

