### PR TITLE
[glmatrix-next] Added type inference for static method return type

### DIFF
--- a/src/mat2.ts
+++ b/src/mat2.ts
@@ -96,7 +96,7 @@ export class Mat2 extends Float32Array {
    * @returns `this`
    */
   multiply(b: Readonly<Mat2Like>): Mat2 {
-    return Mat2.multiply(this, this, b) as Mat2;
+    return Mat2.multiply(this, this, b);
   }
 
   /**
@@ -111,7 +111,7 @@ export class Mat2 extends Float32Array {
    * @returns `this`
    */
   transpose(): Mat2 {
-    return Mat2.transpose(this, this) as Mat2;
+    return Mat2.transpose(this, this);
   }
 
   /**
@@ -121,7 +121,7 @@ export class Mat2 extends Float32Array {
    * @returns `this`
    */
   invert(): Mat2 {
-    return Mat2.invert(this, this) as Mat2;
+    return Mat2.invert(this, this);
   }
 
   /**
@@ -132,7 +132,7 @@ export class Mat2 extends Float32Array {
    * @returns `this`
    */
   scale(v: Readonly<Vec2Like>): Mat2 {
-    return Mat2.scale(this, this, v) as Mat2;
+    return Mat2.scale(this, this, v);
   }
 
   /**
@@ -143,7 +143,7 @@ export class Mat2 extends Float32Array {
    * @returns `out`
    */
   rotate(rad: number): Mat2 {
-    return Mat2.rotate(this, this, rad) as Mat2;
+    return Mat2.rotate(this, this, rad);
   }
 
   //================
@@ -179,7 +179,7 @@ export class Mat2 extends Float32Array {
    * @param a - Matrix to copy
    * @returns `out`
    */
-  static copy(out: Mat2Like, a: Readonly<Mat2Like>): Mat2Like {
+  static copy<T extends Mat2Like>(out: T, a: Readonly<Mat2Like>): T {
     out[0] = a[0];
     out[1] = a[1];
     out[2] = a[2];
@@ -206,7 +206,7 @@ export class Mat2 extends Float32Array {
    * @param values - Matrix components
    * @returns `out`
    */
-  static set(out: Mat2Like, ...values: number[]): Mat2Like {
+  static set<T extends Mat2Like>(out: T, ...values: number[]): T {
     out[0] = values[0];
     out[1] = values[1];
     out[2] = values[2];
@@ -221,7 +221,7 @@ export class Mat2 extends Float32Array {
    * @param out - The receiving matrix
    * @returns `out`
    */
-  static identity(out: Mat2Like): Mat2Like {
+  static identity<T extends Mat2Like>(out: T): T {
     out[0] = 1;
     out[1] = 0;
     out[2] = 0;
@@ -237,7 +237,7 @@ export class Mat2 extends Float32Array {
    * @param a - the source matrix
    * @returns `out`
    */
-  static transpose(out: Mat2Like, a: Readonly<Mat2Like>): Mat2Like {
+  static transpose<T extends Mat2Like>(out: T, a: Readonly<Mat2Like>): T {
     // If we are transposing ourselves we can skip a few steps but have to cache
     // some values
     if (out === a) {
@@ -262,7 +262,7 @@ export class Mat2 extends Float32Array {
    * @param a - the source matrix
    * @returns `out` or `null` if the matrix is not invertable
    */
-  static invert(out: Mat2Like, a: Mat2Like): Mat2Like | null {
+  static invert<T extends Mat2Like>(out: T, a: Mat2Like): T | null {
     const a0 = a[0];
     const a1 = a[1];
     const a2 = a[2];
@@ -292,7 +292,7 @@ export class Mat2 extends Float32Array {
    * @param a - the source matrix
    * @returns `out`
    */
-  static adjoint(out: Mat2Like, a: Mat2Like): Mat2Like {
+  static adjoint<T extends Mat2Like>(out: T, a: Mat2Like): T {
     // Caching this value is necessary if out == a
     const a0 = a[0];
     out[0] = a[3];
@@ -322,7 +322,7 @@ export class Mat2 extends Float32Array {
    * @param b - the second operand
    * @returns `out`
    */
-  static add(out: Mat2Like, a: Readonly<Mat2Like>, b: Readonly<Mat2Like>): Mat2Like {
+  static add<T extends Mat2Like>(out: T, a: Readonly<Mat2Like>, b: Readonly<Mat2Like>): T {
     out[0] = a[0] + b[0];
     out[1] = a[1] + b[1];
     out[2] = a[2] + b[2];
@@ -339,7 +339,7 @@ export class Mat2 extends Float32Array {
    * @param b - the second operand
    * @returns `out`
    */
-  static subtract(out: Mat2Like, a: Readonly<Mat2Like>, b: Readonly<Mat2Like>): Mat2Like {
+  static subtract<T extends Mat2Like>(out: T, a: Readonly<Mat2Like>, b: Readonly<Mat2Like>): T {
     out[0] = a[0] - b[0];
     out[1] = a[1] - b[1];
     out[2] = a[2] - b[2];
@@ -351,7 +351,7 @@ export class Mat2 extends Float32Array {
    * Alias for {@link Mat2.subtract}
    * @category Static
    */
-  static sub(out: Mat2Like, a: Readonly<Mat2Like>, b: Readonly<Mat2Like>): Mat2Like { return out; }
+  static sub<T extends Mat2Like>(out: T, a: Readonly<Mat2Like>, b: Readonly<Mat2Like>): T { return out; }
 
   /**
    * Multiplies two {@link Mat2}s
@@ -362,7 +362,7 @@ export class Mat2 extends Float32Array {
    * @param b - The second operand
    * @returns `out`
    */
-  static multiply(out: Mat2Like, a: Readonly<Mat2Like>, b: Readonly<Mat2Like>): Mat2Like {
+  static multiply<T extends Mat2Like>(out: T, a: Readonly<Mat2Like>, b: Readonly<Mat2Like>): T {
     const a0 = a[0];
     const a1 = a[1];
     const a2 = a[2];
@@ -382,7 +382,7 @@ export class Mat2 extends Float32Array {
    * Alias for {@link Mat2.multiply}
    * @category Static
    */
-  static mul(out: Mat2Like, a: Readonly<Mat2Like>, b: Readonly<Mat2Like>): Mat2Like { return out; }
+  static mul<T extends Mat2Like>(out: T, a: Readonly<Mat2Like>, b: Readonly<Mat2Like>): T { return out; }
 
   /**
    * Rotates a {@link Mat2} by the given angle
@@ -393,7 +393,7 @@ export class Mat2 extends Float32Array {
    * @param rad - the angle to rotate the matrix by
    * @returns `out`
    */
-  static rotate(out: Mat2Like, a: Readonly<Mat2Like>, rad: number): Mat2Like {
+  static rotate<T extends Mat2Like>(out: T, a: Readonly<Mat2Like>, rad: number): T {
     const a0 = a[0];
     const a1 = a[1];
     const a2 = a[2];
@@ -416,7 +416,7 @@ export class Mat2 extends Float32Array {
    * @param v - the {@link Vec2} to scale the matrix by
    * @returns `out`
    **/
-  static scale(out: Mat2Like, a: Readonly<Mat2Like>, v: Readonly<Vec2Like>): Mat2Like {
+  static scale<T extends Mat2Like>(out: T, a: Readonly<Mat2Like>, v: Readonly<Vec2Like>): T {
     const a0 = a[0];
     const a1 = a[1];
     const a2 = a[2];
@@ -442,7 +442,7 @@ export class Mat2 extends Float32Array {
    * @param rad - the angle to rotate the matrix by
    * @returns `out`
    */
-  static fromRotation(out: Mat2Like, rad: number): Mat2Like {
+  static fromRotation<T extends Mat2Like>(out: T, rad: number): T {
     const s = Math.sin(rad);
     const c = Math.cos(rad);
     out[0] = c;
@@ -464,7 +464,7 @@ export class Mat2 extends Float32Array {
    * @param v - Scaling vector
    * @returns `out`
    */
-  static fromScaling(out: Mat2Like, v: Readonly<Vec2Like>): Mat2Like {
+  static fromScaling<T extends Mat2Like>(out: T, v: Readonly<Vec2Like>): T {
     out[0] = v[0];
     out[1] = 0;
     out[2] = 0;
@@ -492,7 +492,7 @@ export class Mat2 extends Float32Array {
    * @param b - amount to scale the matrix's elements by
    * @returns `out`
    */
-  static multiplyScalar(out: Mat2Like, a: Readonly<Mat2Like>, b: number): Mat2Like {
+  static multiplyScalar<T extends Mat2Like>(out: T, a: Readonly<Mat2Like>, b: number): T {
     out[0] = a[0] * b;
     out[1] = a[1] * b;
     out[2] = a[2] * b;
@@ -510,7 +510,7 @@ export class Mat2 extends Float32Array {
    * @param scale - the amount to scale b's elements by before adding
    * @returns `out`
    */
-  static multiplyScalarAndAdd(out: Mat2Like, a: Readonly<Mat2Like>, b: Readonly<Mat2Like>, scale: number): Mat2Like {
+  static multiplyScalarAndAdd<T extends Mat2Like>(out: T, a: Readonly<Mat2Like>, b: Readonly<Mat2Like>, scale: number): T {
     out[0] = a[0] + b[0] * scale;
     out[1] = a[1] + b[1] * scale;
     out[2] = a[2] + b[2] * scale;

--- a/src/mat2d.ts
+++ b/src/mat2d.ts
@@ -99,7 +99,7 @@ export class Mat2d extends Float32Array {
    * @returns `this`
    */
   multiply(b: Readonly<Mat2dLike>): Mat2d {
-    return Mat2d.multiply(this, this, b) as Mat2d;
+    return Mat2d.multiply(this, this, b);
   }
 
   /**
@@ -115,7 +115,7 @@ export class Mat2d extends Float32Array {
    * @returns `this`
    */
   translate(v: Readonly<Vec2Like>): Mat2d {
-    return Mat2d.translate(this, this, v) as Mat2d;
+    return Mat2d.translate(this, this, v);
   }
 
   /**
@@ -126,7 +126,7 @@ export class Mat2d extends Float32Array {
    * @returns `out`
    */
   rotate(rad: number): Mat2d {
-    return Mat2d.rotate(this, this, rad) as Mat2d;
+    return Mat2d.rotate(this, this, rad);
   }
 
   /**
@@ -137,7 +137,7 @@ export class Mat2d extends Float32Array {
    * @returns `this`
    */
   scale(v: Readonly<Vec2Like>): Mat2d {
-    return Mat2d.scale(this, this, v) as Mat2d;
+    return Mat2d.scale(this, this, v);
   }
 
   //================
@@ -173,7 +173,7 @@ export class Mat2d extends Float32Array {
    * @param a - Matrix to copy
    * @returns `out`
    */
-  static copy(out: Mat2dLike, a: Readonly<Mat2dLike>): Mat2dLike {
+  static copy<T extends Mat2dLike>(out: T, a: Readonly<Mat2dLike>): T {
     out[0] = a[0];
     out[1] = a[1];
     out[2] = a[2];
@@ -202,7 +202,7 @@ export class Mat2d extends Float32Array {
    * @param values - Matrix components
    * @returns `out`
    */
-  static set(out: Mat2dLike, ...values: number[]): Mat2dLike {
+  static set<T extends Mat2dLike>(out: T, ...values: number[]): T {
     out[0] = values[0];
     out[1] = values[1];
     out[2] = values[2];
@@ -219,7 +219,7 @@ export class Mat2d extends Float32Array {
    * @param out - The receiving matrix
    * @returns `out`
    */
-  static identity(out: Mat2dLike): Mat2dLike {
+  static identity<T extends Mat2dLike>(out: T): T {
     out[0] = 1;
     out[1] = 0;
     out[2] = 0;
@@ -237,7 +237,7 @@ export class Mat2d extends Float32Array {
    * @param a - the source matrix
    * @returns `out` or `null` if the matrix is not invertable
    */
-  static invert(out: Mat2dLike, a: Mat2dLike): Mat2dLike | null {
+  static invert<T extends Mat2dLike>(out: T, a: Mat2dLike): T | null {
     const aa = a[0];
     const ab = a[1];
     const ac = a[2];
@@ -280,7 +280,7 @@ export class Mat2d extends Float32Array {
    * @param b - the second operand
    * @returns `out`
    */
-  static add(out: Mat2dLike, a: Readonly<Mat2dLike>, b: Readonly<Mat2dLike>): Mat2dLike {
+  static add<T extends Mat2dLike>(out: T, a: Readonly<Mat2dLike>, b: Readonly<Mat2dLike>): T {
     out[0] = a[0] + b[0];
     out[1] = a[1] + b[1];
     out[2] = a[2] + b[2];
@@ -299,7 +299,7 @@ export class Mat2d extends Float32Array {
    * @param b - the second operand
    * @returns `out`
    */
-  static subtract(out: Mat2dLike, a: Readonly<Mat2dLike>, b: Readonly<Mat2dLike>): Mat2dLike {
+  static subtract<T extends Mat2dLike>(out: T, a: Readonly<Mat2dLike>, b: Readonly<Mat2dLike>): T {
     out[0] = a[0] - b[0];
     out[1] = a[1] - b[1];
     out[2] = a[2] - b[2];
@@ -313,7 +313,7 @@ export class Mat2d extends Float32Array {
    * Alias for {@link Mat2d.subtract}
    * @category Static
    */
-  static sub(out: Mat2dLike, a: Readonly<Mat2dLike>, b: Readonly<Mat2dLike>): Mat2dLike { return out; }
+  static sub<T extends Mat2dLike>(out: T, a: Readonly<Mat2dLike>, b: Readonly<Mat2dLike>): T { return out; }
 
   /**
    * Multiplies two {@link Mat2d}s
@@ -324,7 +324,7 @@ export class Mat2d extends Float32Array {
    * @param b - The second operand
    * @returns `out`
    */
-  static multiply(out: Mat2dLike, a: Readonly<Mat2dLike>, b: Readonly<Mat2dLike>): Mat2dLike {
+  static multiply<T extends Mat2dLike>(out: T, a: Readonly<Mat2dLike>, b: Readonly<Mat2dLike>): T {
     const a0 = a[0];
     const a1 = a[1];
     const a2 = a[2];
@@ -350,7 +350,7 @@ export class Mat2d extends Float32Array {
    * Alias for {@link Mat2d.multiply}
    * @category Static
    */
-  static mul(out: Mat2dLike, a: Readonly<Mat2dLike>, b: Readonly<Mat2dLike>): Mat2dLike { return out; }
+  static mul<T extends Mat2dLike>(out: T, a: Readonly<Mat2dLike>, b: Readonly<Mat2dLike>): T { return out; }
 
   /**
    * Translate a {@link Mat2d} by the given vector
@@ -361,7 +361,7 @@ export class Mat2d extends Float32Array {
    * @param v - vector to translate by
    * @returns `out`
    */
-  static translate(out: Mat2dLike, a: Readonly<Mat2dLike>, v: Readonly<Vec2Like>): Mat2dLike {
+  static translate<T extends Mat2dLike>(out: T, a: Readonly<Mat2dLike>, v: Readonly<Vec2Like>): T {
     const a0 = a[0];
     const a1 = a[1];
     const a2 = a[2];
@@ -388,7 +388,7 @@ export class Mat2d extends Float32Array {
    * @param rad - the angle to rotate the matrix by
    * @returns `out`
    */
-  static rotate(out: Mat2dLike, a: Readonly<Mat2dLike>, rad: number): Mat2dLike {
+  static rotate<T extends Mat2dLike>(out: T, a: Readonly<Mat2dLike>, rad: number): T {
     const a0 = a[0];
     const a1 = a[1];
     const a2 = a[2];
@@ -415,7 +415,7 @@ export class Mat2d extends Float32Array {
    * @param v - the {@link Vec2} to scale the matrix by
    * @returns `out`
    **/
-  static scale(out: Mat2dLike, a: Readonly<Mat2dLike>, v: Readonly<Vec2Like>): Mat2dLike {
+  static scale<T extends Mat2dLike>(out: T, a: Readonly<Mat2dLike>, v: Readonly<Vec2Like>): T {
     const a0 = a[0];
     const a1 = a[1];
     const a2 = a[2];
@@ -447,7 +447,7 @@ export class Mat2d extends Float32Array {
    * @param v - Translation vector
    * @returns `out`
    */
-  static fromTranslation(out: Mat2dLike, v: Readonly<Vec2Like>): Mat2dLike {
+  static fromTranslation<T extends Mat2dLike>(out: T, v: Readonly<Vec2Like>): T {
     out[0] = 1;
     out[1] = 0;
     out[2] = 0;
@@ -469,7 +469,7 @@ export class Mat2d extends Float32Array {
    * @param rad - the angle to rotate the matrix by
    * @returns `out`
    */
-  static fromRotation(out: Mat2dLike, rad: number): Mat2dLike {
+  static fromRotation<T extends Mat2dLike>(out: T, rad: number): T {
     const s = Math.sin(rad);
     const c = Math.cos(rad);
     out[0] = c;
@@ -493,7 +493,7 @@ export class Mat2d extends Float32Array {
    * @param v - Scaling vector
    * @returns `out`
    */
-  static fromScaling(out: Mat2dLike, v: Readonly<Vec2Like>): Mat2dLike {
+  static fromScaling<T extends Mat2dLike>(out: T, v: Readonly<Vec2Like>): T {
     out[0] = v[0];
     out[1] = 0;
     out[2] = 0;
@@ -523,7 +523,7 @@ export class Mat2d extends Float32Array {
    * @param b - amount to scale the matrix's elements by
    * @returns `out`
    */
-  static multiplyScalar(out: Mat2dLike, a: Readonly<Mat2dLike>, b: number): Mat2dLike {
+  static multiplyScalar<T extends Mat2dLike>(out: T, a: Readonly<Mat2dLike>, b: number): T {
     out[0] = a[0] * b;
     out[1] = a[1] * b;
     out[2] = a[2] * b;
@@ -543,7 +543,7 @@ export class Mat2d extends Float32Array {
    * @param scale - the amount to scale b's elements by before adding
    * @returns `out`
    */
-  static multiplyScalarAndAdd(out: Mat2dLike, a: Readonly<Mat2dLike>, b: Readonly<Mat2dLike>, scale: number): Mat2dLike {
+  static multiplyScalarAndAdd<T extends Mat2dLike>(out: T, a: Readonly<Mat2dLike>, b: Readonly<Mat2dLike>, scale: number): T {
     out[0] = a[0] + b[0] * scale;
     out[1] = a[1] + b[1] * scale;
     out[2] = a[2] + b[2] * scale;

--- a/src/mat3.ts
+++ b/src/mat3.ts
@@ -102,7 +102,7 @@ export class Mat3 extends Float32Array {
    * @returns `this`
    */
   multiply(b: Readonly<Mat3Like>): Mat3 {
-    return Mat3.multiply(this, this, b) as Mat3;
+    return Mat3.multiply(this, this, b);
   }
 
   /**
@@ -117,7 +117,7 @@ export class Mat3 extends Float32Array {
    * @returns `this`
    */
   transpose(): Mat3 {
-    return Mat3.transpose(this, this) as Mat3;
+    return Mat3.transpose(this, this);
   }
 
   /**
@@ -127,7 +127,7 @@ export class Mat3 extends Float32Array {
    * @returns `this`
    */
   invert(): Mat3 {
-    return Mat3.invert(this, this) as Mat3;
+    return Mat3.invert(this, this);
   }
 
   /**
@@ -138,7 +138,7 @@ export class Mat3 extends Float32Array {
    * @returns `this`
    */
   translate(v: Readonly<Vec2Like>): Mat3 {
-    return Mat3.translate(this, this, v) as Mat3;
+    return Mat3.translate(this, this, v);
   }
 
   /**
@@ -149,7 +149,7 @@ export class Mat3 extends Float32Array {
    * @returns `out`
    */
   rotate(rad: number): Mat3 {
-    return Mat3.rotate(this, this, rad) as Mat3;
+    return Mat3.rotate(this, this, rad);
   }
 
   /**
@@ -160,7 +160,7 @@ export class Mat3 extends Float32Array {
    * @returns `this`
    */
   scale(v: Readonly<Vec2Like>): Mat3 {
-    return Mat3.scale(this, this, v) as Mat3;
+    return Mat3.scale(this, this, v);
   }
 
   //================
@@ -196,7 +196,7 @@ export class Mat3 extends Float32Array {
    * @param a - Matrix to copy
    * @returns `out`
    */
-  static copy(out: Mat3Like, a: Readonly<Mat3Like>): Mat3Like {
+  static copy<T extends Mat3Like>(out: T, a: Readonly<Mat3Like>): T {
     out[0] = a[0];
     out[1] = a[1];
     out[2] = a[2];
@@ -228,7 +228,7 @@ export class Mat3 extends Float32Array {
    * @param values - Matrix components
    * @returns `out`
    */
-  static set(out: Mat3Like, ...values: number[]): Mat3Like {
+  static set<T extends Mat3Like>(out: T, ...values: number[]): T {
     out[0] = values[0];
     out[1] = values[1];
     out[2] = values[2];
@@ -248,7 +248,7 @@ export class Mat3 extends Float32Array {
    * @param out - The receiving matrix
    * @returns `out`
    */
-  static identity(out: Mat3Like): Mat3Like {
+  static identity<T extends Mat3Like>(out: T): T {
     out[0] = 1;
     out[1] = 0;
     out[2] = 0;
@@ -269,7 +269,7 @@ export class Mat3 extends Float32Array {
    * @param a - the source matrix
    * @returns `out`
    */
-  static transpose(out: Mat3Like, a: Readonly<Mat3Like>): Mat3Like {
+  static transpose<T extends Mat3Like>(out: T, a: Readonly<Mat3Like>): T {
     // If we are transposing ourselves we can skip a few steps but have to cache some values
     if (out === a) {
       const a01 = a[1],
@@ -304,7 +304,7 @@ export class Mat3 extends Float32Array {
    * @param a - the source matrix
    * @returns `out` or `null` if the matrix is not invertable
    */
-  static invert(out: Mat3Like, a: Mat3Like): Mat3Like | null {
+  static invert<T extends Mat3Like>(out: T, a: Mat3Like): T | null {
     const a00 = a[0],
       a01 = a[1],
       a02 = a[2];
@@ -347,7 +347,7 @@ export class Mat3 extends Float32Array {
    * @param a - the source matrix
    * @returns `out`
    */
-  static adjoint(out: Mat3Like, a: Mat3Like): Mat3Like {
+  static adjoint<T extends Mat3Like>(out: T, a: Mat3Like): T {
     const a00 = a[0];
     const a01 = a[1];
     const a02 = a[2];
@@ -404,7 +404,7 @@ export class Mat3 extends Float32Array {
    * @param b - the second operand
    * @returns `out`
    */
-  static add(out: Mat3Like, a: Readonly<Mat3Like>, b: Readonly<Mat3Like>): Mat3Like {
+  static add<T extends Mat3Like>(out: T, a: Readonly<Mat3Like>, b: Readonly<Mat3Like>): T {
     out[0] = a[0] + b[0];
     out[1] = a[1] + b[1];
     out[2] = a[2] + b[2];
@@ -426,7 +426,7 @@ export class Mat3 extends Float32Array {
    * @param b - the second operand
    * @returns `out`
    */
-  static subtract(out: Mat3Like, a: Readonly<Mat3Like>, b: Readonly<Mat3Like>): Mat3Like {
+  static subtract<T extends Mat3Like>(out: T, a: Readonly<Mat3Like>, b: Readonly<Mat3Like>): T {
     out[0] = a[0] - b[0];
     out[1] = a[1] - b[1];
     out[2] = a[2] - b[2];
@@ -443,7 +443,7 @@ export class Mat3 extends Float32Array {
    * Alias for {@link Mat3.subtract}
    * @category Static
    */
-  static sub(out: Mat3Like, a: Readonly<Mat3Like>, b: Readonly<Mat3Like>): Mat3Like { return out; }
+  static sub<T extends Mat3Like>(out: T, a: Readonly<Mat3Like>, b: Readonly<Mat3Like>): T { return out; }
 
   /**
    * Multiplies two {@link Mat3}s
@@ -454,7 +454,7 @@ export class Mat3 extends Float32Array {
    * @param b - The second operand
    * @returns `out`
    */
-  static multiply(out: Mat3Like, a: Readonly<Mat3Like>, b: Readonly<Mat3Like>): Mat3Like {
+  static multiply<T extends Mat3Like>(out: T, a: Readonly<Mat3Like>, b: Readonly<Mat3Like>): T {
     const a00 = a[0];
     const a01 = a[1];
     const a02 = a[2];
@@ -492,7 +492,7 @@ export class Mat3 extends Float32Array {
    * Alias for {@link Mat3.multiply}
    * @category Static
    */
-  static mul(out: Mat3Like, a: Readonly<Mat3Like>, b: Readonly<Mat3Like>): Mat3Like { return out; }
+  static mul<T extends Mat3Like>(out: T, a: Readonly<Mat3Like>, b: Readonly<Mat3Like>): T { return out; }
 
   /**
    * Translate a {@link Mat3} by the given vector
@@ -503,7 +503,7 @@ export class Mat3 extends Float32Array {
    * @param v - vector to translate by
    * @returns `out`
    */
-  static translate(out: Mat3Like, a: Readonly<Mat3Like>, v: Readonly<Vec2Like>): Mat3Like {
+  static translate<T extends Mat3Like>(out: T, a: Readonly<Mat3Like>, v: Readonly<Vec2Like>): T {
     const a00 = a[0];
     const a01 = a[1];
     const a02 = a[2];
@@ -539,7 +539,7 @@ export class Mat3 extends Float32Array {
    * @param rad - the angle to rotate the matrix by
    * @returns `out`
    */
-  static rotate(out: Mat3Like, a: Readonly<Mat3Like>, rad: number): Mat3Like {
+  static rotate<T extends Mat3Like>(out: T, a: Readonly<Mat3Like>, rad: number): T {
     const a00 = a[0];
     const a01 = a[1];
     const a02 = a[2];
@@ -575,7 +575,7 @@ export class Mat3 extends Float32Array {
    * @param v - the {@link Vec2} to scale the matrix by
    * @returns `out`
    **/
-  static scale(out: Mat3Like, a: Readonly<Mat3Like>, v: Readonly<Vec2Like>): Mat3Like {
+  static scale<T extends Mat3Like>(out: T, a: Readonly<Mat3Like>, v: Readonly<Vec2Like>): T {
     const x = v[0];
     const y = v[1];
 
@@ -605,7 +605,7 @@ export class Mat3 extends Float32Array {
    * @param v - Translation vector
    * @returns `out`
    */
-  static fromTranslation(out: Mat3Like, v: Readonly<Vec2Like>): Mat3Like {
+  static fromTranslation<T extends Mat3Like>(out: T, v: Readonly<Vec2Like>): T {
     out[0] = 1;
     out[1] = 0;
     out[2] = 0;
@@ -630,7 +630,7 @@ export class Mat3 extends Float32Array {
    * @param rad - the angle to rotate the matrix by
    * @returns `out`
    */
-  static fromRotation(out: Mat3Like, rad: number): Mat3Like {
+  static fromRotation<T extends Mat3Like>(out: T, rad: number): T {
     const s = Math.sin(rad);
     const c = Math.cos(rad);
 
@@ -660,7 +660,7 @@ export class Mat3 extends Float32Array {
    * @param v - Scaling vector
    * @returns `out`
    */
-  static fromScaling(out: Mat3Like, v: Readonly<Vec2Like>): Mat3Like {
+  static fromScaling<T extends Mat3Like>(out: T, v: Readonly<Vec2Like>): T {
     out[0] = v[0];
     out[1] = 0;
     out[2] = 0;
@@ -684,7 +684,7 @@ export class Mat3 extends Float32Array {
    * @param a - the source 2x3 matrix
    * @returns `out`
    */
-  static fromMat2d(out: Mat3Like, a: Readonly<Mat2dLike>): Mat3Like {
+  static fromMat2d<T extends Mat3Like>(out: T, a: Readonly<Mat2dLike>): T {
     out[0] = a[0];
     out[1] = a[1];
     out[2] = 0;
@@ -706,7 +706,7 @@ export class Mat3 extends Float32Array {
    * @param q - {@link Quat} to create matrix from
    * @returns `out`
    */
-  static fromQuat(out: Mat3Like, q: Readonly<QuatLike>): Mat3Like {
+  static fromQuat<T extends Mat3Like>(out: T, q: Readonly<QuatLike>): T {
     const x = q[0];
     const y = q[1];
     const z = q[2];
@@ -749,7 +749,7 @@ export class Mat3 extends Float32Array {
    * @param a - the source 4x4 matrix
    * @returns `out`
    */
-  static fromMat4(out: Mat3Like, a: Readonly<Mat4Like>): Mat3Like {
+  static fromMat4<T extends Mat3Like>(out: T, a: Readonly<Mat4Like>): T {
     out[0] = a[0];
     out[1] = a[1];
     out[2] = a[2];
@@ -771,7 +771,7 @@ export class Mat3 extends Float32Array {
    * @param {ReadonlyMat4} a Mat4 to derive the normal matrix from
    * @returns `out` or `null` if the matrix is not invertable
    */
-  static normalFromMat4(out: Mat3Like, a: Readonly<Mat4Like>): Mat3Like {
+  static normalFromMat4<T extends Mat3Like>(out: T, a: Readonly<Mat4Like>): T {
     // Only difference from adjoint() is these indices.
     const a00 = a[0];
     const a01 = a[1];
@@ -804,7 +804,7 @@ export class Mat3 extends Float32Array {
    * @category Static
    * @deprecated Use {@link Mat3.normalFromMat4}
    */
-  static normalFromMat4Fast(out: Mat3Like, a: Readonly<Mat4Like>): Mat3Like { return out; }
+  static normalFromMat4Fast<T extends Mat3Like>(out: T, a: Readonly<Mat4Like>): T { return out; }
 
   /**
    * Generates a 2D projection matrix with the given bounds
@@ -815,7 +815,7 @@ export class Mat3 extends Float32Array {
    * @param height Height of gl context
    * @returns `out`
    */
-  static projection(out: Mat3Like, width: number, height: number): Mat3Like {
+  static projection<T extends Mat3Like>(out: T, width: number, height: number): T {
     out[0] = 2 / width;
     out[1] = 0;
     out[2] = 0;
@@ -858,7 +858,7 @@ export class Mat3 extends Float32Array {
    * @param b - amount to scale the matrix's elements by
    * @returns `out`
    */
-  static multiplyScalar(out: Mat3Like, a: Readonly<Mat3Like>, b: number): Mat3Like {
+  static multiplyScalar<T extends Mat3Like>(out: T, a: Readonly<Mat3Like>, b: number): T {
     out[0] = a[0] * b;
     out[1] = a[1] * b;
     out[2] = a[2] * b;
@@ -881,7 +881,7 @@ export class Mat3 extends Float32Array {
    * @param scale - the amount to scale b's elements by before adding
    * @returns `out`
    */
-  static multiplyScalarAndAdd(out: Mat3Like, a: Readonly<Mat3Like>, b: Readonly<Mat3Like>, scale: number): Mat3Like {
+  static multiplyScalarAndAdd<T extends Mat3Like>(out: T, a: Readonly<Mat3Like>, b: Readonly<Mat3Like>, scale: number): T {
     out[0] = a[0] + b[0] * scale;
     out[1] = a[1] + b[1] * scale;
     out[2] = a[2] + b[2] * scale;

--- a/src/mat4.ts
+++ b/src/mat4.ts
@@ -104,7 +104,7 @@ export class Mat4 extends Float32Array {
    * @returns `this`
    */
   multiply(b: Readonly<Mat4Like>): Mat4 {
-    return Mat4.multiply(this, this, b) as Mat4;
+    return Mat4.multiply(this, this, b);
   }
 
   /**
@@ -119,7 +119,7 @@ export class Mat4 extends Float32Array {
    * @returns `this`
    */
   transpose(): Mat4 {
-    return Mat4.transpose(this, this) as Mat4;
+    return Mat4.transpose(this, this);
   }
 
   /**
@@ -129,7 +129,7 @@ export class Mat4 extends Float32Array {
    * @returns `this`
    */
   invert(): Mat4 {
-    return Mat4.invert(this, this) as Mat4;
+    return Mat4.invert(this, this);
   }
 
   /**
@@ -140,7 +140,7 @@ export class Mat4 extends Float32Array {
    * @returns `this`
    */
   translate(v: Readonly<Vec3Like>): Mat4 {
-    return Mat4.translate(this, this, v) as Mat4;
+    return Mat4.translate(this, this, v);
   }
 
   /**
@@ -152,7 +152,7 @@ export class Mat4 extends Float32Array {
    * @returns `out`
    */
   rotate(rad: number, axis: Readonly<Vec3Like>): Mat4 {
-    return Mat4.rotate(this, this, rad, axis) as Mat4;
+    return Mat4.rotate(this, this, rad, axis);
   }
 
   /**
@@ -163,7 +163,7 @@ export class Mat4 extends Float32Array {
    * @returns `this`
    */
   scale(v: Readonly<Vec3Like>): Mat4 {
-    return Mat4.scale(this, this, v) as Mat4;
+    return Mat4.scale(this, this, v);
   }
 
   /**
@@ -174,7 +174,7 @@ export class Mat4 extends Float32Array {
    * @returns `this`
    */
   rotateX(rad: number): Mat4 {
-    return Mat4.rotateX(this, this, rad) as Mat4;
+    return Mat4.rotateX(this, this, rad);
   }
 
   /**
@@ -185,7 +185,7 @@ export class Mat4 extends Float32Array {
    * @returns `this`
    */
   rotateY(rad: number): Mat4 {
-    return Mat4.rotateY(this, this, rad) as Mat4;
+    return Mat4.rotateY(this, this, rad);
   }
 
   /**
@@ -196,7 +196,7 @@ export class Mat4 extends Float32Array {
    * @returns `this`
    */
   rotateZ(rad: number): Mat4 {
-    return Mat4.rotateZ(this, this, rad) as Mat4;
+    return Mat4.rotateZ(this, this, rad);
   }
 
   /**
@@ -213,7 +213,7 @@ export class Mat4 extends Float32Array {
    * @returns `this`
    */
   perspectiveNO(fovy: number, aspect: number, near: number, far: number): Mat4 {
-    return Mat4.perspectiveNO(this, fovy, aspect, near, far) as Mat4;
+    return Mat4.perspectiveNO(this, fovy, aspect, near, far);
   }
 
   /**
@@ -230,7 +230,7 @@ export class Mat4 extends Float32Array {
    * @returns `this`
    */
   perspectiveZO(fovy: number, aspect: number, near: number, far: number): Mat4 {
-    return Mat4.perspectiveZO(this, fovy, aspect, near, far) as Mat4;
+    return Mat4.perspectiveZO(this, fovy, aspect, near, far);
   }
 
   /**
@@ -248,7 +248,7 @@ export class Mat4 extends Float32Array {
    * @returns `this`
    */
   orthoNO(left: number, right: number, bottom: number, top: number, near: number, far: number): Mat4 {
-    return Mat4.orthoNO(this, left, right, bottom, top, near, far) as Mat4;
+    return Mat4.orthoNO(this, left, right, bottom, top, near, far);
   }
 
   /**
@@ -266,7 +266,7 @@ export class Mat4 extends Float32Array {
    * @returns `this`
    */
   orthoZO(left: number, right: number, bottom: number, top: number, near: number, far: number): Mat4 {
-    return Mat4.orthoZO(this, left, right, bottom, top, near, far) as Mat4;
+    return Mat4.orthoZO(this, left, right, bottom, top, near, far);
   }
 
   //================
@@ -302,7 +302,7 @@ export class Mat4 extends Float32Array {
    * @param a - Matrix to copy
    * @returns `out`
    */
-  static copy(out: Mat4Like, a: Readonly<Mat4Like>): Mat4Like {
+  static copy<T extends Mat4Like>(out: T, a: Readonly<Mat4Like>): T {
     out[0] = a[0];
     out[1] = a[1];
     out[2] = a[2];
@@ -341,7 +341,7 @@ export class Mat4 extends Float32Array {
    * @param values - Matrix components
    * @returns `out`
    */
-  static set(out: Mat4Like, ...values: number[]): Mat4Like {
+  static set<T extends Mat4Like>(out: T, ...values: number[]): T {
     out[0] = values[0];
     out[1] = values[1];
     out[2] = values[2];
@@ -368,7 +368,7 @@ export class Mat4 extends Float32Array {
    * @param out - The receiving Matrix
    * @returns `out`
    */
-   static identity(out: Mat4Like): Mat4Like {
+   static identity<T extends Mat4Like>(out: T): T {
     out[0] = 1;
     out[1] = 0;
     out[2] = 0;
@@ -396,7 +396,7 @@ export class Mat4 extends Float32Array {
    * @param a - the source matrix
    * @returns `out`
    */
-  static transpose(out: Mat4Like, a: Readonly<Mat4Like>): Mat4Like {
+  static transpose<T extends Mat4Like>(out: T, a: Readonly<Mat4Like>): T {
     // If we are transposing ourselves we can skip a few steps but have to cache some values
     if (out === a) {
       const a01 = a[1],
@@ -448,7 +448,7 @@ export class Mat4 extends Float32Array {
    * @param a - the source matrix
    * @returns `out` or `null` if the matrix is not invertable
    */
-  static invert(out: Mat4Like, a: Mat4Like): Mat4Like | null {
+  static invert<T extends Mat4Like>(out: T, a: Mat4Like): T | null {
     const a00 = a[0],
       a01 = a[1],
       a02 = a[2],
@@ -516,7 +516,7 @@ export class Mat4 extends Float32Array {
    * @param a - the source matrix
    * @returns `out`
    */
-  static adjoint(out: Mat4Like, a: Mat4Like): Mat4Like {
+  static adjoint<T extends Mat4Like>(out: T, a: Mat4Like): T {
     const a00 = a[0],
       a01 = a[1],
       a02 = a[2],
@@ -615,7 +615,7 @@ export class Mat4 extends Float32Array {
    * @param b - The second operand
    * @returns `out`
    */
-  static multiply(out: Mat4Like, a: Readonly<Mat4Like>, b: Readonly<Mat4Like>): Mat4Like {
+  static multiply<T extends Mat4Like>(out: T, a: Readonly<Mat4Like>, b: Readonly<Mat4Like>): T {
     const a00 = a[0];
     const a01 = a[1];
     const a02 = a[2];
@@ -676,7 +676,7 @@ export class Mat4 extends Float32Array {
    * Alias for {@link Mat4.multiply}
    * @category Static
    */
-  static mul(out: Mat4Like, a: Readonly<Mat4Like>, b: Readonly<Mat4Like>): Mat4Like { return out; }
+  static mul<T extends Mat4Like>(out: T, a: Readonly<Mat4Like>, b: Readonly<Mat4Like>): T { return out; }
 
   /**
    * Translate a {@link Mat4} by the given vector
@@ -687,7 +687,7 @@ export class Mat4 extends Float32Array {
    * @param v - vector to translate by
    * @returns `out`
    */
-  static translate(out: Mat4Like, a: Readonly<Mat4Like>, v: Readonly<Vec3Like>): Mat4Like {
+  static translate<T extends Mat4Like>(out: T, a: Readonly<Mat4Like>, v: Readonly<Vec3Like>): T {
     const x = v[0];
     const y = v[1];
     const z = v[2];
@@ -742,7 +742,7 @@ export class Mat4 extends Float32Array {
    * @param v - the {@link Vec3} to scale the matrix by
    * @returns `out`
    **/
-  static scale(out: Mat4Like, a: Readonly<Mat4Like>, v: Readonly<Vec3Like>): Mat4Like {
+  static scale<T extends Mat4Like>(out: T, a: Readonly<Mat4Like>, v: Readonly<Vec3Like>): T {
     const x = v[0];
     const y = v[1];
     const z = v[2];
@@ -776,7 +776,7 @@ export class Mat4 extends Float32Array {
    * @param axis - the axis to rotate around
    * @returns `out` or `null` if axis has a length of 0
    */
-  static rotate(out: Mat4Like, a: Readonly<Mat4Like>, rad: number, axis: Readonly<Vec3Like>): Mat4Like | null {
+  static rotate<T extends Mat4Like>(out: T, a: Readonly<Mat4Like>, rad: number, axis: Readonly<Vec3Like>): T | null {
     let x = axis[0];
     let y = axis[1];
     let z = axis[2];
@@ -852,7 +852,7 @@ export class Mat4 extends Float32Array {
    * @param rad - the angle to rotate the matrix by
    * @returns `out`
    */
-  static rotateX(out: Mat4Like, a: Readonly<Mat4Like>, rad: number): Mat4Like {
+  static rotateX<T extends Mat4Like>(out: T, a: Readonly<Mat4Like>, rad: number): T {
     let s = Math.sin(rad);
     let c = Math.cos(rad);
     let a10 = a[4];
@@ -897,7 +897,7 @@ export class Mat4 extends Float32Array {
    * @param rad - the angle to rotate the matrix by
    * @returns `out`
    */
-  static rotateY(out: Mat4Like, a: Readonly<Mat4Like>, rad: number): Mat4Like {
+  static rotateY<T extends Mat4Like>(out: T, a: Readonly<Mat4Like>, rad: number): T {
     let s = Math.sin(rad);
     let c = Math.cos(rad);
     let a00 = a[0];
@@ -942,7 +942,7 @@ export class Mat4 extends Float32Array {
    * @param rad - the angle to rotate the matrix by
    * @returns `out`
    */
-  static rotateZ(out: Mat4Like, a: Readonly<Mat4Like>, rad: number): Mat4Like {
+  static rotateZ<T extends Mat4Like>(out: T, a: Readonly<Mat4Like>, rad: number): T {
     let s = Math.sin(rad);
     let c = Math.cos(rad);
     let a00 = a[0];
@@ -990,7 +990,7 @@ export class Mat4 extends Float32Array {
    * @param v - Translation vector
    * @returns `out`
    */
-  static fromTranslation(out: Mat4Like, v: Readonly<Vec3Like>): Mat4Like {
+  static fromTranslation<T extends Mat4Like>(out: T, v: Readonly<Vec3Like>): T {
     out[0] = 1;
     out[1] = 0;
     out[2] = 0;
@@ -1022,7 +1022,7 @@ export class Mat4 extends Float32Array {
    * @param v - Scaling vector
    * @returns `out`
    */
-  static fromScaling(out: Mat4Like, v: Readonly<Vec3Like>): Mat4Like {
+  static fromScaling<T extends Mat4Like>(out: T, v: Readonly<Vec3Like>): T {
     out[0] = v[0];
     out[1] = 0;
     out[2] = 0;
@@ -1055,7 +1055,7 @@ export class Mat4 extends Float32Array {
    * @param axis - the axis to rotate around
    * @returns `out` or `null` if `axis` has a length of 0
    */
-  static fromRotation(out: Mat4Like, rad: number, axis: Readonly<Vec3Like>): Mat4Like | null {
+  static fromRotation<T extends Mat4Like>(out: T, rad: number, axis: Readonly<Vec3Like>): T | null {
     let x = axis[0];
     let y = axis[1];
     let z = axis[2];
@@ -1106,7 +1106,7 @@ export class Mat4 extends Float32Array {
    * @param rad - the angle to rotate the matrix by
    * @returns `out`
    */
-  static fromXRotation(out: Mat4Like, rad: number): Mat4Like {
+  static fromXRotation<T extends Mat4Like>(out: T, rad: number): T {
     let s = Math.sin(rad);
     let c = Math.cos(rad);
 
@@ -1142,7 +1142,7 @@ export class Mat4 extends Float32Array {
    * @param rad - the angle to rotate the matrix by
    * @returns `out`
    */
-  static fromYRotation(out: Mat4Like, rad: number): Mat4Like {
+  static fromYRotation<T extends Mat4Like>(out: T, rad: number): T {
     let s = Math.sin(rad);
     let c = Math.cos(rad);
 
@@ -1178,7 +1178,7 @@ export class Mat4 extends Float32Array {
    * @param rad - the angle to rotate the matrix by
    * @returns `out`
    */
-  static fromZRotation(out: Mat4Like, rad: number): Mat4Like {
+  static fromZRotation<T extends Mat4Like>(out: T, rad: number): T {
     const s = Math.sin(rad);
     const c = Math.cos(rad);
 
@@ -1218,7 +1218,7 @@ export class Mat4 extends Float32Array {
    * @param v - Translation vector
    * @returns `out`
    */
-  static fromRotationTranslation(out: Mat4Like, q: Readonly<QuatLike>, v: Readonly<Vec3Like>): Mat4Like {
+  static fromRotationTranslation<T extends Mat4Like>(out: T, q: Readonly<QuatLike>, v: Readonly<Vec3Like>): T {
     // Quaternion math
     const x = q[0];
     const y = q[1];
@@ -1266,7 +1266,7 @@ export class Mat4 extends Float32Array {
    * @param a - Dual Quaternion
    * @returns `out`
    */
-  static fromQuat2(out: Mat4Like, a: Quat2Like): Mat4Like {
+  static fromQuat2<T extends Mat4Like>(out: T, a: Quat2Like): T {
     const bx = -a[0];
     const by = -a[1];
     const bz = -a[2];
@@ -1300,7 +1300,7 @@ export class Mat4 extends Float32Array {
    * @param a - Mat4 to derive the normal matrix from
    * @returns `out`
    */
-  static normalFromMat4(out: Mat4Like, a: Readonly<Mat4Like>): Mat4Like {
+  static normalFromMat4<T extends Mat4Like>(out: T, a: Readonly<Mat4Like>): T {
     // Only difference from Mat3.adjoint() is the input and output indices.
     const a00 = a[0];
     const a01 = a[1];
@@ -1343,7 +1343,7 @@ export class Mat4 extends Float32Array {
    * @category Static
    * @deprecated Use {@link Mat4.normalFromMat4}
    */
-  static normalFromMat4Fast(out: Mat4Like, a: Readonly<Mat4Like>): Mat4Like { return out; }
+  static normalFromMat4Fast<T extends Mat4Like>(out: T, a: Readonly<Mat4Like>): T { return out; }
 
   /**
    * Returns the translation vector component of a transformation
@@ -1356,7 +1356,7 @@ export class Mat4 extends Float32Array {
    * @param  {ReadonlyMat4} mat Matrix to be decomposed (input)
    * @return {vec3} out
    */
-  static getTranslation(out: Vec3Like, mat: Readonly<Mat4Like>): Vec3Like {
+  static getTranslation<T extends Vec3Like>(out: T, mat: Readonly<Mat4Like>): T {
     out[0] = mat[12];
     out[1] = mat[13];
     out[2] = mat[14];
@@ -1376,7 +1376,7 @@ export class Mat4 extends Float32Array {
    * @param  {ReadonlyMat4} mat Matrix to be decomposed (input)
    * @return {vec3} out
    */
-  static getScaling(out: Vec3Like, mat: Readonly<Mat4Like>): Vec3Like {
+  static getScaling<T extends Vec3Like>(out: T, mat: Readonly<Mat4Like>): T {
     const m11 = mat[0];
     const m12 = mat[1];
     const m13 = mat[2];
@@ -1405,7 +1405,7 @@ export class Mat4 extends Float32Array {
    * @param mat - Matrix to be decomposed (input)
    * @return `out`
    */
-  static getRotation(out: QuatLike, mat: Readonly<Mat4Like>): QuatLike {
+  static getRotation<T extends QuatLike>(out: T, mat: Readonly<Mat4Like>): T {
     Mat4.getScaling(tmpVec3, mat);
 
     const is1 = 1 / tmpVec3[0];
@@ -1465,7 +1465,7 @@ export class Mat4 extends Float32Array {
    * @param mat - Matrix to be decomposed (input)
    * @returns `out_r`
    */
-  static decompose(out_r: QuatLike, out_t: Vec3Like, out_s: Vec3Like, mat: Readonly<Mat4Like>): QuatLike {
+  static decompose<T extends QuatLike>(out_r: T, out_t: Vec3Like, out_s: Vec3Like, mat: Readonly<Mat4Like>): T {
     out_t[0] = mat[12];
     out_t[1] = mat[13];
     out_t[2] = mat[14];
@@ -1548,7 +1548,7 @@ export class Mat4 extends Float32Array {
    * @param s - Scaling vector
    * @returns `out`
    */
-  static fromRotationTranslationScale(out: Mat4Like, q: Readonly<QuatLike>, v: Readonly<Vec3Like>, s: Readonly<Vec3Like>): Mat4Like {
+  static fromRotationTranslationScale<T extends Mat4Like>(out: T, q: Readonly<QuatLike>, v: Readonly<Vec3Like>, s: Readonly<Vec3Like>): T {
     // Quaternion math
     const x = q[0];
     const y = q[1];
@@ -1612,7 +1612,7 @@ export class Mat4 extends Float32Array {
    * @param o - The origin vector around which to scale and rotate
    * @returns `out`
    */
-  static fromRotationTranslationScaleOrigin(out: Mat4Like, q: Readonly<QuatLike>, v: Readonly<Vec3Like>, s: Readonly<Vec3Like>, o: Readonly<Vec3Like>): Mat4Like {
+  static fromRotationTranslationScaleOrigin<T extends Mat4Like>(out: T, q: Readonly<QuatLike>, v: Readonly<Vec3Like>, s: Readonly<Vec3Like>, o: Readonly<Vec3Like>): T {
     // Quaternion math
     const x = q[0];
     const y = q[1];
@@ -1678,7 +1678,7 @@ export class Mat4 extends Float32Array {
    * @param q - Quaternion to create matrix from
    * @returns `out`
    */
-  static fromQuat(out: Mat4Like, q: Readonly<QuatLike>): Mat4Like {
+  static fromQuat<T extends Mat4Like>(out: T, q: Readonly<QuatLike>): T {
     const x = q[0];
     const y = q[1];
     const z = q[2];
@@ -1736,7 +1736,7 @@ export class Mat4 extends Float32Array {
    * @param far -  Far bound of the frustum, can be null or Infinity
    * @returns `out`
    */
-  static frustumNO(out: Mat4Like, left: number, right: number, bottom: number, top: number, near: number, far: number = Infinity): Mat4Like {
+  static frustumNO<T extends Mat4Like>(out: T, left: number, right: number, bottom: number, top: number, near: number, far: number = Infinity): T {
     const rl = 1 / (right - left);
     const tb = 1 / (top - bottom);
     out[0] = near * 2 * rl;
@@ -1770,7 +1770,7 @@ export class Mat4 extends Float32Array {
    * @category Static
    * @deprecated Use {@link Mat4.frustumNO} or {@link Mat4.frustumZO} explicitly
    */
-  static frustum(out: Mat4Like, left: number, right: number, bottom: number, top: number, near: number, far: number = Infinity): Mat4Like { return out; }
+  static frustum<T extends Mat4Like>(out: T, left: number, right: number, bottom: number, top: number, near: number, far: number = Infinity): T { return out; }
 
   /**
    * Generates a frustum matrix with the given bounds
@@ -1788,7 +1788,7 @@ export class Mat4 extends Float32Array {
    * @param far - Far bound of the frustum, can be null or Infinity
    * @returns `out`
    */
-  static frustumZO(out: Mat4Like, left: number, right: number, bottom: number, top: number, near: number, far: number = Infinity): Mat4Like {
+  static frustumZO<T extends Mat4Like>(out: T, left: number, right: number, bottom: number, top: number, near: number, far: number = Infinity): T {
     const rl = 1 / (right - left);
     const tb = 1 / (top - bottom);
     out[0] = near * 2 * rl;
@@ -1831,7 +1831,7 @@ export class Mat4 extends Float32Array {
    * @param far - Far bound of the frustum, can be null or Infinity
    * @returns `out`
    */
-  static perspectiveNO(out: Mat4Like, fovy: number, aspect: number, near: number, far: number = Infinity): Mat4Like {
+  static perspectiveNO<T extends Mat4Like>(out: T, fovy: number, aspect: number, near: number, far: number = Infinity): T {
     const f = 1.0 / Math.tan(fovy / 2);
     out[0] = f / aspect;
     out[1] = 0;
@@ -1863,7 +1863,7 @@ export class Mat4 extends Float32Array {
    * @category Static
    * @deprecated Use {@link Mat4.perspectiveNO} or {@link Mat4.perspectiveZO} explicitly
    */
-  static perspective(out: Mat4Like, fovy: number, aspect: number, near: number, far: number = Infinity): Mat4Like { return out; }
+  static perspective<T extends Mat4Like>(out: T, fovy: number, aspect: number, near: number, far: number = Infinity): T { return out; }
 
   /**
    * Generates a perspective projection matrix suitable for WebGPU with the given bounds.
@@ -1879,7 +1879,7 @@ export class Mat4 extends Float32Array {
    * @param far - Far bound of the frustum, can be null or Infinity
    * @returns `out`
    */
-  static perspectiveZO(out: Mat4Like, fovy: number, aspect: number, near: number, far: number = Infinity): Mat4Like {
+  static perspectiveZO<T extends Mat4Like>(out: T, fovy: number, aspect: number, near: number, far: number = Infinity): T {
     const f = 1.0 / Math.tan(fovy / 2);
     out[0] = f / aspect;
     out[1] = 0;
@@ -1919,7 +1919,7 @@ export class Mat4 extends Float32Array {
    * @returns `out`
    * @deprecated
    */
-  static perspectiveFromFieldOfView(out: Mat4Like, fov, near: number, far: number): Mat4Like {
+  static perspectiveFromFieldOfView<T extends Mat4Like>(out: T, fov, near: number, far: number): T {
     const upTan = Math.tan((fov.upDegrees * Math.PI) / 180.0);
     const downTan = Math.tan((fov.downDegrees * Math.PI) / 180.0);
     const leftTan = Math.tan((fov.leftDegrees * Math.PI) / 180.0);
@@ -1961,7 +1961,7 @@ export class Mat4 extends Float32Array {
    * @param far - Far bound of the frustum
    * @returns `out`
    */
-  static orthoNO(out: Mat4Like, left: number, right: number, bottom: number, top: number, near: number, far: number): Mat4Like {
+  static orthoNO<T extends Mat4Like>(out: T, left: number, right: number, bottom: number, top: number, near: number, far: number): T {
     const lr = 1 / (left - right);
     const bt = 1 / (bottom - top);
     const nf = 1 / (near - far);
@@ -1989,7 +1989,7 @@ export class Mat4 extends Float32Array {
    * @category Static
    * @deprecated Use {@link Mat4.orthoNO} or {@link Mat4.orthoZO} explicitly
    */
-  static ortho(out: Mat4Like, left: number, right: number, bottom: number, top: number, near: number, far: number): Mat4Like { return out; }
+  static ortho<T extends Mat4Like>(out: T, left: number, right: number, bottom: number, top: number, near: number, far: number): T { return out; }
 
   /**
    * Generates a orthogonal projection matrix with the given bounds.
@@ -2006,7 +2006,7 @@ export class Mat4 extends Float32Array {
    * @param far - Far bound of the frustum
    * @returns `out`
    */
-  static orthoZO(out: Mat4Like, left: number, right: number, bottom: number, top: number, near: number, far: number): Mat4Like {
+  static orthoZO<T extends Mat4Like>(out: T, left: number, right: number, bottom: number, top: number, near: number, far: number): T {
     const lr = 1 / (left - right);
     const bt = 1 / (bottom - top);
     const nf = 1 / (near - far);
@@ -2040,7 +2040,7 @@ export class Mat4 extends Float32Array {
    * @param up - vec3 pointing up
    * @returns `out`
    */
-  static lookAt(out: Mat4Like, eye: Readonly<Vec3Like>, center: Readonly<Vec3Like>, up: Readonly<Vec3Like>): Mat4Like {
+  static lookAt<T extends Mat4Like>(out: T, eye: Readonly<Vec3Like>, center: Readonly<Vec3Like>, up: Readonly<Vec3Like>): T {
     const eyex = eye[0];
     const eyey = eye[1];
     const eyez = eye[2];
@@ -2129,7 +2129,7 @@ export class Mat4 extends Float32Array {
    * @param up - vec3 pointing up
    * @returns `out`
    */
-  static targetTo(out: Mat4Like, eye: Readonly<Vec3Like>, target: Readonly<Vec3Like>, up: Readonly<Vec3Like>): Mat4Like {
+  static targetTo<T extends Mat4Like>(out: T, eye: Readonly<Vec3Like>, target: Readonly<Vec3Like>, up: Readonly<Vec3Like>): T {
     const eyex = eye[0];
     const eyey = eye[1];
     const eyez = eye[2];
@@ -2217,7 +2217,7 @@ export class Mat4 extends Float32Array {
    * @param b - the second operand
    * @returns `out`
    */
-  static add(out: Mat4Like, a: Readonly<Mat4Like>, b: Readonly<Mat4Like>): Mat4Like {
+  static add<T extends Mat4Like>(out: T, a: Readonly<Mat4Like>, b: Readonly<Mat4Like>): T {
     out[0] = a[0] + b[0];
     out[1] = a[1] + b[1];
     out[2] = a[2] + b[2];
@@ -2246,7 +2246,7 @@ export class Mat4 extends Float32Array {
    * @param b - the second operand
    * @returns `out`
    */
-  static subtract(out: Mat4Like, a: Readonly<Mat4Like>, b: Readonly<Mat4Like>): Mat4Like {
+  static subtract<T extends Mat4Like>(out: T, a: Readonly<Mat4Like>, b: Readonly<Mat4Like>): T {
     out[0] = a[0] - b[0];
     out[1] = a[1] - b[1];
     out[2] = a[2] - b[2];
@@ -2269,7 +2269,7 @@ export class Mat4 extends Float32Array {
    * Alias for {@link Mat4.subtract}
    * @category Static
    */
-  static sub(out: Mat4Like, a: Readonly<Mat4Like>, b: Readonly<Mat4Like>): Mat4Like { return out; }
+  static sub<T extends Mat4Like>(out: T, a: Readonly<Mat4Like>, b: Readonly<Mat4Like>): T { return out; }
 
   /**
    * Multiply each element of the matrix by a scalar.
@@ -2280,7 +2280,7 @@ export class Mat4 extends Float32Array {
    * @param b - amount to scale the matrix's elements by
    * @returns `out`
    */
-  static multiplyScalar(out: Mat4Like, a: Readonly<Mat4Like>, b: number): Mat4Like {
+  static multiplyScalar<T extends Mat4Like>(out: T, a: Readonly<Mat4Like>, b: number): T {
     out[0] = a[0] * b;
     out[1] = a[1] * b;
     out[2] = a[2] * b;
@@ -2310,7 +2310,7 @@ export class Mat4 extends Float32Array {
    * @param scale - the amount to scale b's elements by before adding
    * @returns `out`
    */
-  static multiplyScalarAndAdd(out: Mat4Like, a: Readonly<Mat4Like>, b: Readonly<Mat4Like>, scale: number): Mat4Like {
+  static multiplyScalarAndAdd<T extends Mat4Like>(out: T, a: Readonly<Mat4Like>, b: Readonly<Mat4Like>, scale: number): T {
     out[0] = a[0] + b[0] * scale;
     out[1] = a[1] + b[1] * scale;
     out[2] = a[2] + b[2] * scale;

--- a/src/quat.ts
+++ b/src/quat.ts
@@ -143,7 +143,7 @@ export class Quat extends Float32Array {
    * @returns `this`
    */
   multiply(b: Readonly<QuatLike>): Quat {
-    return Quat.multiply(this, this, b) as Quat;
+    return Quat.multiply(this, this, b);
   }
 
   /**
@@ -159,7 +159,7 @@ export class Quat extends Float32Array {
    * @returns `this`
    */
   rotateX(rad: number): Quat {
-    return Quat.rotateX(this, this, rad) as Quat;
+    return Quat.rotateX(this, this, rad);
   }
 
   /**
@@ -170,7 +170,7 @@ export class Quat extends Float32Array {
    * @returns `this`
    */
   rotateY(rad: number): Quat {
-    return Quat.rotateY(this, this, rad) as Quat;
+    return Quat.rotateY(this, this, rad);
   }
 
   /**
@@ -181,7 +181,7 @@ export class Quat extends Float32Array {
    * @returns `this`
    */
   rotateZ(rad: number): Quat {
-    return Quat.rotateZ(this, this, rad) as Quat;
+    return Quat.rotateZ(this, this, rad);
   }
 
   /**
@@ -191,7 +191,7 @@ export class Quat extends Float32Array {
    * @returns `this`
    */
   invert(): Quat {
-    return Quat.invert(this, this) as Quat;
+    return Quat.invert(this, this);
   }
 
   /**
@@ -243,7 +243,7 @@ export class Quat extends Float32Array {
    * @param out - the receiving quaternion
    * @returns `out`
    */
-  static identity(out: QuatLike): QuatLike {
+  static identity<T extends QuatLike>(out: T): T {
     out[0] = 0;
     out[1] = 0;
     out[2] = 0;
@@ -261,7 +261,7 @@ export class Quat extends Float32Array {
    * @param rad - the angle in radians
    * @returns `out`
    **/
-  static setAxisAngle(out: QuatLike, axis: Readonly<Vec3Like>, rad: number): QuatLike {
+  static setAxisAngle<T extends QuatLike>(out: T, axis: Readonly<Vec3Like>, rad: number): T {
     rad = rad * 0.5;
     const s = Math.sin(rad);
     out[0] = s * axis[0];
@@ -325,7 +325,7 @@ export class Quat extends Float32Array {
    * @param b - the second operand
    * @returns `out`
    */
-  static multiply(out: QuatLike, a: Readonly<QuatLike>, b: Readonly<QuatLike>): QuatLike {
+  static multiply<T extends QuatLike>(out: T, a: Readonly<QuatLike>, b: Readonly<QuatLike>): T {
     const ax = a[0];
     const ay = a[1];
     const az = a[2];
@@ -351,7 +351,7 @@ export class Quat extends Float32Array {
    * @param rad - angle (in radians) to rotate
    * @returns `out`
    */
-  static rotateX(out: QuatLike, a: Readonly<QuatLike>, rad: number): QuatLike {
+  static rotateX<T extends QuatLike>(out: T, a: Readonly<QuatLike>, rad: number): T {
     rad *= 0.5;
 
     const ax = a[0];
@@ -377,7 +377,7 @@ export class Quat extends Float32Array {
    * @param rad - angle (in radians) to rotate
    * @returns `out`
    */
-  static rotateY(out: QuatLike, a: Readonly<QuatLike>, rad: number): QuatLike {
+  static rotateY<T extends QuatLike>(out: T, a: Readonly<QuatLike>, rad: number): T {
     rad *= 0.5;
 
     const ax = a[0];
@@ -403,7 +403,7 @@ export class Quat extends Float32Array {
    * @param rad - angle (in radians) to rotate
    * @returns `out`
    */
-  static rotateZ(out: QuatLike, a: Readonly<QuatLike>, rad: number): QuatLike {
+  static rotateZ<T extends QuatLike>(out: T, a: Readonly<QuatLike>, rad: number): T {
     rad *= 0.5;
 
     const ax = a[0];
@@ -430,7 +430,7 @@ export class Quat extends Float32Array {
    * @param a - quat to calculate W component of
    * @returns `out`
    */
-  static calculateW(out: QuatLike, a: Readonly<QuatLike>): QuatLike {
+  static calculateW<T extends QuatLike>(out: T, a: Readonly<QuatLike>): T {
     const x = a[0],
       y = a[1],
       z = a[2];
@@ -450,7 +450,7 @@ export class Quat extends Float32Array {
    * @param a - quat to calculate the exponential of
    * @returns `out`
    */
-  static exp(out: QuatLike, a: Readonly<QuatLike>): QuatLike {
+  static exp<T extends QuatLike>(out: T, a: Readonly<QuatLike>): T {
     const x = a[0],
       y = a[1],
       z = a[2],
@@ -476,7 +476,7 @@ export class Quat extends Float32Array {
    * @param a - quat to calculate the exponential of
    * @returns `out`
    */
-  static ln(out: QuatLike, a: Readonly<QuatLike>): QuatLike {
+  static ln<T extends QuatLike>(out: T, a: Readonly<QuatLike>): T {
     const x = a[0],
       y = a[1],
       z = a[2],
@@ -502,7 +502,7 @@ export class Quat extends Float32Array {
    * @param b - amount to scale the quaternion by
    * @returns `out`
    */
-  static pow(out: QuatLike, a: Readonly<QuatLike>, b: number): QuatLike {
+  static pow<T extends QuatLike>(out: T, a: Readonly<QuatLike>, b: number): T {
     Quat.ln(out, a);
     Quat.scale(out, out, b);
     Quat.exp(out, out);
@@ -519,7 +519,7 @@ export class Quat extends Float32Array {
    * @param t - interpolation amount, in the range [0-1], between the two inputs
    * @returns `out`
    */
-  static slerp(out: QuatLike, a: Readonly<QuatLike>, b: Readonly<QuatLike>, t: number): QuatLike {
+  static slerp<T extends QuatLike>(out: T, a: Readonly<QuatLike>, b: Readonly<QuatLike>, t: number): T {
     // benchmarks:
     //    http://jsperf.com/quaternion-slerp-implementations
     const ax = a[0],
@@ -598,7 +598,7 @@ export class Quat extends Float32Array {
    * @param a - quat to calculate inverse of
    * @returns `out`
    */
-  static invert(out: QuatLike, a: Readonly<QuatLike>): QuatLike {
+  static invert<T extends QuatLike>(out: T, a: Readonly<QuatLike>): T {
     const a0 = a[0],
       a1 = a[1],
       a2 = a[2],
@@ -624,7 +624,7 @@ export class Quat extends Float32Array {
    * @param a - quat to calculate conjugate of
    * @returns `out`
    */
-  static conjugate(out: QuatLike, a: Readonly<QuatLike>): QuatLike {
+  static conjugate<T extends QuatLike>(out: T, a: Readonly<QuatLike>): T {
     out[0] = -a[0];
     out[1] = -a[1];
     out[2] = -a[2];
@@ -643,7 +643,7 @@ export class Quat extends Float32Array {
    * @param m - rotation matrix
    * @returns `out`
    */
-  static fromMat3(out: QuatLike, m: Readonly<Mat3Like>): QuatLike {
+  static fromMat3<T extends QuatLike>(out: T, m: Readonly<Mat3Like>): T {
     // Algorithm in Ken Shoemake's article in 1987 SIGGRAPH course notes
     // article "Quaternion Calculus and Fast Animation".
     const fTrace = m[0] + m[4] + m[8];
@@ -687,7 +687,7 @@ export class Quat extends Float32Array {
    * @param {'xyz'|'xzy'|'yxz'|'yzx'|'zxy'|'zyx'} order - Intrinsic order for conversion, default is zyx.
    * @returns `out`
    */
-  static fromEuler(out: QuatLike, x: number, y: number, z: number, order = ANGLE_ORDER): QuatLike {
+  static fromEuler<T extends QuatLike>(out: T, x: number, y: number, z: number, order = ANGLE_ORDER): T {
     let halfToRad = (0.5 * Math.PI) / 180.0;
     x *= halfToRad;
     y *= halfToRad;
@@ -794,7 +794,7 @@ export class Quat extends Float32Array {
    * @param a - the source quaternion
    * @returns `out`
    */
-  static copy(out: QuatLike, a: Readonly<QuatLike>): QuatLike {
+  static copy<T extends QuatLike>(out: T, a: Readonly<QuatLike>): T {
     out[0] = a[0];
     out[1] = a[1];
     out[2] = a[2];
@@ -813,7 +813,7 @@ export class Quat extends Float32Array {
    * @param w - W component
    * @returns `out`
    */
-  static set(out: QuatLike, x: number, y: number, z: number, w: number): QuatLike { return out; }
+  static set<T extends QuatLike>(out: T, x: number, y: number, z: number, w: number): T { return out; }
 
   /**
    * Adds two {@link Quat}'s
@@ -824,13 +824,13 @@ export class Quat extends Float32Array {
    * @param b - the second operand
    * @returns `out`
    */
-  static add(out: QuatLike, a: Readonly<QuatLike>, b: Readonly<QuatLike>): QuatLike { return out; }
+  static add<T extends QuatLike>(out: T, a: Readonly<QuatLike>, b: Readonly<QuatLike>): T { return out; }
 
   /**
    * Alias for {@link Quat.multiply}
    * @category Static
    */
-  static mul(out: QuatLike, a: Readonly<QuatLike>, b: Readonly<QuatLike>): QuatLike { return out; }
+  static mul<T extends QuatLike>(out: T, a: Readonly<QuatLike>, b: Readonly<QuatLike>): T { return out; }
 
   /**
    * Scales a quat by a scalar number
@@ -841,7 +841,7 @@ export class Quat extends Float32Array {
    * @param b - amount to scale the vector by
    * @returns `out`
    */
-  static scale(out: QuatLike, a: Readonly<QuatLike>, scale: number): QuatLike {
+  static scale<T extends QuatLike>(out: T, a: Readonly<QuatLike>, scale: number): T {
     out[0] = a[0] * scale;
     out[1] = a[1] * scale;
     out[2] = a[2] * scale;
@@ -871,7 +871,7 @@ export class Quat extends Float32Array {
    * @param t - interpolation amount, in the range [0-1], between the two inputs
    * @returns `out`
    */
-   static lerp(out: QuatLike, a: Readonly<QuatLike>, b: Readonly<QuatLike>, t: number): QuatLike { return out }
+   static lerp<T extends QuatLike>(out: T, a: Readonly<QuatLike>, b: Readonly<QuatLike>, t: number): T { return out }
 
   /**
    * Calculates the magnitude (length) of a {@link Quat}
@@ -926,7 +926,7 @@ export class Quat extends Float32Array {
    * @param a - quaternion to normalize
    * @returns `out`
    */
-  static normalize(out: QuatLike, a: Readonly<QuatLike>): QuatLike { return out; }
+  static normalize<T extends QuatLike>(out: T, a: Readonly<QuatLike>): T { return out; }
 
   /**
    * Returns whether or not the quaternions have exactly the same elements in the same position (when compared with ===)
@@ -960,7 +960,7 @@ export class Quat extends Float32Array {
    * @param b - the destination vector
    * @returns `out`
    */
-  static rotationTo(out: QuatLike, a: Readonly<Vec3Like>, b: Readonly<Vec3Like>): QuatLike {
+  static rotationTo<T extends QuatLike>(out: T, a: Readonly<Vec3Like>, b: Readonly<Vec3Like>): T {
     let dot = Vec3.dot(a, b);
     if (dot < -0.999999) {
       Vec3.cross(tmpVec3, xUnitVec3, a);
@@ -996,7 +996,7 @@ export class Quat extends Float32Array {
    * @param t - interpolation amount, in the range [0-1], between the two inputs
    * @returns `out`
    */
-  static sqlerp(out: QuatLike, a: Readonly<QuatLike>, b: Readonly<QuatLike>, c: Readonly<QuatLike>, d: Readonly<QuatLike>, t: number): QuatLike {
+  static sqlerp<T extends QuatLike>(out: T, a: Readonly<QuatLike>, b: Readonly<QuatLike>, c: Readonly<QuatLike>, d: Readonly<QuatLike>, t: number): T {
     Quat.slerp(tmpQuat1, a, d, t);
     Quat.slerp(tmpQuat2, b, c, t);
     Quat.slerp(out, tmpQuat1, tmpQuat2, 2 * t * (1 - t));
@@ -1016,7 +1016,7 @@ export class Quat extends Float32Array {
    * @param up - the vector representing the local "up" direction
    * @returns `out`
    */
-  static setAxes(out: QuatLike, view: Readonly<Vec3Like>, right: Readonly<Vec3Like>, up: Readonly<Vec3Like>): QuatLike {
+  static setAxes<T extends QuatLike>(out: T, view: Readonly<Vec3Like>, right: Readonly<Vec3Like>, up: Readonly<Vec3Like>): T {
     tmpMat3[0] = right[0];
     tmpMat3[3] = right[1];
     tmpMat3[6] = right[2];

--- a/src/quat2.ts
+++ b/src/quat2.ts
@@ -153,7 +153,7 @@ export class Quat2 extends Float32Array {
    * @param t - translation vector
    * @returns `out`
    */
-  static fromRotationTranslation(out: Quat2Like, q: Readonly<QuatLike>, t: Readonly<Vec3Like>): Quat2Like {
+  static fromRotationTranslation<T extends Quat2Like>(out: T, q: Readonly<QuatLike>, t: Readonly<Vec3Like>): T {
     const ax = t[0] * 0.5;
     const ay = t[1] * 0.5;
     const az = t[2] * 0.5;
@@ -180,7 +180,7 @@ export class Quat2 extends Float32Array {
    * @param t - translation vector
    * @returns `out`
    */
-  static fromTranslation(out: Quat2Like, t: Readonly<Vec3Like>): Quat2Like {
+  static fromTranslation<T extends Quat2Like>(out: T, t: Readonly<Vec3Like>): T {
     out[0] = 0;
     out[1] = 0;
     out[2] = 0;
@@ -200,7 +200,7 @@ export class Quat2 extends Float32Array {
    * @param q - a normalized quaternion
    * @returns `out`
    */
-  static fromRotation(out: Quat2Like, q: Readonly<QuatLike>): Quat2Like {
+  static fromRotation<T extends Quat2Like>(out: T, q: Readonly<QuatLike>): T {
     out[0] = q[0];
     out[1] = q[1];
     out[2] = q[2];
@@ -220,7 +220,7 @@ export class Quat2 extends Float32Array {
    * @param a - the matrix
    * @returns `out`
    */
-  static fromMat4(out: Quat2Like, a: Readonly<Mat4Like>): Quat2Like {
+  static fromMat4<T extends Quat2Like>(out: T, a: Readonly<Mat4Like>): T {
     Mat4.getRotation(tmpQuat, a);
     Mat4.getTranslation(tmpVec3, a);
     return Quat2.fromRotationTranslation(out, tmpQuat, tmpVec3);
@@ -234,7 +234,7 @@ export class Quat2 extends Float32Array {
    * @param a - the source dual quaternion
    * @returns `out`
    */
-  static copy(out: Quat2Like, a: Readonly<Quat2Like>): Quat2Like {
+  static copy<T extends Quat2Like>(out: T, a: Readonly<Quat2Like>): T {
     out[0] = a[0];
     out[1] = a[1];
     out[2] = a[2];
@@ -253,7 +253,7 @@ export class Quat2 extends Float32Array {
    * @param out - the receiving dual quaternion
    * @returns `out`
    */
-  static identity(out: QuatLike): QuatLike {
+  static identity<T extends Quat2Like>(out: T): T {
     out[0] = 0;
     out[1] = 0;
     out[2] = 0;
@@ -280,8 +280,8 @@ export class Quat2 extends Float32Array {
    * @param w2 - 2nd W component
    * @returns `out`
    */
-  static set(out: Quat2Like, x1: number, y1: number, z1: number, w1: number,
-                             x2: number, y2: number, z2: number, w2: number): Quat2Like {
+  static set<T extends Quat2Like>(out: T, x1: number, y1: number, z1: number, w1: number,
+                                  x2: number, y2: number, z2: number, w2: number): T {
     out[0] = x1;
     out[1] = y1;
     out[2] = z1;
@@ -301,7 +301,7 @@ export class Quat2 extends Float32Array {
    * @param a - Dual Quaternion
    * @return `out`
    */
-  static getReal(out: QuatLike, a: Readonly<Quat2Like>): QuatLike {
+  static getReal<T extends QuatLike>(out: T, a: Readonly<Quat2Like>): T {
     out[0] = a[0];
     out[1] = a[1];
     out[2] = a[2];
@@ -317,7 +317,7 @@ export class Quat2 extends Float32Array {
    * @param a - Dual Quaternion
    * @return `out`
    */
-  static getDual(out: QuatLike, a: Readonly<Quat2Like>): QuatLike {
+  static getDual<T extends QuatLike>(out: T, a: Readonly<Quat2Like>): T {
     out[0] = a[4];
     out[1] = a[5];
     out[2] = a[6];
@@ -333,7 +333,7 @@ export class Quat2 extends Float32Array {
    * @param a - a quaternion representing the real part
    * @return `out`
    */
-  static setReal(out: Quat2Like, a: Readonly<QuatLike>): Quat2Like {
+  static setReal<T extends Quat2Like>(out: T, a: Readonly<QuatLike>): T {
     out[0] = a[0];
     out[1] = a[1];
     out[2] = a[2];
@@ -349,7 +349,7 @@ export class Quat2 extends Float32Array {
    * @param a - a quaternion representing the dual part
    * @return `out`
    */
-  static setDual(out: Quat2Like, a: Readonly<QuatLike>): Quat2Like {
+  static setDual<T extends Quat2Like>(out: T, a: Readonly<QuatLike>): T {
     out[4] = a[0];
     out[5] = a[1];
     out[6] = a[2];
@@ -365,7 +365,7 @@ export class Quat2 extends Float32Array {
    * @param a - Dual Quaternion to be decomposed
    * @return `out`
    */
-  static getTranslation(out: Vec3Like, a: Readonly<Quat2Like>): Vec3Like {
+  static getTranslation<T extends Vec3Like>(out: T, a: Readonly<Quat2Like>): T {
     const ax = a[4];
     const ay = a[5];
     const az = a[6];
@@ -389,7 +389,7 @@ export class Quat2 extends Float32Array {
    * @param v - vector to translate by
    * @returns `out`
    */
-  static translate(out: Quat2Like, a: Readonly<Quat2Like>, v: Readonly<Vec3Like>): Quat2Like {
+  static translate<T extends Quat2Like>(out: T, a: Readonly<Quat2Like>, v: Readonly<Vec3Like>): T {
     const ax1 = a[0];
     const ay1 = a[1];
     const az1 = a[2];
@@ -421,7 +421,7 @@ export class Quat2 extends Float32Array {
    * @param rad - angle (in radians) to rotate
    * @returns `out`
    */
-  static rotateX(out: Quat2Like, a: Readonly<Quat2Like>, rad: number): Quat2Like {
+  static rotateX<T extends Quat2Like>(out: T, a: Readonly<Quat2Like>, rad: number): T {
     let bx = -a[0];
     let by = -a[1];
     let bz = -a[2];
@@ -455,7 +455,7 @@ export class Quat2 extends Float32Array {
    * @param rad - angle (in radians) to rotate
    * @returns `out`
    */
-  static rotateY(out: Quat2Like, a: Readonly<Quat2Like>, rad: number): Quat2Like {
+  static rotateY<T extends Quat2Like>(out: T, a: Readonly<Quat2Like>, rad: number): T {
     let bx = -a[0];
     let by = -a[1];
     let bz = -a[2];
@@ -489,7 +489,7 @@ export class Quat2 extends Float32Array {
    * @param rad - angle (in radians) to rotate
    * @returns `out`
    */
-  static rotateZ(out: Quat2Like, a: Readonly<Quat2Like>, rad: number): Quat2Like {
+  static rotateZ<T extends Quat2Like>(out: T, a: Readonly<Quat2Like>, rad: number): T {
     let bx = -a[0];
     let by = -a[1];
     let bz = -a[2];
@@ -523,7 +523,7 @@ export class Quat2 extends Float32Array {
    * @param q - quaternion to rotate by
    * @returns `out`
    */
-  static rotateByQuatAppend(out: Quat2Like, a: Readonly<Quat2Like>, q: Readonly<QuatLike>): Quat2Like {
+  static rotateByQuatAppend<T extends Quat2Like>(out: T, a: Readonly<Quat2Like>, q: Readonly<QuatLike>): T {
     const qx = q[0];
     const qy = q[1];
     const qz = q[2];
@@ -557,7 +557,7 @@ export class Quat2 extends Float32Array {
    * @param a - the dual quaternion to rotate
    * @returns `out`
    */
-  static rotateByQuatPrepend(out: Quat2Like, q: Readonly<QuatLike>, a: Readonly<Quat2Like>): Quat2Like {
+  static rotateByQuatPrepend<T extends Quat2Like>(out: T, q: Readonly<QuatLike>, a: Readonly<Quat2Like>): T {
     const qx = q[0];
     const qy = q[1];
     const qz = q[2];
@@ -592,7 +592,7 @@ export class Quat2 extends Float32Array {
    * @param rad - how far the rotation should be
    * @returns `out`
    */
-  static rotateAroundAxis(out: Quat2Like, a: Readonly<Quat2Like>, axis: Readonly<Vec3Like>, rad: number): Quat2Like {
+  static rotateAroundAxis<T extends Quat2Like>(out: T, a: Readonly<Quat2Like>, axis: Readonly<Vec3Like>, rad: number): T {
     //Special case for rad = 0
     if (Math.abs(rad) < EPSILON) {
       return Quat2.copy(out, a);
@@ -636,7 +636,7 @@ export class Quat2 extends Float32Array {
    * @param b - the second operand
    * @returns `out`
    */
-  static add(out: Quat2Like, a: Readonly<Quat2Like>, b: Readonly<Quat2Like>): Quat2Like {
+  static add<T extends Quat2Like>(out: T, a: Readonly<Quat2Like>, b: Readonly<Quat2Like>): T {
     out[0] = a[0] + b[0];
     out[1] = a[1] + b[1];
     out[2] = a[2] + b[2];
@@ -657,7 +657,7 @@ export class Quat2 extends Float32Array {
    * @param b - the second operand
    * @returns {quat2} out
    */
-  static multiply(out: Quat2Like, a: Readonly<Quat2Like>, b: Readonly<Quat2Like>): Quat2Like {
+  static multiply<T extends Quat2Like>(out: T, a: Readonly<Quat2Like>, b: Readonly<Quat2Like>): T {
     const ax0 = a[0];
     const ay0 = a[1];
     const az0 = a[2];
@@ -721,7 +721,7 @@ export class Quat2 extends Float32Array {
    * Alias for {@link Quat2.multiply}
    * @category Static
    */
-  static mul(out: Quat2Like, a: Readonly<Quat2Like>, b: Readonly<Quat2Like>): Quat2Like { return out; }
+  static mul<T extends Quat2Like>(out: T, a: Readonly<Quat2Like>, b: Readonly<Quat2Like>): T { return out; }
 
   /**
    * Scales a {@link Quat2} by a scalar value
@@ -732,7 +732,7 @@ export class Quat2 extends Float32Array {
    * @param b - scalar value to scale the dual quaterion by
    * @returns `out`
    */
-  static scale(out: Quat2Like, a: Readonly<Quat2Like>, b: number): Quat2Like {
+  static scale<T extends Quat2Like>(out: T, a: Readonly<Quat2Like>, b: number): T {
     out[0] = a[0] * b;
     out[1] = a[1] * b;
     out[2] = a[2] * b;
@@ -765,7 +765,7 @@ export class Quat2 extends Float32Array {
    * @param t - interpolation amount, in the range [0-1], between the two inputs
    * @returns `out`
    */
-  static lerp(out: Quat2Like, a: Readonly<Quat2Like>, b: Readonly<Quat2Like>, t: number): Quat2Like {
+  static lerp<T extends Quat2Like>(out: T, a: Readonly<Quat2Like>, b: Readonly<Quat2Like>, t: number): T {
     const mt = 1 - t;
     if (Quat2.dot(a, b) < 0) t = -t;
 
@@ -789,7 +789,7 @@ export class Quat2 extends Float32Array {
    * @param a - dual quat to calculate inverse of
    * @returns `out`
    */
-  static invert(out: Quat2Like, a: Readonly<Quat2Like>): Quat2Like {
+  static invert<T extends Quat2Like>(out: T, a: Readonly<Quat2Like>): T {
     const sqlen = Quat2.squaredLength(a);
     out[0] = -a[0] / sqlen;
     out[1] = -a[1] / sqlen;
@@ -811,7 +811,7 @@ export class Quat2 extends Float32Array {
    * @param a - dual quaternion to calculate conjugate of
    * @returns `out`
    */
-  static conjugate(out: Quat2Like, a: Readonly<Quat2Like>): Quat2Like {
+  static conjugate<T extends Quat2Like>(out: T, a: Readonly<Quat2Like>): T {
     out[0] = -a[0];
     out[1] = -a[1];
     out[2] = -a[2];
@@ -876,7 +876,7 @@ export class Quat2 extends Float32Array {
    * @param a - dual quaternion to normalize
    * @returns `out`
    */
-  static normalize(out: Quat2Like, a: Readonly<Quat2Like>): Quat2Like {
+  static normalize<T extends Quat2Like>(out: T, a: Readonly<Quat2Like>): T {
     let magnitude = Quat2.squaredLength(a);
     if (magnitude > 0) {
       magnitude = Math.sqrt(magnitude);

--- a/src/vec2.ts
+++ b/src/vec2.ts
@@ -315,7 +315,7 @@ export class Vec2 extends Float32Array {
    * @returns `this`
    */
    normalize(): Vec2 {
-    return Vec2.normalize(this, this) as Vec2;
+    return Vec2.normalize(this, this);
   }
 
   //================
@@ -363,7 +363,7 @@ export class Vec2 extends Float32Array {
    * @param a - The source vector
    * @returns `out`
    */
-  static copy(out: Vec2Like, a: Readonly<Vec2Like>): Vec2Like {
+  static copy<T extends Vec2Like>(out: T, a: Readonly<Vec2Like>): T {
     out[0] = a[0];
     out[1] = a[1];
     return out;
@@ -378,7 +378,7 @@ export class Vec2 extends Float32Array {
    * @param y - Y component
    * @returns `out`
    */
-  static set(out: Vec2Like, x: number, y: number): Vec2Like {
+  static set<T extends Vec2Like>(out: T, x: number, y: number): T {
     out[0] = x;
     out[1] = y;
     return out;
@@ -393,7 +393,7 @@ export class Vec2 extends Float32Array {
    * @param b - The second operand
    * @returns `out`
    */
-  static add(out: Vec2Like, a: Readonly<Vec2Like>, b: Readonly<Vec2Like>): Vec2Like {
+  static add<T extends Vec2Like>(out: T, a: Readonly<Vec2Like>, b: Readonly<Vec2Like>): T {
     out[0] = a[0] + b[0];
     out[1] = a[1] + b[1];
     return out;
@@ -408,7 +408,7 @@ export class Vec2 extends Float32Array {
    * @param b - The second operand
    * @returns `out`
    */
-  static subtract(out: Vec2Like, a: Readonly<Vec2Like>, b: Readonly<Vec2Like>): Vec2Like {
+  static subtract<T extends Vec2Like>(out: T, a: Readonly<Vec2Like>, b: Readonly<Vec2Like>): T {
     out[0] = a[0] - b[0];
     out[1] = a[1] - b[1];
     return out;
@@ -418,7 +418,7 @@ export class Vec2 extends Float32Array {
    * Alias for {@link Vec2.subtract}
    * @category Static
    */
-  static sub(out: Vec2Like, a: Readonly<Vec2Like>, b: Readonly<Vec2Like>): Vec2Like { return [0, 0]; }
+  static sub<T extends Vec2Like>(out: T, a: Readonly<Vec2Like>, b: Readonly<Vec2Like>): T { return out; }
 
   /**
    * Multiplies two {@link Vec2}s
@@ -429,7 +429,7 @@ export class Vec2 extends Float32Array {
    * @param b - The second operand
    * @returns `out`
    */
-  static multiply(out: Vec2Like, a: Readonly<Vec2Like>, b: Readonly<Vec2Like>): Vec2Like {
+  static multiply<T extends Vec2Like>(out: T, a: Readonly<Vec2Like>, b: Readonly<Vec2Like>): T {
     out[0] = a[0] * b[0];
     out[1] = a[1] * b[1];
     return out;
@@ -439,7 +439,7 @@ export class Vec2 extends Float32Array {
    * Alias for {@link Vec2.multiply}
    * @category Static
    */
-   static mul(out: Vec2Like, a: Readonly<Vec2Like>, b: Readonly<Vec2Like>): Vec2Like { return [0, 0]; }
+   static mul<T extends Vec2Like>(out: T, a: Readonly<Vec2Like>, b: Readonly<Vec2Like>): T { return out; }
 
   /**
    * Divides two {@link Vec2}s
@@ -450,7 +450,7 @@ export class Vec2 extends Float32Array {
    * @param b - The second operand
    * @returns `out`
    */
-  static divide(out: Vec2Like, a: Readonly<Vec2Like>, b: Readonly<Vec2Like>): Vec2Like {
+  static divide<T extends Vec2Like>(out: T, a: Readonly<Vec2Like>, b: Readonly<Vec2Like>): T {
     out[0] = a[0] / b[0];
     out[1] = a[1] / b[1];
     return out;
@@ -460,7 +460,7 @@ export class Vec2 extends Float32Array {
    * Alias for {@link Vec2.divide}
    * @category Static
    */
-  static div(out: Vec2Like, a: Readonly<Vec2Like>, b: Readonly<Vec2Like>): Vec2Like { return [0, 0]; }
+  static div<T extends Vec2Like>(out: T, a: Readonly<Vec2Like>, b: Readonly<Vec2Like>): T { return out; }
 
   /**
    * Math.ceil the components of a {@link Vec2}
@@ -470,7 +470,7 @@ export class Vec2 extends Float32Array {
    * @param a - Vector to ceil
    * @returns `out`
    */
-  static ceil(out: Vec2Like, a: Readonly<Vec2Like>): Vec2Like {
+  static ceil<T extends Vec2Like>(out: T, a: Readonly<Vec2Like>): T {
     out[0] = Math.ceil(a[0]);
     out[1] = Math.ceil(a[1]);
     return out;
@@ -484,7 +484,7 @@ export class Vec2 extends Float32Array {
    * @param a - Vector to floor
    * @returns `out`
    */
-  static floor(out: Vec2Like, a: Readonly<Vec2Like>): Vec2Like {
+  static floor<T extends Vec2Like>(out: T, a: Readonly<Vec2Like>): T {
     out[0] = Math.floor(a[0]);
     out[1] = Math.floor(a[1]);
     return out;
@@ -499,7 +499,7 @@ export class Vec2 extends Float32Array {
    * @param b - The second operand
    * @returns `out`
    */
-  static min(out: Vec2Like, a: Readonly<Vec2Like>, b: Readonly<Vec2Like>): Vec2Like {
+  static min<T extends Vec2Like>(out: T, a: Readonly<Vec2Like>, b: Readonly<Vec2Like>): T {
     out[0] = Math.min(a[0], b[0]);
     out[1] = Math.min(a[1], b[1]);
     return out;
@@ -514,7 +514,7 @@ export class Vec2 extends Float32Array {
    * @param b - The second operand
    * @returns `out`
    */
-  static max(out: Vec2Like, a: Readonly<Vec2Like>, b: Readonly<Vec2Like>): Vec2Like {
+  static max<T extends Vec2Like>(out: T, a: Readonly<Vec2Like>, b: Readonly<Vec2Like>): T {
     out[0] = Math.max(a[0], b[0]);
     out[1] = Math.max(a[1], b[1]);
     return out;
@@ -528,7 +528,7 @@ export class Vec2 extends Float32Array {
    * @param a - Vector to round
    * @returns `out`
    */
-  static round(out: Vec2Like, a: Readonly<Vec2Like>): Vec2Like {
+  static round<T extends Vec2Like>(out: T, a: Readonly<Vec2Like>): T {
     out[0] = Math.round(a[0]);
     out[1] = Math.round(a[1]);
     return out;
@@ -543,7 +543,7 @@ export class Vec2 extends Float32Array {
    * @param b - Amount to scale the vector by
    * @returns `out`
    */
-  static scale(out: Vec2Like, a: Readonly<Vec2Like>, b: number): Vec2Like {
+  static scale<T extends Vec2Like>(out: T, a: Readonly<Vec2Like>, b: number): T {
     out[0] = a[0] * b;
     out[1] = a[1] * b;
     return out;
@@ -559,7 +559,7 @@ export class Vec2 extends Float32Array {
    * @param scale - The amount to scale b by before adding
    * @returns `out`
    */
-  static scaleAndAdd(out: Vec2Like, a: Readonly<Vec2Like>, b: Readonly<Vec2Like>, scale: number): Vec2Like {
+  static scaleAndAdd<T extends Vec2Like>(out: T, a: Readonly<Vec2Like>, b: Readonly<Vec2Like>, scale: number): T {
     out[0] = a[0] + b[0] * scale;
     out[1] = a[1] + b[1] * scale;
     return out;
@@ -662,7 +662,7 @@ export class Vec2 extends Float32Array {
    * @param a - Vector to negate
    * @returns `out`
    */
-  static negate(out: Vec2Like, a: Readonly<Vec2Like>) {
+  static negate<T extends Vec2Like>(out: T, a: Readonly<Vec2Like>): T {
     out[0] = -a[0];
     out[1] = -a[1];
     return out;
@@ -676,7 +676,7 @@ export class Vec2 extends Float32Array {
    * @param a - Vector to invert
    * @returns `out`
    */
-  static inverse(out: Vec2Like, a: Readonly<Vec2Like>): Vec2Like {
+  static inverse<T extends Vec2Like>(out: T, a: Readonly<Vec2Like>): T {
     out[0] = 1.0 / a[0];
     out[1] = 1.0 / a[1];
     return out;
@@ -690,7 +690,7 @@ export class Vec2 extends Float32Array {
    * @param a - Vector to compute the absolute values of
    * @returns `out`
    */
-  static abs(out: Vec2Like, a: Readonly<Vec2Like>): Vec2Like {
+  static abs<T extends Vec2Like>(out: T, a: Readonly<Vec2Like>): T {
     out[0] = Math.abs(a[0]);
     out[1] = Math.abs(a[1]);
     return out;
@@ -704,7 +704,7 @@ export class Vec2 extends Float32Array {
    * @param a - Vector to normalize
    * @returns `out`
    */
-  static normalize(out: Vec2Like, a: Readonly<Vec2Like>): Vec2Like {
+  static normalize<T extends Vec2Like>(out: T, a: Readonly<Vec2Like>): T {
     const x = a[0];
     const y = a[1];
     let len = x * x + y * y;
@@ -740,7 +740,7 @@ export class Vec2 extends Float32Array {
    * @param b - The second operand
    * @returns `out`
    */
-  static cross(out: Vec2Like, a: Readonly<Vec2Like>, b: Readonly<Vec2Like>): Vec2Like {
+  static cross<T extends Vec2Like>(out: T, a: Readonly<Vec2Like>, b: Readonly<Vec2Like>): T {
     const z = a[0] * b[1] - a[1] * b[0];
     out[0] = out[1] = 0;
     out[2] = z;
@@ -757,7 +757,7 @@ export class Vec2 extends Float32Array {
    * @param t - Interpolation amount, in the range [0-1], between the two inputs
    * @returns `out`
    */
-  static lerp(out: Vec2Like, a: Readonly<Vec2Like>, b: Readonly<Vec2Like>, t: number): Vec2Like {
+  static lerp<T extends Vec2Like>(out: T, a: Readonly<Vec2Like>, b: Readonly<Vec2Like>, t: number): T {
     const ax = a[0];
     const ay = a[1];
     out[0] = ax + t * (b[0] - ax);
@@ -773,7 +773,7 @@ export class Vec2 extends Float32Array {
    * @param m - Matrix to transform with
    * @returns `out`
    */
-  static transformMat2(out: Vec2Like, a: Readonly<Vec2Like>, m: Readonly<Mat2Like>): Vec2Like {
+  static transformMat2<T extends Vec2Like>(out: T, a: Readonly<Vec2Like>, m: Readonly<Mat2Like>): T {
     const x = a[0];
     const y = a[1];
     out[0] = m[0] * x + m[2] * y;
@@ -789,7 +789,7 @@ export class Vec2 extends Float32Array {
    * @param m - Matrix to transform with
    * @returns `out`
    */
-  static transformMat2d(out: Vec2Like, a: Readonly<Vec2Like>, m: Readonly<Mat2dLike>): Vec2Like {
+  static transformMat2d<T extends Vec2Like>(out: T, a: Readonly<Vec2Like>, m: Readonly<Mat2dLike>): T {
     const x = a[0];
     const y = a[1];
     out[0] = m[0] * x + m[2] * y + m[4];
@@ -806,7 +806,7 @@ export class Vec2 extends Float32Array {
    * @param m - Matrix to transform with
    * @returns `out`
    */
-  static transformMat3(out: Vec2Like, a: Readonly<Vec2Like>, m: Readonly<Mat3Like>): Vec2Like {
+  static transformMat3<T extends Vec2Like>(out: T, a: Readonly<Vec2Like>, m: Readonly<Mat3Like>): T {
     const x = a[0];
     const y = a[1];
     out[0] = m[0] * x + m[3] * y + m[6];
@@ -824,7 +824,7 @@ export class Vec2 extends Float32Array {
    * @param m - Matrix to transform with
    * @returns `out`
    */
-  static transformMat4(out: Vec2Like, a: Readonly<Vec2Like>, m: Readonly<Mat4Like>): Vec2Like {
+  static transformMat4<T extends Vec2Like>(out: T, a: Readonly<Vec2Like>, m: Readonly<Mat4Like>): T {
     const x = a[0];
     const y = a[1];
     out[0] = m[0] * x + m[4] * y + m[12];
@@ -842,7 +842,7 @@ export class Vec2 extends Float32Array {
    * @param rad - The angle of rotation in radians
    * @returns `out`
    */
-  static rotate(out: Vec2Like, a: Readonly<Vec2Like>, b: Readonly<Vec2Like>, rad: number): Vec2Like {
+  static rotate<T extends Vec2Like>(out: T, a: Readonly<Vec2Like>, b: Readonly<Vec2Like>, rad: number): T {
     //Translate point to the origin
     const p0 = a[0] - b[0];
     const p1 = a[1] - b[1];
@@ -884,7 +884,7 @@ export class Vec2 extends Float32Array {
    * @param out - The receiving vector
    * @returns `out`
    */
-  static zero(out: Vec2Like): Vec2Like {
+  static zero<T extends Vec2Like>(out: T): T {
     out[0] = 0.0;
     out[1] = 0.0;
     return out;

--- a/src/vec3.ts
+++ b/src/vec3.ts
@@ -336,7 +336,7 @@ export class Vec3 extends Float32Array {
    * @returns `this`
    */
    normalize(): Vec3 {
-    return Vec3.normalize(this, this) as Vec3;
+    return Vec3.normalize(this, this);
   }
 
   //================
@@ -420,7 +420,7 @@ export class Vec3 extends Float32Array {
    * @param a - the source vector
    * @returns `out`
    */
-  static copy(out: Vec3Like, a: Readonly<Vec3Like>): Vec3Like {
+  static copy<T extends Vec3Like>(out: T, a: Readonly<Vec3Like>): T {
     out[0] = a[0];
     out[1] = a[1];
     out[2] = a[2];
@@ -437,7 +437,7 @@ export class Vec3 extends Float32Array {
    * @param z - Z component
    * @returns `out`
    */
-  static set(out: Vec3Like, x: number, y: number, z: number): Vec3Like {
+  static set<T extends Vec3Like>(out: T, x: number, y: number, z: number): T {
     out[0] = x;
     out[1] = y;
     out[2] = z;
@@ -453,7 +453,7 @@ export class Vec3 extends Float32Array {
    * @param b - The second operand
    * @returns `out`
    */
-  static add(out: Vec3Like, a: Readonly<Vec3Like>, b: Readonly<Vec3Like>): Vec3Like {
+  static add<T extends Vec3Like>(out: T, a: Readonly<Vec3Like>, b: Readonly<Vec3Like>): T {
     out[0] = a[0] + b[0];
     out[1] = a[1] + b[1];
     out[2] = a[2] + b[2];
@@ -469,7 +469,7 @@ export class Vec3 extends Float32Array {
    * @param b - the second operand
    * @returns `out`
    */
-  static subtract(out: Vec3Like, a: Readonly<Vec3Like>, b: Readonly<Vec3Like>): Vec3Like {
+  static subtract<T extends Vec3Like>(out: T, a: Readonly<Vec3Like>, b: Readonly<Vec3Like>): T {
     out[0] = a[0] - b[0];
     out[1] = a[1] - b[1];
     out[2] = a[2] - b[2];
@@ -480,7 +480,7 @@ export class Vec3 extends Float32Array {
    * Alias for {@link Vec3.subtract}
    * @category Static
    */
-  static sub(out: Vec3Like, a: Readonly<Vec3Like>, b: Readonly<Vec3Like>): Vec3Like { return [0, 0, 0]; };
+  static sub<T extends Vec3Like>(out: T, a: Readonly<Vec3Like>, b: Readonly<Vec3Like>): T { return out; };
 
   /**
    * Multiplies two vec3's
@@ -491,7 +491,7 @@ export class Vec3 extends Float32Array {
    * @param b - the second operand
    * @returns `out`
    */
-  static multiply(out: Vec3Like, a: Readonly<Vec3Like>, b: Readonly<Vec3Like>): Vec3Like {
+  static multiply<T extends Vec3Like>(out: T, a: Readonly<Vec3Like>, b: Readonly<Vec3Like>): T {
     out[0] = a[0] * b[0];
     out[1] = a[1] * b[1];
     out[2] = a[2] * b[2];
@@ -502,7 +502,7 @@ export class Vec3 extends Float32Array {
    * Alias for {@link Vec3.multiply}
    * @category Static
    */
-  static mul(out: Vec3Like, a: Readonly<Vec3Like>, b: Readonly<Vec3Like>): Vec3Like { return [0, 0, 0]; }
+  static mul<T extends Vec3Like>(out: T, a: Readonly<Vec3Like>, b: Readonly<Vec3Like>): T { return out; }
 
   /**
    * Divides two vec3's
@@ -513,7 +513,7 @@ export class Vec3 extends Float32Array {
    * @param b - the second operand
    * @returns `out`
    */
-  static divide(out: Vec3Like, a: Readonly<Vec3Like>, b: Readonly<Vec3Like>): Vec3Like {
+  static divide<T extends Vec3Like>(out: T, a: Readonly<Vec3Like>, b: Readonly<Vec3Like>): T {
     out[0] = a[0] / b[0];
     out[1] = a[1] / b[1];
     out[2] = a[2] / b[2];
@@ -524,7 +524,7 @@ export class Vec3 extends Float32Array {
    * Alias for {@link Vec3.divide}
    * @category Static
    */
-   static div(out: Vec3Like, a: Readonly<Vec3Like>, b: Readonly<Vec3Like>): Vec3Like { return [0, 0, 0]; };
+   static div<T extends Vec3Like>(out: T, a: Readonly<Vec3Like>, b: Readonly<Vec3Like>): T { return out; };
 
   /**
    * Math.ceil the components of a vec3
@@ -534,7 +534,7 @@ export class Vec3 extends Float32Array {
    * @param a - vector to ceil
    * @returns `out`
    */
-  static ceil(out: Vec3Like, a: Readonly<Vec3Like>): Vec3Like {
+  static ceil<T extends Vec3Like>(out: T, a: Readonly<Vec3Like>): T {
     out[0] = Math.ceil(a[0]);
     out[1] = Math.ceil(a[1]);
     out[2] = Math.ceil(a[2]);
@@ -549,7 +549,7 @@ export class Vec3 extends Float32Array {
    * @param a - vector to floor
    * @returns `out`
    */
-  static floor(out: Vec3Like, a: Readonly<Vec3Like>): Vec3Like {
+  static floor<T extends Vec3Like>(out: T, a: Readonly<Vec3Like>): T {
     out[0] = Math.floor(a[0]);
     out[1] = Math.floor(a[1]);
     out[2] = Math.floor(a[2]);
@@ -565,7 +565,7 @@ export class Vec3 extends Float32Array {
    * @param b - the second operand
    * @returns `out`
    */
-  static min(out: Vec3Like, a: Readonly<Vec3Like>, b: Readonly<Vec3Like>): Vec3Like {
+  static min<T extends Vec3Like>(out: T, a: Readonly<Vec3Like>, b: Readonly<Vec3Like>): T {
     out[0] = Math.min(a[0], b[0]);
     out[1] = Math.min(a[1], b[1]);
     out[2] = Math.min(a[2], b[2]);
@@ -581,7 +581,7 @@ export class Vec3 extends Float32Array {
    * @param b - the second operand
    * @returns `out`
    */
-  static max(out: Vec3Like, a: Readonly<Vec3Like>, b: Readonly<Vec3Like>): Vec3Like {
+  static max<T extends Vec3Like>(out: T, a: Readonly<Vec3Like>, b: Readonly<Vec3Like>): T {
     out[0] = Math.max(a[0], b[0]);
     out[1] = Math.max(a[1], b[1]);
     out[2] = Math.max(a[2], b[2]);
@@ -612,7 +612,7 @@ export class Vec3 extends Float32Array {
    * @param scale - amount to scale the vector by
    * @returns `out`
    */
-  static scale(out: Vec3Like, a: Readonly<Vec3Like>, scale: number): Vec3Like {
+  static scale<T extends Vec3Like>(out: T, a: Readonly<Vec3Like>, scale: number): T {
     out[0] = a[0] * scale;
     out[1] = a[1] * scale;
     out[2] = a[2] * scale;
@@ -629,7 +629,7 @@ export class Vec3 extends Float32Array {
    * @param scale - the amount to scale b by before adding
    * @returns `out`
    */
-  static scaleAndAdd(out: Vec3Like, a: Readonly<Vec3Like>, b: Readonly<Vec3Like>, scale: number) {
+  static scaleAndAdd<T extends Vec3Like>(out: T, a: Readonly<Vec3Like>, b: Readonly<Vec3Like>, scale: number): T {
     out[0] = a[0] + b[0] * scale;
     out[1] = a[1] + b[1] * scale;
     out[2] = a[2] + b[2] * scale;
@@ -700,7 +700,7 @@ export class Vec3 extends Float32Array {
    * @param a - vector to negate
    * @returns `out`
    */
-  static negate(out: Vec3Like, a: Readonly<Vec3Like>): Vec3Like {
+  static negate<T extends Vec3Like>(out: T, a: Readonly<Vec3Like>): T {
     out[0] = -a[0];
     out[1] = -a[1];
     out[2] = -a[2];
@@ -715,7 +715,7 @@ export class Vec3 extends Float32Array {
    * @param a - vector to invert
    * @returns `out`
    */
-  static inverse(out: Vec3Like, a: Readonly<Vec3Like>): Vec3Like {
+  static inverse<T extends Vec3Like>(out: T, a: Readonly<Vec3Like>): T {
     out[0] = 1.0 / a[0];
     out[1] = 1.0 / a[1];
     out[2] = 1.0 / a[2];
@@ -730,7 +730,7 @@ export class Vec3 extends Float32Array {
    * @param a - Vector to compute the absolute values of
    * @returns `out`
    */
-  static abs(out: Vec3Like, a: Readonly<Vec3Like>): Vec3Like {
+  static abs<T extends Vec3Like>(out: T, a: Readonly<Vec3Like>): T {
     out[0] = Math.abs(a[0]);
     out[1] = Math.abs(a[1]);
     out[2] = Math.abs(a[2]);
@@ -745,7 +745,7 @@ export class Vec3 extends Float32Array {
    * @param a - vector to normalize
    * @returns `out`
    */
-  static normalize(out: Vec3Like, a: Readonly<Vec3Like>): Vec3Like {
+  static normalize<T extends Vec3Like>(out: T, a: Readonly<Vec3Like>): T {
     const x = a[0];
     const y = a[1];
     const z = a[2];
@@ -781,7 +781,7 @@ export class Vec3 extends Float32Array {
    * @param b - the second operand
    * @returns `out`
    */
-  static cross(out: Vec3Like, a: Readonly<Vec3Like>, b: Readonly<Vec3Like>): Vec3Like {
+  static cross<T extends Vec3Like>(out: T, a: Readonly<Vec3Like>, b: Readonly<Vec3Like>): T {
     const ax = a[0],
       ay = a[1],
       az = a[2];
@@ -805,7 +805,7 @@ export class Vec3 extends Float32Array {
    * @param t - interpolation amount, in the range [0-1], between the two inputs
    * @returns `out`
    */
-  static lerp(out: Vec3Like, a: Readonly<Vec3Like>, b: Readonly<Vec3Like>, t: number): Vec3Like {
+  static lerp<T extends Vec3Like>(out: T, a: Readonly<Vec3Like>, b: Readonly<Vec3Like>, t: number): T {
     const ax = a[0];
     const ay = a[1];
     const az = a[2];
@@ -825,7 +825,7 @@ export class Vec3 extends Float32Array {
    * @param t - interpolation amount, in the range [0-1], between the two inputs
    * @returns `out`
    */
-  static slerp(out: Vec3Like, a: Readonly<Vec3Like>, b: Readonly<Vec3Like>, t: number): Vec3Like {
+  static slerp<T extends Vec3Like>(out: T, a: Readonly<Vec3Like>, b: Readonly<Vec3Like>, t: number): T {
     const angle = Math.acos(Math.min(Math.max(Vec3.dot(a, b), -1), 1));
     const sinTotal = Math.sin(angle);
 
@@ -850,7 +850,7 @@ export class Vec3 extends Float32Array {
    * @param t - interpolation amount, in the range [0-1], between the two inputs
    * @returns `out`
    */
-  static hermite(out: Vec3Like, a: Readonly<Vec3Like>, b: Readonly<Vec3Like>, c: Readonly<Vec3Like>, d: Readonly<Vec3Like>, t: number): Vec3Like {
+  static hermite<T extends Vec3Like>(out: T, a: Readonly<Vec3Like>, b: Readonly<Vec3Like>, c: Readonly<Vec3Like>, d: Readonly<Vec3Like>, t: number): T {
     const factorTimes2 = t * t;
     const factor1 = factorTimes2 * (2 * t - 3) + 1;
     const factor2 = factorTimes2 * (t - 2) + t;
@@ -923,7 +923,7 @@ export class Vec3 extends Float32Array {
    * @param m - matrix to transform with
    * @returns `out`
    */
-  static transformMat4(out: Vec3Like, a: Readonly<Vec3Like>, m: Readonly<Mat4Like>): Vec3Like {
+  static transformMat4<T extends Vec3Like>(out: T, a: Readonly<Vec3Like>, m: Readonly<Mat4Like>): T {
     const x = a[0],
       y = a[1],
       z = a[2];
@@ -943,7 +943,7 @@ export class Vec3 extends Float32Array {
    * @param m - the 3x3 matrix to transform with
    * @returns `out`
    */
-  static transformMat3(out: Vec3Like, a: Vec3Like, m: Mat3Like): Vec3Like {
+  static transformMat3<T extends Vec3Like>(out: T, a: Vec3Like, m: Mat3Like): T {
     let x = a[0],
       y = a[1],
       z = a[2];
@@ -963,7 +963,7 @@ export class Vec3 extends Float32Array {
    * @param q - quaternion to transform with
    * @returns `out`
    */
-  static transformQuat(out: Vec3Like, a: Readonly<Vec3Like>, q: Readonly<QuatLike>): Vec3Like {
+  static transformQuat<T extends Vec3Like>(out: T, a: Readonly<Vec3Like>, q: Readonly<QuatLike>): T {
     // benchmarks: https://jsperf.com/quaternion-transform-vec3-implementations-fixed
     const qx = q[0];
     const qy = q[1];
@@ -998,7 +998,7 @@ export class Vec3 extends Float32Array {
    * @param rad - The angle of rotation in radians
    * @returns `out`
    */
-  static rotateX(out: Vec3Like, a: Readonly<Vec3Like>, b: Readonly<Vec3Like>, rad: number): Vec3Like {
+  static rotateX<T extends Vec3Like>(out: T, a: Readonly<Vec3Like>, b: Readonly<Vec3Like>, rad: number): T {
     const by = b[1];
     const bz = b[2];
 
@@ -1023,7 +1023,7 @@ export class Vec3 extends Float32Array {
    * @param rad - The angle of rotation in radians
    * @returns `out`
    */
-  static rotateY(out: Vec3Like, a: Readonly<Vec3Like>, b: Readonly<Vec3Like>, rad: number): Vec3Like {
+  static rotateY<T extends Vec3Like>(out: T, a: Readonly<Vec3Like>, b: Readonly<Vec3Like>, rad: number): T {
     const bx = b[0];
     const bz = b[2];
 
@@ -1048,7 +1048,7 @@ export class Vec3 extends Float32Array {
    * @param rad - The angle of rotation in radians
    * @returns `out`
    */
-  static rotateZ(out: Vec3Like, a: Readonly<Vec3Like>, b: Readonly<Vec3Like>, rad: number): Vec3Like {
+  static rotateZ<T extends Vec3Like>(out: T, a: Readonly<Vec3Like>, b: Readonly<Vec3Like>, rad: number): T {
     const bx = b[0];
     const by = b[1];
 
@@ -1090,7 +1090,7 @@ export class Vec3 extends Float32Array {
    * @param out - the receiving vector
    * @returns `out`
    */
-  static zero(out: Vec3Like): Vec3Like {
+  static zero<T extends Vec3Like>(out: T): T {
     out[0] = 0.0;
     out[1] = 0.0;
     out[2] = 0.0;

--- a/src/vec4.ts
+++ b/src/vec4.ts
@@ -345,7 +345,7 @@ export class Vec4 extends Float32Array {
    * @returns `this`
    */
   normalize(): Vec4 {
-    return Vec4.normalize(this, this) as Vec4;
+    return Vec4.normalize(this, this);
   }
 
   //===================
@@ -395,7 +395,7 @@ export class Vec4 extends Float32Array {
    * @param a - the source vector
    * @returns `out`
    */
-  static copy(out: Vec4Like, a: Readonly<Vec4Like>): Vec4Like {
+  static copy<T extends Vec4Like>(out: T, a: Readonly<Vec4Like>): T {
     out[0] = a[0];
     out[1] = a[1];
     out[2] = a[2];
@@ -414,7 +414,7 @@ export class Vec4 extends Float32Array {
    * @param w - W component
    * @returns `out`
    */
-  static set(out: Vec4Like, x: number, y: number, z: number, w: number): Vec4Like {
+  static set<T extends Vec4Like>(out: T, x: number, y: number, z: number, w: number): T {
     out[0] = x;
     out[1] = y;
     out[2] = z;
@@ -431,7 +431,7 @@ export class Vec4 extends Float32Array {
    * @param b - The second operand
    * @returns `out`
    */
-  static add(out: Vec4Like, a: Readonly<Vec4Like>, b: Readonly<Vec4Like>): Vec4Like {
+  static add<T extends Vec4Like>(out: T, a: Readonly<Vec4Like>, b: Readonly<Vec4Like>): T {
     out[0] = a[0] + b[0];
     out[1] = a[1] + b[1];
     out[2] = a[2] + b[2];
@@ -448,7 +448,7 @@ export class Vec4 extends Float32Array {
    * @param b - the second operand
    * @returns `out`
    */
-  static subtract(out: Vec4Like, a: Readonly<Vec4Like>, b: Readonly<Vec4Like>): Vec4Like {
+  static subtract<T extends Vec4Like>(out: T, a: Readonly<Vec4Like>, b: Readonly<Vec4Like>): T {
     out[0] = a[0] - b[0];
     out[1] = a[1] - b[1];
     out[2] = a[2] - b[2];
@@ -460,7 +460,7 @@ export class Vec4 extends Float32Array {
    * Alias for {@link Vec4.subtract}
    * @category Static
    */
-  static sub(out: Vec4Like, a: Readonly<Vec4Like>, b: Readonly<Vec4Like>): Vec4Like { return out; }
+  static sub<T extends Vec4Like>(out: T, a: Readonly<Vec4Like>, b: Readonly<Vec4Like>): T { return out; }
 
   /**
    * Multiplies two {@link Vec4}'s
@@ -471,7 +471,7 @@ export class Vec4 extends Float32Array {
    * @param b - the second operand
    * @returns `out`
    */
-  static multiply(out: Vec4Like, a: Readonly<Vec4Like>, b: Readonly<Vec4Like>): Vec4Like {
+  static multiply<T extends Vec4Like>(out: T, a: Readonly<Vec4Like>, b: Readonly<Vec4Like>): T {
     out[0] = a[0] * b[0];
     out[1] = a[1] * b[1];
     out[2] = a[2] * b[2];
@@ -483,7 +483,7 @@ export class Vec4 extends Float32Array {
    * Alias for {@link Vec4.multiply}
    * @category Static
    */
-  static mul(out: Vec4Like, a: Readonly<Vec4Like>, b: Readonly<Vec4Like>): Vec4Like { return out; }
+  static mul<T extends Vec4Like>(out: T, a: Readonly<Vec4Like>, b: Readonly<Vec4Like>): T { return out; }
 
   /**
    * Divides two {@link Vec4}'s
@@ -494,7 +494,7 @@ export class Vec4 extends Float32Array {
    * @param b - the second operand
    * @returns `out`
    */
-  static divide(out: Vec4Like, a: Readonly<Vec4Like>, b: Readonly<Vec4Like>): Vec4Like {
+  static divide<T extends Vec4Like>(out: T, a: Readonly<Vec4Like>, b: Readonly<Vec4Like>): T {
     out[0] = a[0] / b[0];
     out[1] = a[1] / b[1];
     out[2] = a[2] / b[2];
@@ -506,7 +506,7 @@ export class Vec4 extends Float32Array {
    * Alias for {@link Vec4.divide}
    * @category Static
    */
-  static div(out: Vec4Like, a: Readonly<Vec4Like>, b: Readonly<Vec4Like>): Vec4Like { return out; }
+  static div<T extends Vec4Like>(out: T, a: Readonly<Vec4Like>, b: Readonly<Vec4Like>): T { return out; }
 
   /**
    * Math.ceil the components of a {@link Vec4}
@@ -516,7 +516,7 @@ export class Vec4 extends Float32Array {
    * @param a - vector to ceil
    * @returns `out`
    */
-  static ceil(out: Vec4Like, a: Readonly<Vec4Like>): Vec4Like {
+  static ceil<T extends Vec4Like>(out: T, a: Readonly<Vec4Like>): T {
     out[0] = Math.ceil(a[0]);
     out[1] = Math.ceil(a[1]);
     out[2] = Math.ceil(a[2]);
@@ -532,7 +532,7 @@ export class Vec4 extends Float32Array {
    * @param a - vector to floor
    * @returns `out`
    */
-  static floor(out: Vec4Like, a: Readonly<Vec4Like>): Vec4Like {
+  static floor<T extends Vec4Like>(out: T, a: Readonly<Vec4Like>): T {
     out[0] = Math.floor(a[0]);
     out[1] = Math.floor(a[1]);
     out[2] = Math.floor(a[2]);
@@ -549,7 +549,7 @@ export class Vec4 extends Float32Array {
    * @param b - the second operand
    * @returns `out`
    */
-  static min(out: Vec4Like, a: Readonly<Vec4Like>, b: Readonly<Vec4Like>): Vec4Like {
+  static min<T extends Vec4Like>(out: T, a: Readonly<Vec4Like>, b: Readonly<Vec4Like>): T {
     out[0] = Math.min(a[0], b[0]);
     out[1] = Math.min(a[1], b[1]);
     out[2] = Math.min(a[2], b[2]);
@@ -566,7 +566,7 @@ export class Vec4 extends Float32Array {
    * @param b - the second operand
    * @returns `out`
    */
-  static max(out: Vec4Like, a: Readonly<Vec4Like>, b: Readonly<Vec4Like>): Vec4Like {
+  static max<T extends Vec4Like>(out: T, a: Readonly<Vec4Like>, b: Readonly<Vec4Like>): T {
     out[0] = Math.max(a[0], b[0]);
     out[1] = Math.max(a[1], b[1]);
     out[2] = Math.max(a[2], b[2]);
@@ -582,7 +582,7 @@ export class Vec4 extends Float32Array {
    * @param a - vector to round
    * @returns `out`
    */
-  static round(out: Vec4Like, a: Readonly<Vec4Like>): Vec4Like {
+  static round<T extends Vec4Like>(out: T, a: Readonly<Vec4Like>): T {
     out[0] = Math.round(a[0]);
     out[1] = Math.round(a[1]);
     out[2] = Math.round(a[2]);
@@ -599,7 +599,7 @@ export class Vec4 extends Float32Array {
    * @param scale - amount to scale the vector by
    * @returns `out`
    */
-  static scale(out: Vec4Like, a: Readonly<Vec4Like>, scale: number): Vec4Like {
+  static scale<T extends Vec4Like>(out: T, a: Readonly<Vec4Like>, scale: number): T {
     out[0] = a[0] * scale;
     out[1] = a[1] * scale;
     out[2] = a[2] * scale;
@@ -617,7 +617,7 @@ export class Vec4 extends Float32Array {
    * @param scale - the amount to scale b by before adding
    * @returns `out`
    */
-  static scaleAndAdd(out: Vec4Like, a: Readonly<Vec4Like>, b: Readonly<Vec4Like>, scale: number): Vec4Like {
+  static scaleAndAdd<T extends Vec4Like>(out: T, a: Readonly<Vec4Like>, b: Readonly<Vec4Like>, scale: number): T {
     out[0] = a[0] + b[0] * scale;
     out[1] = a[1] + b[1] * scale;
     out[2] = a[2] + b[2] * scale;
@@ -731,7 +731,7 @@ export class Vec4 extends Float32Array {
    * @param a - vector to negate
    * @returns `out`
    */
-  static negate(out: Vec4Like, a: Readonly<Vec4Like>): Vec4Like {
+  static negate<T extends Vec4Like>(out: T, a: Readonly<Vec4Like>): T {
     out[0] = -a[0];
     out[1] = -a[1];
     out[2] = -a[2];
@@ -747,7 +747,7 @@ export class Vec4 extends Float32Array {
    * @param a - vector to invert
    * @returns `out`
    */
-  static inverse(out: Vec4Like, a: Readonly<Vec4Like>): Vec4Like {
+  static inverse<T extends Vec4Like>(out: T, a: Readonly<Vec4Like>): T {
     out[0] = 1.0 / a[0];
     out[1] = 1.0 / a[1];
     out[2] = 1.0 / a[2];
@@ -763,7 +763,7 @@ export class Vec4 extends Float32Array {
    * @param a - Vector to compute the absolute values of
    * @returns `out`
    */
-  static abs(out: Vec4Like, a: Readonly<Vec4Like>): Vec4Like {
+  static abs<T extends Vec4Like>(out: T, a: Readonly<Vec4Like>): T {
     out[0] = Math.abs(a[0]);
     out[1] = Math.abs(a[1]);
     out[2] = Math.abs(a[2]);
@@ -779,7 +779,7 @@ export class Vec4 extends Float32Array {
    * @param a - vector to normalize
    * @returns `out`
    */
-  static normalize(out: Vec4Like, a: Readonly<Vec4Like>): Vec4Like {
+  static normalize<T extends Vec4Like>(out: T, a: Readonly<Vec4Like>): T {
     const x = a[0];
     const y = a[1];
     const z = a[2];
@@ -817,7 +817,7 @@ export class Vec4 extends Float32Array {
    * @param w - the third vector
    * @returns result
    */
-  static cross(out: Vec4Like, u: Readonly<Vec4Like>, v: Readonly<Vec4Like>, w: Readonly<Vec4Like>): Vec4Like {
+  static cross<T extends Vec4Like>(out: T, u: Readonly<Vec4Like>, v: Readonly<Vec4Like>, w: Readonly<Vec4Like>): T {
     const a = v[0] * w[1] - v[1] * w[0];
     const b = v[0] * w[2] - v[2] * w[0];
     const c = v[0] * w[3] - v[3] * w[0];
@@ -847,7 +847,7 @@ export class Vec4 extends Float32Array {
    * @param t - interpolation amount, in the range [0-1], between the two inputs
    * @returns `out`
    */
-  static lerp(out: Vec4Like, a: Readonly<Vec4Like>, b: Readonly<Vec4Like>, t: number): Vec4Like {
+  static lerp<T extends Vec4Like>(out: T, a: Readonly<Vec4Like>, b: Readonly<Vec4Like>, t: number): T {
     const ax = a[0];
     const ay = a[1];
     const az = a[2];
@@ -903,7 +903,7 @@ export class Vec4 extends Float32Array {
    * @param m - matrix to transform with
    * @returns `out`
    */
-  static transformMat4(out: Vec4Like, a: Readonly<Vec4Like>, m: Readonly<Mat4Like>): Vec4Like {
+  static transformMat4<T extends Vec4Like>(out: T, a: Readonly<Vec4Like>, m: Readonly<Mat4Like>): T {
     const x = a[0];
     const y = a[1];
     const z = a[2];
@@ -924,7 +924,7 @@ export class Vec4 extends Float32Array {
    * @param q - quaternion to transform with
    * @returns `out`
    */
-  static transformQuat(out: Vec4Like, a: Readonly<Vec4Like>, q: Readonly<QuatLike>): Vec4Like {
+  static transformQuat<T extends Vec4Like>(out: T, a: Readonly<Vec4Like>, q: Readonly<QuatLike>): T {
     const x = a[0];
     const y = a[1];
     const z = a[2];
@@ -954,7 +954,7 @@ export class Vec4 extends Float32Array {
    * @param out - the receiving vector
    * @returns `out`
    */
-  static zero(out: Vec4Like): Vec4Like {
+  static zero<T extends Vec4Like>(out: T): T {
     out[0] = 0.0;
     out[1] = 0.0;
     out[2] = 0.0;


### PR DESCRIPTION
Currently the static methods reduce the scope of the `out` variable on return to the associated `TypeLike` type. We can use type inference to guarantee the return type of the method matches the input. This enables chaining on static method return, or directly returning the method response. E.g:

```typescript
function doThing(): Vec3 {
  const test = new Vec3();
  return Vec3.transformMat3(test, ...).invert(test);
}
```

This also removed the need for type assertions in parts of the code.