### PR TITLE
Improved calculation of angles for vec2

### DIFF
--- a/spec/gl-matrix/vec2-spec.js
+++ b/spec/gl-matrix/vec2-spec.js
@@ -601,15 +601,41 @@ describe("vec2", function() {
 	});
     
     describe("angle", function() {
-        beforeEach(function() {
-            vecA = [1,0];
-            vecB = [1,2];
-            result = vec2.angle(vecA, vecB);
+        it("should always return the positive angle between 0 and pi", function() {
+            expect(vec2.angle([1, 0], [1, 2]))
+                .toBeEqualish(1.10714);
+            expect(vec2.angle([1, 2], [1, 0]))
+                .toBeEqualish(1.10714);
+            expect(vec2.angle([-1, 0], [1, 2]))
+                .toBeEqualish(2.03445);
+            expect(vec2.angle([1, 2], [-1, 0]))
+                .toBeEqualish(2.03445);
         });
+        it("should not modify the arguments", function() {
+            let a = [1, 0], b = [1, 2];
+            vec2.angle(a, b);
+            expect(a).toBeEqualish([1, 0]);
+            expect(b).toBeEqualish([1, 2]);
+        });
+    });
 
-        it("should return the angle", function() { expect(result).toBeEqualish(1.10714); });
-        it("should not modify vecA", function() { expect(vecA).toBeEqualish([1, 0]); });
-        it("should not modify vecB", function() { expect(vecB).toBeEqualish([1, 2]); });
+    describe("signedAngle", function() {
+        it("should always return the signed angle between -pi and pi", function() {
+            expect(vec2.signedAngle([1, 0], [1, 2]))
+                .toBeEqualish(1.10714);
+            expect(vec2.signedAngle([1, 2], [1, 0]))
+                .toBeEqualish(-1.10714);
+            expect(vec2.signedAngle([-1, 0], [1, 2]))
+                .toBeEqualish(-2.03445);
+            expect(vec2.signedAngle([1, 2], [-1, 0]))
+                .toBeEqualish(2.03445);
+        });
+        it("should not modify the arguments", function() {
+            let a = [1, 0], b = [1, 2];
+            vec2.signedAngle(a, b);
+            expect(a).toBeEqualish([1, 0]);
+            expect(b).toBeEqualish([1, 2]);
+        });
     });
 
     describe("str", function() {

--- a/src/vec2.js
+++ b/src/vec2.js
@@ -470,23 +470,30 @@ export function rotate(out, a, b, rad) {
 }
 
 /**
- * Get the angle between two 2D vectors
+ * Get the smallest angle between two 2D vectors
  * @param {ReadonlyVec2} a The first operand
  * @param {ReadonlyVec2} b The second operand
  * @returns {Number} The angle in radians
  */
 export function angle(a, b) {
-  let x1 = a[0],
-    y1 = a[1],
-    x2 = b[0],
-    y2 = b[1],
-    // mag is the product of the magnitudes of a and b
-    mag = Math.sqrt((x1 * x1 + y1 * y1) * (x2 * x2 + y2 * y2)),
-    // mag &&.. short circuits if mag == 0
-    cosine = mag && (x1 * x2 + y1 * y2) / mag;
-  // Math.min(Math.max(cosine, -1), 1) clamps the cosine between -1 and 1
-  return Math.acos(Math.min(Math.max(cosine, -1), 1));
+  let ax = a[0], ay = a[1],
+    bx = b[0], by = b[1];
+  return Math.abs(Math.atan2(ay * bx - ax * by, ax * bx + ay * by));
 }
+
+/**
+ * Get the signed angle in the interval [-pi,pi] between two 2D vectors (positive if `a` is to the right of `b`)
+ * 
+ * @param {ReadonlyVec2} a The first vector
+ * @param {ReadonlyVec2} b The second vector
+ * @returns {number} The signed angle in radians
+ */
+export function signedAngle(a, b) {
+  let ax = a[0], ay = a[1],
+    bx = b[0], by = b[1];
+  return Math.atan2(ax * by - ay * bx, ax * bx + ay * by);
+}
+
 
 /**
  * Set the components of a vec2 to zero


### PR DESCRIPTION
provided a new implementation of vec2.angle which is about 1.2 times
faster and created a new function, called vec2.signedAngle, which
returns the same value as vec2.angle but negative when the first
vector is to the left of the second (it's useful when you want to know
the rotation matrix which aligns both vectors, for example)

updated the tests for vec2.angle and created new tests for
vec2.signedAngle in order to make sure both behave as expected,
returning values in the expected intervals
