### PR TITLE
Clamp getAxisAngle acos argument to avoid NaN

### DIFF
--- a/spec/gl-matrix/quat-spec.js
+++ b/spec/gl-matrix/quat-spec.js
@@ -472,6 +472,15 @@ describe("quat", function() {
             it("should return a multiple of 2*PI as the angle component", function() { expect(deg90 % (Math.PI * 2.0)).toBeEqualish(0.0); });
         });
 
+        describe("for a rotation composed with its own conjugate", function() {
+            beforeEach(function() {
+                let q = quat.setAxisAngle(quat.create(), [1, 0, 0], (50 * Math.PI) / 180);
+                quat.multiply(out, q, quat.conjugate(quat.create(), q));
+                deg90 = quat.getAxisAngle(vec, out);
+            });
+            it("should return a multiple of 2*PI as the angle component", function() { expect(deg90 % (Math.PI * 2.0)).toBeEqualish(0.0); });
+        });
+
         describe("for a simple rotation about X axis", function() {
             beforeEach(function() { result = quat.setAxisAngle(out, [1, 0, 0], 0.7778); deg90 = quat.getAxisAngle(vec, out); });
             it("should return the same provided angle", function() { expect(deg90).toBeEqualish(0.7778); });

--- a/src/quat.js
+++ b/src/quat.js
@@ -71,7 +71,7 @@ export function setAxisAngle(out, axis, rad) {
  * @return {Number}     Angle, in radians, of the rotation
  */
 export function getAxisAngle(out_axis, q) {
-  let rad = Math.acos(q[3]) * 2.0;
+  let rad = Math.acos(Math.min(Math.max(q[3], -1), 1)) * 2.0;
   let s = Math.sin(rad / 2.0);
   if (s > glMatrix.EPSILON) {
     out_axis[0] = q[0] / s;


### PR DESCRIPTION
`quat.getAxisAngle` computed `acos(q[3])` with no clamping. Composing unit quaternions (for example a rotation multiplied by its own conjugate) can leave the w component rounded slightly above 1, so the argument exceeded 1 and `acos` returned NaN for the angle. The fix clamps the argument to `[-1, 1]`, as `getAngle` and `vec3.angle` already do. Adds a test for a rotation composed with its own conjugate.
