### PR TITLE
Fix generated namespace types in index.d.ts

### DIFF
--- a/utils/bundle-dts.js
+++ b/utils/bundle-dts.js
@@ -18,7 +18,7 @@ if (typingsLength == typings.length)
 // Rename common module to glMatrix
 typings = typings.replace(
   'declare module "common" {',
-  "export module glMatrix {"
+  "export namespace glMatrix {"
 );
 
 // Replace imports from other modules with direct references
@@ -28,7 +28,7 @@ typings = typings.replace(/import\("([^"]+?)(\.js)?"\)/g, "$1");
 typings = typings.replace(/ *import.+from.*;/g, "");
 
 // Replace declare module with exports
-typings = typings.replace(/declare module "([^"]+?)" {/g, "export module $1 {");
+typings = typings.replace(/declare module "([^"]+?)" {/g, "export namespace $1 {");
 
 // Add types
 typings = "\n" + sourceTypings.replace(/declare/g, "export") + "\n" + typings;


### PR DESCRIPTION
Previously some namespace types were generated using the legacy `module` keyword from ten years ago. Now we emit the modern TS `namespace` keyword that has been the preferred keyword since TypeScript 1.5 in 2015.

Please review the resulting diff for the generated `dist/index.d.ts` file:  https://gist.github.com/robpalme/a320dc3f0cb50bcd14962bca46827dae/revisions

Note that the outer _Ambient Module Declaration_ intentionally remains untouched because it is not a namespace.  These are differentiated by using a quoted string rather than a bare identifier

`module "quoted" {`
vs
`module bare {`

---

Background:  This usage of the legacy keyword was found by [a TypeScript real-world test suite](https://github.com/microsoft/TypeScript/pull/61450#issuecomment-2744477736) that checks the compatibility of proposed changes.  Using the `module` keyword for namespaces is [proposed for deprecation in TypeScript 6.0](https://github.com/microsoft/TypeScript/issues/54500#issuecomment-2744284025) so it's worth getting ahead of this.