### PR TITLE
Fix vec3.slerp returning NaN for parallel inputs

### DIFF
--- a/spec/gl-matrix/vec3-spec.js
+++ b/spec/gl-matrix/vec3-spec.js
@@ -593,6 +593,10 @@ describe("vec3", function() {
           let result = vec3.slerp([], [1,0,0], [0,1,0], 0.5);
           expect(result).toBeEqualish([0.7071067811865475,0.7071067811865475,0]);
         });
+        it('should return the shared vector when both inputs are equal', () => {
+          let result = vec3.slerp([], [0,0,1], [0,0,1], 0.5);
+          expect(result).toBeEqualish([0,0,1]);
+        });
       });
 
     describe("random", function() {

--- a/src/vec3.js
+++ b/src/vec3.js
@@ -412,8 +412,8 @@ export function slerp(out, a, b, t) {
   let angle = Math.acos(Math.min(Math.max(dot(a, b), -1), 1));
   let sinTotal = Math.sin(angle);
 
-  let ratioA = Math.sin((1 - t) * angle) / sinTotal;
-  let ratioB = Math.sin(t * angle) / sinTotal;
+  let ratioA = sinTotal > glMatrix.EPSILON ? Math.sin((1 - t) * angle) / sinTotal : 1 - t;
+  let ratioB = sinTotal > glMatrix.EPSILON ? Math.sin(t * angle) / sinTotal : t;
   out[0] = ratioA * a[0] + ratioB * b[0];
   out[1] = ratioA * a[1] + ratioB * b[1];
   out[2] = ratioA * a[2] + ratioB * b[2];


### PR DESCRIPTION
`vec3.slerp` divided by `sin(angle)` with no guard, so when `a` and `b` point in the same direction the angle is zero, `sin(angle)` is zero and every output component became `0/0 = NaN`. For example `vec3.slerp(out, [0, 0, 1], [0, 0, 1], 0.5)` returned `[NaN, NaN, NaN]` instead of `[0, 0, 1]`.

The fix falls back to linear interpolation when the vectors are nearly parallel, which is the correct limit as the angle approaches zero. Adds a test for equal and parallel inputs.
