### PR TITLE
Fix equals() returning true for vectors/values containing Infinity

### DIFF
--- a/spec/gl-matrix/common-spec.js
+++ b/spec/gl-matrix/common-spec.js
@@ -14,19 +14,27 @@ describe("common", function(){
   });
 
   describe("equals", function() {
-    let r0, r1, r2, r3, r4;
+    let r0, r1, r2, r3, r4, r5, r6, r7, r8;
     beforeEach(function() {
       r0 = glMatrix.equals(1.0, 0.0);
       r1 = glMatrix.equals(1.0, 1.0);
       r2 = glMatrix.equals(1.0+glMatrix.EPSILON/2, 1.0);
       r3 = glMatrix.equals(1.0011, 1.0, 0.001);
       r4 = glMatrix.equals(100.5, 100.7, 0.2);
+      r5 = glMatrix.equals(1.0, Infinity);
+      r6 = glMatrix.equals(Infinity, Infinity);
+      r7 = glMatrix.equals(Infinity, -Infinity);
+      r8 = glMatrix.equals(-Infinity, -Infinity);
     });
     it("should return false for different numbers", function() { expect(r0).toBe(false); });
     it("should return true for the same number", function() { expect(r1).toBe(true); });
     it("should return true for numbers that are close", function() { expect(r2).toBe(true); });
     it("should return false for numbers that are close but tolerance is set to smaller value", function() { expect(r3).toBe(false); });
     it("should return true for numbers that are close with tolerance is set to bigger value", function() { expect(r4).toBe(true); });
+    it("should return false comparing a finite number with Infinity", function() { expect(r5).toBe(false); });
+    it("should return true comparing matching infinities", function() { expect(r6).toBe(true); });
+    it("should return false comparing opposite infinities", function() { expect(r7).toBe(false); });
+    it("should return true comparing matching negative infinities", function() { expect(r8).toBe(true); });
   });
 
 });

--- a/spec/gl-matrix/vec2-spec.js
+++ b/spec/gl-matrix/vec2-spec.js
@@ -661,19 +661,25 @@ describe("vec2", function() {
     });
 
     describe("equals", function() {
-        let vecC, vecD, r0, r1, r2;
+        let vecC, vecD, vecE, vecF, r0, r1, r2, r3, r4;
         beforeEach(function() {
             vecA = [0, 1];
             vecB = [0, 1];
             vecC = [1, 2];
             vecD = [1e-16, 1];
+            vecE = [Infinity, Infinity];
+            vecF = [Infinity, Infinity];
             r0 = vec2.equals(vecA, vecB);
             r1 = vec2.equals(vecA, vecC);
             r2 = vec2.equals(vecA, vecD);
+            r3 = vec2.equals(vecA, vecE);
+            r4 = vec2.equals(vecE, vecF);
         });
         it("should return true for identical vectors", function() { expect(r0).toBe(true); });
         it("should return false for different vectors", function() { expect(r1).toBe(false); });
         it("should return true for close but not identical vectors", function() { expect(r2).toBe(true); });
+        it("should return false comparing a finite vector with an infinite one", function() { expect(r3).toBe(false); });
+        it("should return true comparing two matching infinite vectors", function() { expect(r4).toBe(true); });
         it("should not modify vecA", function() { expect(vecA).toBeEqualish([0, 1]); });
         it("should not modify vecB", function() { expect(vecB).toBeEqualish([0, 1]); });
     });

--- a/spec/gl-matrix/vec3-spec.js
+++ b/spec/gl-matrix/vec3-spec.js
@@ -745,19 +745,25 @@ describe("vec3", function() {
     });
 
     describe("equals", function() {
-        let vecC, vecD, r0, r1, r2;
+        let vecC, vecD, vecE, vecF, r0, r1, r2, r3, r4;
         beforeEach(function() {
             vecA = [0, 1, 2];
             vecB = [0, 1, 2];
             vecC = [1, 2, 3];
             vecD = [1e-16, 1, 2];
+            vecE = [Infinity, Infinity, Infinity];
+            vecF = [Infinity, Infinity, Infinity];
             r0 = vec3.equals(vecA, vecB);
             r1 = vec3.equals(vecA, vecC);
             r2 = vec3.equals(vecA, vecD);
+            r3 = vec3.equals(vecA, vecE);
+            r4 = vec3.equals(vecE, vecF);
         });
         it("should return true for identical vectors", function() { expect(r0).toBe(true); });
         it("should return false for different vectors", function() { expect(r1).toBe(false); });
         it("should return true for close but not identical vectors", function() { expect(r2).toBe(true); });
+        it("should return false comparing a finite vector with an infinite one", function() { expect(r3).toBe(false); });
+        it("should return true comparing two matching infinite vectors", function() { expect(r4).toBe(true); });
         it("should not modify vecA", function() { expect(vecA).toBeEqualish([0, 1, 2]); });
         it("should not modify vecB", function() { expect(vecB).toBeEqualish([0, 1, 2]); });
     });

--- a/spec/gl-matrix/vec4-spec.js
+++ b/spec/gl-matrix/vec4-spec.js
@@ -595,19 +595,25 @@ describe("vec4", function() {
     });
 
     describe("equals", function() {
-        let vecC, vecD, r0, r1, r2;
+        let vecC, vecD, vecE, vecF, r0, r1, r2, r3, r4;
         beforeEach(function() {
             vecA = [0, 1, 2, 3];
             vecB = [0, 1, 2, 3];
             vecC = [1, 2, 3, 4];
             vecD = [1e-16, 1, 2, 3];
+            vecE = [Infinity, Infinity, Infinity, Infinity];
+            vecF = [Infinity, Infinity, Infinity, Infinity];
             r0 = vec4.equals(vecA, vecB);
             r1 = vec4.equals(vecA, vecC);
             r2 = vec4.equals(vecA, vecD);
+            r3 = vec4.equals(vecA, vecE);
+            r4 = vec4.equals(vecE, vecF);
         });
         it("should return true for identical vectors", function() { expect(r0).toBe(true); });
         it("should return false for different vectors", function() { expect(r1).toBe(false); });
         it("should return true for close but not identical vectors", function() { expect(r2).toBe(true); });
+        it("should return false comparing a finite vector with an infinite one", function() { expect(r3).toBe(false); });
+        it("should return true comparing two matching infinite vectors", function() { expect(r4).toBe(true); });
         it("should not modify vecA", function() { expect(vecA).toBeEqualish([0, 1, 2, 3]); });
         it("should not modify vecB", function() { expect(vecB).toBeEqualish([0, 1, 2, 3]); });
     });

--- a/src/common.js
+++ b/src/common.js
@@ -65,5 +65,13 @@ export function toDegree(a) {
  * @returns {Boolean} True if the numbers are approximately equal, false otherwise.
  */
 export function equals(a, b, tolerance = EPSILON) {
-  return Math.abs(a - b) <= tolerance * Math.max(1, Math.abs(a), Math.abs(b));
+  // `a === b` handles exactly-equal values (including matching infinities),
+  // while clamping the relative scale to Number.MAX_VALUE prevents an infinite
+  // operand from producing an infinite tolerance (which would make differing
+  // infinities, or a finite value and an infinity, compare as approximately equal).
+  return (
+    a === b ||
+    Math.abs(a - b) <=
+      tolerance * Math.min(Number.MAX_VALUE, Math.max(1, Math.abs(a), Math.abs(b)))
+  );
 }

--- a/src/vec2.js
+++ b/src/vec2.js
@@ -541,10 +541,14 @@ export function equals(a, b) {
   let b0 = b[0],
     b1 = b[1];
   return (
-    Math.abs(a0 - b0) <=
-      glMatrix.EPSILON * Math.max(1.0, Math.abs(a0), Math.abs(b0)) &&
-    Math.abs(a1 - b1) <=
-      glMatrix.EPSILON * Math.max(1.0, Math.abs(a1), Math.abs(b1))
+    (a0 === b0 ||
+      Math.abs(a0 - b0) <=
+        glMatrix.EPSILON *
+          Math.min(Number.MAX_VALUE, Math.max(1.0, Math.abs(a0), Math.abs(b0)))) &&
+    (a1 === b1 ||
+      Math.abs(a1 - b1) <=
+        glMatrix.EPSILON *
+          Math.min(Number.MAX_VALUE, Math.max(1.0, Math.abs(a1), Math.abs(b1))))
   );
 }
 

--- a/src/vec3.js
+++ b/src/vec3.js
@@ -727,12 +727,18 @@ export function equals(a, b) {
     b1 = b[1],
     b2 = b[2];
   return (
-    Math.abs(a0 - b0) <=
-      glMatrix.EPSILON * Math.max(1.0, Math.abs(a0), Math.abs(b0)) &&
-    Math.abs(a1 - b1) <=
-      glMatrix.EPSILON * Math.max(1.0, Math.abs(a1), Math.abs(b1)) &&
-    Math.abs(a2 - b2) <=
-      glMatrix.EPSILON * Math.max(1.0, Math.abs(a2), Math.abs(b2))
+    (a0 === b0 ||
+      Math.abs(a0 - b0) <=
+        glMatrix.EPSILON *
+          Math.min(Number.MAX_VALUE, Math.max(1.0, Math.abs(a0), Math.abs(b0)))) &&
+    (a1 === b1 ||
+      Math.abs(a1 - b1) <=
+        glMatrix.EPSILON *
+          Math.min(Number.MAX_VALUE, Math.max(1.0, Math.abs(a1), Math.abs(b1)))) &&
+    (a2 === b2 ||
+      Math.abs(a2 - b2) <=
+        glMatrix.EPSILON *
+          Math.min(Number.MAX_VALUE, Math.max(1.0, Math.abs(a2), Math.abs(b2))))
   );
 }
 

--- a/src/vec4.js
+++ b/src/vec4.js
@@ -580,14 +580,22 @@ export function equals(a, b) {
     b2 = b[2],
     b3 = b[3];
   return (
-    Math.abs(a0 - b0) <=
-      glMatrix.EPSILON * Math.max(1.0, Math.abs(a0), Math.abs(b0)) &&
-    Math.abs(a1 - b1) <=
-      glMatrix.EPSILON * Math.max(1.0, Math.abs(a1), Math.abs(b1)) &&
-    Math.abs(a2 - b2) <=
-      glMatrix.EPSILON * Math.max(1.0, Math.abs(a2), Math.abs(b2)) &&
-    Math.abs(a3 - b3) <=
-      glMatrix.EPSILON * Math.max(1.0, Math.abs(a3), Math.abs(b3))
+    (a0 === b0 ||
+      Math.abs(a0 - b0) <=
+        glMatrix.EPSILON *
+          Math.min(Number.MAX_VALUE, Math.max(1.0, Math.abs(a0), Math.abs(b0)))) &&
+    (a1 === b1 ||
+      Math.abs(a1 - b1) <=
+        glMatrix.EPSILON *
+          Math.min(Number.MAX_VALUE, Math.max(1.0, Math.abs(a1), Math.abs(b1)))) &&
+    (a2 === b2 ||
+      Math.abs(a2 - b2) <=
+        glMatrix.EPSILON *
+          Math.min(Number.MAX_VALUE, Math.max(1.0, Math.abs(a2), Math.abs(b2)))) &&
+    (a3 === b3 ||
+      Math.abs(a3 - b3) <=
+        glMatrix.EPSILON *
+          Math.min(Number.MAX_VALUE, Math.max(1.0, Math.abs(a3), Math.abs(b3))))
   );
 }
 


### PR DESCRIPTION
Closes #443.

`vec3.equals([1, 2, 3], [Infinity, Infinity, Infinity])` returns `true` (and matching infinities like `equals([Inf,Inf,Inf], [Inf,Inf,Inf])` return `false`).

### Cause
The per-component relative tolerance `EPSILON * Math.max(1, |a|, |b|)` evaluates to `Infinity` when an operand is infinite, so `Math.abs(a - b) <= Infinity` is satisfied for differing infinities and for finite-vs-infinite pairs. Conversely, two matching infinities give `Math.abs(Inf - Inf) === NaN`, and `NaN <= x` is `false`, so identical infinite vectors compare as *unequal*.

### Fix
For each component: short-circuit on exact equality (`a === b`, which also covers matching infinities) and clamp the relative scale with `Math.min(Number.MAX_VALUE, …)` so an infinite operand can no longer make the tolerance infinite. Results for all finite inputs are unchanged (for finite values the clamp is a no-op and the existing tests still pass).

Applied to `glMatrix.equals` (common.js) and `vec2`/`vec3`/`vec4` `equals` — the subject of the issue. The same inline pattern exists in `mat2`/`mat2d`/`mat3`/`mat4`/`quat`/`quat2`; happy to extend this PR to those too if you'd prefer them in one change.

### Tests
Added Infinity cases to the `equals` specs (common + vec2/vec3/vec4): finite-vs-infinite → `false`, matching infinities → `true`. Verified they fail on `master` and pass with the fix. Full suite: 1308 passing.