### PR TITLE
Fix mat4.getRotation and decompose under non-uniform scale

### DIFF
--- a/spec/gl-matrix/mat4-spec.js
+++ b/spec/gl-matrix/mat4-spec.js
@@ -634,6 +634,28 @@ function buildMat4Tests() {
                     expect(outangle).toBeEqualish(ang);
                 });
             });
+
+            describe("from a translation, rotation and non-uniform scale matrix", function() {
+                it("should keep the same rotation as when created", function() {
+                    let q = quat.create();
+                    let outVec = vec3.fromValues(5, 6, 7);
+                    let scaleVec = vec3.fromValues(2, 3, 4);
+                    let testVec = vec3.fromValues(1, 5, 2);
+                    let ang = 0.78972;
+
+                    vec3.normalize(testVec, testVec);
+                    q = quat.setAxisAngle(q, testVec, ang);
+                    mat4.fromRotationTranslationScale(out, q, outVec, scaleVec);
+
+                    result = quat.fromValues(2, 3, 4, 6);
+                    mat4.getRotation(result, out);
+                    let outaxis = vec3.create();
+                    let outangle = quat.getAxisAngle(outaxis, result);
+
+                    expect(outaxis).toBeEqualish(testVec);
+                    expect(outangle).toBeEqualish(ang);
+                });
+            });
         });
 
         let out_t, out_s;
@@ -711,17 +733,20 @@ function buildMat4Tests() {
             });
 
             describe("from a translation, rotation and scale matrix", function() {
+                let inputRot;
                 beforeEach(function() {
                     let q = quat.create();
                     let t = vec3.fromValues(1, 2, 3);
                     let s = vec3.fromValues(5, 6, 7);
                     q = quat.setAxisAngle(q, [0, 1, 0], 0.7);
+                    inputRot = quat.clone(q);
                     mat4.fromRotationTranslationScale(out, q, t, s);
                     out_t = vec3.fromValues(7, 8, 9);
                     out_s = vec3.fromValues(4, 5, 6);
                     result = quat.fromValues(2, 3, 4, 6);
                     mat4.decompose(result, out_t, out_s, out);
                 })
+                it("should return the same rotation when created", function() { expect(result).toBeEqualish(inputRot); });
                 it("should return the same scaling factor when created", function() { expect(out_s).toBeEqualish([5, 6, 7]); });
                 it("should return the same translation when created", function() { expect(out_t).toBeEqualish([1, 2, 3]); });
             });

--- a/src/mat4.js
+++ b/src/mat4.js
@@ -1185,13 +1185,13 @@ export function getRotation(out, mat) {
   let is3 = 1 / scaling[2];
 
   let sm11 = mat[0] * is1;
-  let sm12 = mat[1] * is2;
-  let sm13 = mat[2] * is3;
-  let sm21 = mat[4] * is1;
+  let sm12 = mat[1] * is1;
+  let sm13 = mat[2] * is1;
+  let sm21 = mat[4] * is2;
   let sm22 = mat[5] * is2;
-  let sm23 = mat[6] * is3;
-  let sm31 = mat[8] * is1;
-  let sm32 = mat[9] * is2;
+  let sm23 = mat[6] * is2;
+  let sm31 = mat[8] * is3;
+  let sm32 = mat[9] * is3;
   let sm33 = mat[10] * is3;
 
   let trace = sm11 + sm22 + sm33;
@@ -1259,13 +1259,13 @@ export function decompose(out_r, out_t, out_s, mat) {
   let is3 = 1 / out_s[2];
 
   let sm11 = m11 * is1;
-  let sm12 = m12 * is2;
-  let sm13 = m13 * is3;
-  let sm21 = m21 * is1;
+  let sm12 = m12 * is1;
+  let sm13 = m13 * is1;
+  let sm21 = m21 * is2;
   let sm22 = m22 * is2;
-  let sm23 = m23 * is3;
-  let sm31 = m31 * is1;
-  let sm32 = m32 * is2;
+  let sm23 = m23 * is2;
+  let sm31 = m31 * is3;
+  let sm32 = m32 * is3;
   let sm33 = m33 * is3;
 
   let trace = sm11 + sm22 + sm33;


### PR DESCRIPTION
`mat4.getRotation` normalized the matrix by dividing each element by the scale of the wrong axis. Every column of a column-major mat4 must be divided by that column's scale, but the code paired `mat[1]`/`mat[2]` (still column 0) with `is2`/`is3` and `mat[4]`/`mat[8]` (columns 1 and 2) with `is1`. With a non-uniform scale this produced a non-unit, wrong quaternion; with uniform or no scale `is1 == is2 == is3` so the error was hidden.

For a 90 degree rotation about Z with scale `(2, 3, 4)`, `getRotation` returned `[0, 0, 0.766, 0.707]` with length 1.04 instead of the unit `[0, 0, 0.707, 0.707]`. This divides each column by its own scale so a rotation survives a `fromRotationTranslationScale` round trip. `decompose` duplicates the same code and is fixed together. Adds a test for each.
