### PR TITLE
Clamp getAngle acos argument to avoid NaN

### DIFF
--- a/spec/gl-matrix/quat-spec.js
+++ b/spec/gl-matrix/quat-spec.js
@@ -516,6 +516,11 @@ describe("quat", function() {
           it("should be zero", function() {
               expect(quat.getAngle(quatA, quatA)).toBeEqualish(0);
           });
+
+          it("should be zero for a quaternion from an axis and angle", function() {
+              let q = quat.setAxisAngle(quat.create(), [0, 0, 1], 0.7);
+              expect(quat.getAngle(q, q)).toBeEqualish(0);
+          });
         });
 
         describe("from rotated", function() {

--- a/src/quat.js
+++ b/src/quat.js
@@ -96,7 +96,7 @@ export function getAxisAngle(out_axis, q) {
 export function getAngle(a, b) {
   let dotproduct = dot(a, b);
 
-  return Math.acos(2 * dotproduct * dotproduct - 1);
+  return Math.acos(Math.min(Math.max(2 * dotproduct * dotproduct - 1, -1), 1));
 }
 
 /**


### PR DESCRIPTION
`quat.getAngle(a, b)` returns `NaN` for a large fraction of unit-quaternion inputs, including the angular distance of a quaternion with itself.

```js
const q = quat.setAxisAngle(quat.create(), [0, 0, 1], 0.7);
quat.getAngle(q, q); // NaN, expected ~0
```

The function computes `acos(2 * dot * dot - 1)`. For unit quaternions the dot product is ~1, and floating-point rounding can push it slightly above 1, so `2 * dot * dot - 1` exceeds 1 and `Math.acos` of an argument greater than 1 is `NaN`. In a sweep of unit quaternions this happens for about half of the `getAngle(q, q)` cases and for pairs a nanoradian apart (adjacent animation frames), and the `NaN` then makes downstream "are these orientations close" comparisons silently false.

## Fix

Clamp the `acos` argument to `[-1, 1]`, exactly as `vec3.angle` already does for the same hazard.

## Testing

Added a case to the existing `getAngle` "from itself" spec using a quaternion built from an axis and angle, which trips the rounding. It returns `NaN` on the current code and `0` with the fix. The existing `getAngle` specs still pass.
